### PR TITLE
ci: improve CI/CD pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,23 +7,43 @@ on:
     branches: [master]
 
 jobs:
-  test:
+  lint:
+    name: Lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+      - name: Install ruff
+        run: pip install ruff
+      - name: Ruff check
+        run: ruff check mcp_video/
+      - name: Ruff format check
+        run: ruff format --check mcp_video/
+
+  test:
+    name: Test (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
       - name: Install FFmpeg
         run: sudo apt-get update && sudo apt-get install -y --no-install-recommends ffmpeg
       - name: Install dependencies
         run: pip install -e ".[dev]"
-      - name: Lint
-        run: ruff check mcp_video/
       - name: Run tests
-        run: pytest tests/ -q -m "not slow"
+        run: pytest tests/ -q -m "not slow" --tb=short
 
   docker:
+    name: Docker build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,20 +6,42 @@ on:
 
 permissions:
   contents: read
-  id-token: write  # Required for OIDC token
+  id-token: write  # Required for OIDC trusted publishing
 
 jobs:
-  pypi-publish:
-    name: Upload release to PyPI
+  build:
+    name: Build package
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Needed for hatch-vcs if ever adopted
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
       - name: Install build dependencies
-        run: pip install build hatch
+        run: pip install build
       - name: Build package
         run: python -m build
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/mcp_video/__main__.py
+++ b/mcp_video/__main__.py
@@ -56,11 +56,13 @@ def _format_thumbnail_text(result: Any) -> None:
     data = result.model_dump() if hasattr(result, "model_dump") else result
     frame_path = data.get("frame_path", "N/A")
     timestamp = data.get("timestamp", 0.0)
-    console.print(Panel(
-        f"[bold green]Frame extracted:[/bold green] {frame_path}\n[bold green]Timestamp:[/bold green] {timestamp:.2f}s",
-        border_style="green",
-        title="Done",
-    ))
+    console.print(
+        Panel(
+            f"[bold green]Frame extracted:[/bold green] {frame_path}\n[bold green]Timestamp:[/bold green] {timestamp:.2f}s",
+            border_style="green",
+            title="Done",
+        )
+    )
 
 
 def _format_storyboard_text(result: Any) -> None:
@@ -107,6 +109,7 @@ def _format_extract_audio_text(result: Any) -> None:
 def _format_error(e: Exception) -> None:
     """Display error in a styled panel."""
     from .errors import MCPVideoError
+
     if isinstance(e, MCPVideoError):
         try:
             data = e.to_dict()
@@ -131,10 +134,18 @@ def _parse_json_arg(value: str, arg_name: str = "argument", json_mode: bool = Fa
         return json.loads(value)
     except json.JSONDecodeError as e:
         if json_mode:
-            print(json.dumps({
-                "success": False,
-                "error": {"type": "input_error", "code": "invalid_json", "message": f"Invalid JSON in --{arg_name}: {e}"},
-            }))
+            print(
+                json.dumps(
+                    {
+                        "success": False,
+                        "error": {
+                            "type": "input_error",
+                            "code": "invalid_json",
+                            "message": f"Invalid JSON in --{arg_name}: {e}",
+                        },
+                    }
+                )
+            )
         else:
             console.print(f"[bold red]Invalid JSON in --{arg_name}: {e}[/bold red]")
         raise SystemExit(1) from None
@@ -183,7 +194,9 @@ def main() -> None:
     # extract-frame
     eframe_p = subparsers.add_parser("extract-frame", help="Extract a single frame from a video")
     eframe_p.add_argument("input", help="Input video file")
-    eframe_p.add_argument("-t", "--time", dest="timestamp", type=float, help="Time in seconds (default: 10 pct of duration)")
+    eframe_p.add_argument(
+        "-t", "--time", dest="timestamp", type=float, help="Time in seconds (default: 10 pct of duration)"
+    )
     eframe_p.add_argument("-o", "--output", help="Output image path")
 
     # trim
@@ -197,8 +210,18 @@ def main() -> None:
     # merge
     merge_p = subparsers.add_parser("merge", help="Merge multiple clips")
     merge_p.add_argument("inputs", nargs="+", help="Input video files")
-    merge_p.add_argument("-t", "--transition", default=None, choices=["fade", "dissolve", "wipe-left", "wipe-right", "wipe-up", "wipe-down"])
-    merge_p.add_argument("--transitions", nargs="+", choices=["fade", "dissolve", "wipe-left", "wipe-right", "wipe-up", "wipe-down"], help="Per-pair transition types (overrides --transition)")
+    merge_p.add_argument(
+        "-t",
+        "--transition",
+        default=None,
+        choices=["fade", "dissolve", "wipe-left", "wipe-right", "wipe-up", "wipe-down"],
+    )
+    merge_p.add_argument(
+        "--transitions",
+        nargs="+",
+        choices=["fade", "dissolve", "wipe-left", "wipe-right", "wipe-up", "wipe-down"],
+        help="Per-pair transition types (overrides --transition)",
+    )
     merge_p.add_argument("-td", "--transition-duration", type=float, default=1.0, help="Transition duration in seconds")
     merge_p.add_argument("-o", "--output", help="Output file path")
 
@@ -206,7 +229,22 @@ def main() -> None:
     text_p = subparsers.add_parser("add-text", help="Overlay text on a video")
     text_p.add_argument("input", help="Input video file")
     text_p.add_argument("text", help="Text to overlay")
-    text_p.add_argument("-p", "--position", default="top-center", choices=["top-left", "top-center", "top-right", "center-left", "center", "center-right", "bottom-left", "bottom-center", "bottom-right"])
+    text_p.add_argument(
+        "-p",
+        "--position",
+        default="top-center",
+        choices=[
+            "top-left",
+            "top-center",
+            "top-right",
+            "center-left",
+            "center",
+            "center-right",
+            "bottom-left",
+            "bottom-center",
+            "bottom-right",
+        ],
+    )
     text_p.add_argument("--font", help="Path to font file")
     text_p.add_argument("--size", type=int, default=48, help="Font size in pixels")
     text_p.add_argument("--color", default="white", help="Text color")
@@ -231,7 +269,9 @@ def main() -> None:
     resize_p.add_argument("input", help="Input video file")
     resize_p.add_argument("-w", "--width", type=int, help="Target width")
     resize_p.add_argument("--height", type=int, help="Target height")
-    resize_p.add_argument("-a", "--aspect-ratio", choices=["16:9", "9:16", "1:1", "4:3", "4:5", "21:9"], help="Preset aspect ratio")
+    resize_p.add_argument(
+        "-a", "--aspect-ratio", choices=["16:9", "9:16", "1:1", "4:3", "4:5", "21:9"], help="Preset aspect ratio"
+    )
     resize_p.add_argument("-q", "--quality", default="high", choices=["low", "medium", "high", "ultra"])
     resize_p.add_argument("-o", "--output", help="Output file path")
 
@@ -244,7 +284,15 @@ def main() -> None:
     # convert
     convert_p = subparsers.add_parser("convert", help="Convert video format")
     convert_p.add_argument("input", help="Input video file")
-    convert_p.add_argument("-f", "--format", "--fmt", dest="fmt", default="mp4", choices=["mp4", "webm", "gif", "mov"], help="Output format")
+    convert_p.add_argument(
+        "-f",
+        "--format",
+        "--fmt",
+        dest="fmt",
+        default="mp4",
+        choices=["mp4", "webm", "gif", "mov"],
+        help="Output format",
+    )
     convert_p.add_argument("-q", "--quality", default="high", choices=["low", "medium", "high", "ultra"])
     convert_p.add_argument("-o", "--output", help="Output file path")
 
@@ -276,7 +324,21 @@ def main() -> None:
     wm_p = subparsers.add_parser("watermark", help="Add image watermark")
     wm_p.add_argument("input", help="Input video file")
     wm_p.add_argument("image", help="Watermark image (PNG recommended)")
-    wm_p.add_argument("-p", "--position", default="bottom-right", choices=["top-left", "top-center", "top-right", "center-left", "center", "bottom-left", "bottom-center", "bottom-right"])
+    wm_p.add_argument(
+        "-p",
+        "--position",
+        default="bottom-right",
+        choices=[
+            "top-left",
+            "top-center",
+            "top-right",
+            "center-left",
+            "center",
+            "bottom-left",
+            "bottom-center",
+            "bottom-right",
+        ],
+    )
     wm_p.add_argument("--opacity", type=float, default=0.7, help="Watermark opacity (0.0-1.0)")
     wm_p.add_argument("--margin", type=int, default=20, help="Margin from edge in pixels")
     wm_p.add_argument("-o", "--output", help="Output file path")
@@ -293,7 +355,9 @@ def main() -> None:
     # rotate
     rotate_p = subparsers.add_parser("rotate", help="Rotate and/or flip a video")
     rotate_p.add_argument("input", help="Input video file")
-    rotate_p.add_argument("-a", "--angle", type=int, default=0, choices=[0, 90, 180, 270], help="Rotation angle in degrees")
+    rotate_p.add_argument(
+        "-a", "--angle", type=int, default=0, choices=[0, 90, 180, 270], help="Rotation angle in degrees"
+    )
     rotate_p.add_argument("--flip-h", action="store_true", help="Flip horizontally")
     rotate_p.add_argument("--flip-v", action="store_true", help="Flip vertically")
     rotate_p.add_argument("-o", "--output", help="Output file path")
@@ -309,13 +373,23 @@ def main() -> None:
     export_p = subparsers.add_parser("export", help="Export video with quality settings")
     export_p.add_argument("input", help="Input video file")
     export_p.add_argument("-q", "--quality", default="high", choices=["low", "medium", "high", "ultra"])
-    export_p.add_argument("-f", "--format", "--fmt", dest="fmt", default="mp4", choices=["mp4", "webm", "gif", "mov"], help="Output format")
+    export_p.add_argument(
+        "-f",
+        "--format",
+        "--fmt",
+        dest="fmt",
+        default="mp4",
+        choices=["mp4", "webm", "gif", "mov"],
+        help="Output format",
+    )
     export_p.add_argument("-o", "--output", help="Output file path")
 
     # extract_audio
     extract_p = subparsers.add_parser("extract-audio", help="Extract audio from video")
     extract_p.add_argument("input", help="Input video file")
-    extract_p.add_argument("-f", "--format", "--fmt", dest="audio_format", default="mp3", choices=["mp3", "aac", "wav", "ogg", "flac"])
+    extract_p.add_argument(
+        "-f", "--format", "--fmt", dest="audio_format", default="mp3", choices=["mp3", "aac", "wav", "ogg", "flac"]
+    )
     extract_p.add_argument("-o", "--output", help="Output audio file path")
 
     # edit (timeline)
@@ -326,7 +400,27 @@ def main() -> None:
     # filter
     filter_p = subparsers.add_parser("filter", help="Apply a visual filter")
     filter_p.add_argument("input", help="Input video file")
-    filter_p.add_argument("-t", "--type", dest="filter_type", required=True, choices=["blur", "sharpen", "brightness", "contrast", "saturation", "grayscale", "sepia", "invert", "vignette", "color_preset", "denoise", "deinterlace"], help="Filter type")
+    filter_p.add_argument(
+        "-t",
+        "--type",
+        dest="filter_type",
+        required=True,
+        choices=[
+            "blur",
+            "sharpen",
+            "brightness",
+            "contrast",
+            "saturation",
+            "grayscale",
+            "sepia",
+            "invert",
+            "vignette",
+            "color_preset",
+            "denoise",
+            "deinterlace",
+        ],
+        help="Filter type",
+    )
     filter_p.add_argument("--params", help="Filter parameters as JSON")
     filter_p.add_argument("-o", "--output", help="Output file path")
 
@@ -353,7 +447,9 @@ def main() -> None:
     # color-grade (convenience)
     grade_p = subparsers.add_parser("color-grade", help="Apply color grading preset")
     grade_p.add_argument("input", help="Input video file")
-    grade_p.add_argument("-p", "--preset", default="warm", choices=["warm", "cool", "vintage", "cinematic", "noir"], help="Color preset")
+    grade_p.add_argument(
+        "-p", "--preset", default="warm", choices=["warm", "cool", "vintage", "cinematic", "noir"], help="Color preset"
+    )
     grade_p.add_argument("-o", "--output", help="Output file path")
 
     # normalize-audio
@@ -366,7 +462,22 @@ def main() -> None:
     overlay_p = subparsers.add_parser("overlay-video", help="Picture-in-picture overlay")
     overlay_p.add_argument("background", help="Background video file")
     overlay_p.add_argument("overlay", help="Overlay video file")
-    overlay_p.add_argument("-p", "--position", default="top-right", choices=["top-left", "top-center", "top-right", "center-left", "center", "center-right", "bottom-left", "bottom-center", "bottom-right"])
+    overlay_p.add_argument(
+        "-p",
+        "--position",
+        default="top-right",
+        choices=[
+            "top-left",
+            "top-center",
+            "top-right",
+            "center-left",
+            "center",
+            "center-right",
+            "bottom-left",
+            "bottom-center",
+            "bottom-right",
+        ],
+    )
     overlay_p.add_argument("-w", "--width", type=int, help="Overlay width")
     overlay_p.add_argument("--height", type=int, help="Overlay height")
     overlay_p.add_argument("--opacity", type=float, default=0.8, help="Overlay opacity (0.0-1.0)")
@@ -378,21 +489,43 @@ def main() -> None:
     split_p = subparsers.add_parser("split-screen", help="Place two videos side by side or top/bottom")
     split_p.add_argument("left", help="First video file")
     split_p.add_argument("right", help="Second video file")
-    split_p.add_argument("-l", "--layout", default="side-by-side", choices=["side-by-side", "top-bottom"], help="Layout type")
+    split_p.add_argument(
+        "-l", "--layout", default="side-by-side", choices=["side-by-side", "top-bottom"], help="Layout type"
+    )
     split_p.add_argument("-o", "--output", help="Output file path")
 
     # batch
     batch_p = subparsers.add_parser("batch", help="Apply operation to multiple files")
     batch_p.add_argument("inputs", nargs="+", help="Input video files")
     batch_p.add_argument("-o", "--output-dir", help="Output directory for processed files")
-    batch_p.add_argument("--operation", required=True, choices=["trim", "resize", "convert", "filter", "blur", "color_grade", "watermark", "speed", "fade", "normalize_audio"], help="Operation to apply")
+    batch_p.add_argument(
+        "--operation",
+        required=True,
+        choices=[
+            "trim",
+            "resize",
+            "convert",
+            "filter",
+            "blur",
+            "color_grade",
+            "watermark",
+            "speed",
+            "fade",
+            "normalize_audio",
+        ],
+        help="Operation to apply",
+    )
     batch_p.add_argument("--params", help="Operation parameters as JSON")
 
     # detect-scenes
     scenes_p = subparsers.add_parser("detect-scenes", help="Detect scene changes in a video")
     scenes_p.add_argument("input", help="Input video file")
-    scenes_p.add_argument("-t", "--threshold", type=float, default=0.3, help="Detection sensitivity (0.0-1.0, default: 0.3)")
-    scenes_p.add_argument("--min-duration", type=float, default=1.0, help="Minimum scene duration in seconds (default: 1.0)")
+    scenes_p.add_argument(
+        "-t", "--threshold", type=float, default=0.3, help="Detection sensitivity (0.0-1.0, default: 0.3)"
+    )
+    scenes_p.add_argument(
+        "--min-duration", type=float, default=1.0, help="Minimum scene duration in seconds (default: 1.0)"
+    )
 
     # create-from-images
     imgseq_p = subparsers.add_parser("create-from-images", help="Create video from image sequence")
@@ -411,7 +544,9 @@ def main() -> None:
     quality_p = subparsers.add_parser("compare-quality", help="Compare video quality between two files")
     quality_p.add_argument("original", help="Original/reference video file")
     quality_p.add_argument("distorted", help="Processed/distorted video file")
-    quality_p.add_argument("--metrics", nargs="+", choices=["psnr", "ssim"], help="Metrics to compute (default: psnr ssim)")
+    quality_p.add_argument(
+        "--metrics", nargs="+", choices=["psnr", "ssim"], help="Metrics to compute (default: psnr ssim)"
+    )
 
     # read-metadata
     read_meta_p = subparsers.add_parser("read-metadata", help="Read metadata tags from a file")
@@ -420,7 +555,7 @@ def main() -> None:
     # write-metadata
     write_meta_p = subparsers.add_parser("write-metadata", help="Write metadata tags to a file")
     write_meta_p.add_argument("input", help="Input video/audio file")
-    write_meta_p.add_argument("--tags", required=True, help="Metadata as JSON, e.g. '{\"title\": \"My Video\"}'")
+    write_meta_p.add_argument("--tags", required=True, help='Metadata as JSON, e.g. \'{"title": "My Video"}\'')
     write_meta_p.add_argument("-o", "--output", help="Output file path")
 
     # stabilize
@@ -446,7 +581,9 @@ def main() -> None:
     # generate-subtitles
     gen_subs_p = subparsers.add_parser("generate-subtitles", help="Generate SRT subtitles from text entries")
     gen_subs_p.add_argument("input", help="Input video file")
-    gen_subs_p.add_argument("--entries", required=True, help="Subtitle entries as JSON: '[{\"start\":0,\"end\":2,\"text\":\"Hello\"}]'")
+    gen_subs_p.add_argument(
+        "--entries", required=True, help='Subtitle entries as JSON: \'[{"start":0,"end":2,"text":"Hello"}]\''
+    )
     gen_subs_p.add_argument("--burn", action="store_true", help="Burn subtitles into video")
     gen_subs_p.add_argument("-o", "--output", help="Output directory/path (default: auto-generated)")
 
@@ -455,7 +592,11 @@ def main() -> None:
 
     # template (apply a template)
     template_p = subparsers.add_parser("template", help="Apply a video template")
-    template_p.add_argument("name", choices=["tiktok", "youtube-shorts", "instagram-reel", "youtube", "instagram-post"], help="Template name")
+    template_p.add_argument(
+        "name",
+        choices=["tiktok", "youtube-shorts", "instagram-reel", "youtube", "instagram-post"],
+        help="Template name",
+    )
     template_p.add_argument("input", help="Input video file")
     template_p.add_argument("--caption", help="Caption text (for tiktok, instagram)")
     template_p.add_argument("--title", help="Title text (for youtube-shorts, youtube)")
@@ -472,7 +613,12 @@ def main() -> None:
     remotion_render_p.add_argument("project_path", help="Path to Remotion project")
     remotion_render_p.add_argument("composition_id", help="Composition ID to render")
     remotion_render_p.add_argument("-o", "--output", help="Output video file path")
-    remotion_render_p.add_argument("--codec", default="h264", choices=["h264", "h265", "vp8", "vp9", "prores", "gif"], help="Video codec (default: h264)")
+    remotion_render_p.add_argument(
+        "--codec",
+        default="h264",
+        choices=["h264", "h265", "vp8", "vp9", "prores", "gif"],
+        help="Video codec (default: h264)",
+    )
     remotion_render_p.add_argument("--crf", type=int, default=18, help="CRF quality (default: 18)")
     remotion_render_p.add_argument("--width", type=int, help="Output width in pixels")
     remotion_render_p.add_argument("--height", type=int, help="Output height in pixels")
@@ -501,13 +647,17 @@ def main() -> None:
     remotion_still_p.add_argument("composition_id", help="Composition ID to render")
     remotion_still_p.add_argument("-o", "--output", help="Output image file path")
     remotion_still_p.add_argument("--frame", type=int, default=0, help="Frame number to render (default: 0)")
-    remotion_still_p.add_argument("--image-format", default="png", choices=["png", "jpeg", "webp"], help="Image format (default: png)")
+    remotion_still_p.add_argument(
+        "--image-format", default="png", choices=["png", "jpeg", "webp"], help="Image format (default: png)"
+    )
 
     # remotion-create
     remotion_create_p = subparsers.add_parser("remotion-create", help="Scaffold a new Remotion project")
     remotion_create_p.add_argument("name", help="Project name")
     remotion_create_p.add_argument("-d", "--output-dir", help="Output directory (default: current directory)")
-    remotion_create_p.add_argument("-t", "--template", default="blank", choices=["blank", "hello-world"], help="Project template (default: blank)")
+    remotion_create_p.add_argument(
+        "-t", "--template", default="blank", choices=["blank", "hello-world"], help="Project template (default: blank)"
+    )
 
     # remotion-scaffold
     remotion_scaffold_p = subparsers.add_parser("remotion-scaffold", help="Generate composition from spec")
@@ -552,7 +702,9 @@ def main() -> None:
     noise_p.add_argument("input", help="Input video file")
     noise_p.add_argument("-o", "--output", help="Output file path")
     noise_p.add_argument("-i", "--intensity", type=float, default=0.05, help="Noise amount 0-1 (default: 0.05)")
-    noise_p.add_argument("-m", "--mode", default="film", choices=["film", "digital", "color"], help="Noise type (default: film)")
+    noise_p.add_argument(
+        "-m", "--mode", default="film", choices=["film", "digital", "color"], help="Noise type (default: film)"
+    )
     noise_p.add_argument("--static", action="store_true", help="Use static noise instead of animated")
 
     # effect-scanlines
@@ -579,7 +731,9 @@ def main() -> None:
     tglitch_p.add_argument("clip1", help="First video clip")
     tglitch_p.add_argument("clip2", help="Second video clip")
     tglitch_p.add_argument("-o", "--output", help="Output file path")
-    tglitch_p.add_argument("-d", "--duration", type=float, default=0.5, help="Transition duration in seconds (default: 0.5)")
+    tglitch_p.add_argument(
+        "-d", "--duration", type=float, default=0.5, help="Transition duration in seconds (default: 0.5)"
+    )
     tglitch_p.add_argument("-i", "--intensity", type=float, default=0.3, help="Glitch intensity 0-1 (default: 0.3)")
 
     # transition-morph
@@ -587,7 +741,9 @@ def main() -> None:
     tmorph_p.add_argument("clip1", help="First video clip")
     tmorph_p.add_argument("clip2", help="Second video clip")
     tmorph_p.add_argument("-o", "--output", help="Output file path")
-    tmorph_p.add_argument("-d", "--duration", type=float, default=0.6, help="Transition duration in seconds (default: 0.6)")
+    tmorph_p.add_argument(
+        "-d", "--duration", type=float, default=0.6, help="Transition duration in seconds (default: 0.6)"
+    )
     tmorph_p.add_argument("--mesh-size", type=int, default=10, help="Mesh warp intensity (default: 10)")
 
     # transition-pixelate
@@ -595,7 +751,9 @@ def main() -> None:
     tpxl_p.add_argument("clip1", help="First video clip")
     tpxl_p.add_argument("clip2", help="Second video clip")
     tpxl_p.add_argument("-o", "--output", help="Output file path")
-    tpxl_p.add_argument("-d", "--duration", type=float, default=0.4, help="Transition duration in seconds (default: 0.4)")
+    tpxl_p.add_argument(
+        "-d", "--duration", type=float, default=0.4, help="Transition duration in seconds (default: 0.4)"
+    )
     tpxl_p.add_argument("--pixel-size", type=int, default=50, help="Pixel size (default: 50)")
 
     # ------------------------------------------------------------------
@@ -606,7 +764,12 @@ def main() -> None:
     aitrans_p = subparsers.add_parser("video-ai-transcribe", help="Transcribe speech to text using Whisper")
     aitrans_p.add_argument("input", help="Input video file")
     aitrans_p.add_argument("-o", "--output", help="Output SRT file path")
-    aitrans_p.add_argument("--model", default="base", choices=["tiny", "base", "small", "medium", "large"], help="Whisper model (default: base)")
+    aitrans_p.add_argument(
+        "--model",
+        default="base",
+        choices=["tiny", "base", "small", "medium", "large"],
+        help="Whisper model (default: base)",
+    )
     aitrans_p.add_argument("--language", help="Language code (auto-detect if omitted)")
 
     # video-ai-upscale
@@ -634,15 +797,24 @@ def main() -> None:
     aigrade_p.add_argument("input", help="Input video file")
     aigrade_p.add_argument("-o", "--output", help="Output file path")
     aigrade_p.add_argument("--reference", help="Reference video for color matching")
-    aigrade_p.add_argument("--style", default="auto", choices=["auto", "cinematic", "vintage", "warm", "cool", "dramatic"], help="Color style (default: auto)")
+    aigrade_p.add_argument(
+        "--style",
+        default="auto",
+        choices=["auto", "cinematic", "vintage", "warm", "cool", "dramatic"],
+        help="Color style (default: auto)",
+    )
 
     # video-ai-remove-silence
     airms_p = subparsers.add_parser("video-ai-remove-silence", help="Remove silent sections from video")
     airms_p.add_argument("input", help="Input video file")
     airms_p.add_argument("-o", "--output", help="Output file path")
     airms_p.add_argument("--silence-threshold", type=float, default=-50, help="Silence threshold in dB (default: -50)")
-    airms_p.add_argument("--min-silence-duration", type=float, default=0.5, help="Min silence duration in seconds (default: 0.5)")
-    airms_p.add_argument("--keep-margin", type=float, default=0.1, help="Keep margin around silence in seconds (default: 0.1)")
+    airms_p.add_argument(
+        "--min-silence-duration", type=float, default=0.5, help="Min silence duration in seconds (default: 0.5)"
+    )
+    airms_p.add_argument(
+        "--keep-margin", type=float, default=0.1, help="Keep margin around silence in seconds (default: 0.1)"
+    )
 
     # ------------------------------------------------------------------
     # Audio synthesis commands
@@ -651,30 +823,45 @@ def main() -> None:
     # audio-synthesize
     asynth_p = subparsers.add_parser("audio-synthesize", help="Generate audio using waveform synthesis")
     asynth_p.add_argument("-o", "--output", required=True, help="Output WAV file path")
-    asynth_p.add_argument("-w", "--waveform", default="sine", choices=["sine", "square", "sawtooth", "triangle", "noise"], help="Waveform type (default: sine)")
+    asynth_p.add_argument(
+        "-w",
+        "--waveform",
+        default="sine",
+        choices=["sine", "square", "sawtooth", "triangle", "noise"],
+        help="Waveform type (default: sine)",
+    )
     asynth_p.add_argument("-f", "--frequency", type=float, default=440.0, help="Frequency in Hz (default: 440)")
     asynth_p.add_argument("-d", "--duration", type=float, default=1.0, help="Duration in seconds (default: 1.0)")
     asynth_p.add_argument("-v", "--volume", type=float, default=0.5, help="Volume 0-1 (default: 0.5)")
-    asynth_p.add_argument("--effects", help="Effects as JSON, e.g. '{\"reverb\": {\"room_size\": 0.5}}'")
+    asynth_p.add_argument("--effects", help='Effects as JSON, e.g. \'{"reverb": {"room_size": 0.5}}\'')
 
     # audio-compose
     acomp_p = subparsers.add_parser("audio-compose", help="Layer multiple audio tracks with mixing")
     acomp_p.add_argument("-o", "--output", required=True, help="Output WAV file path")
     acomp_p.add_argument("-d", "--duration", type=float, required=True, help="Total duration in seconds")
-    acomp_p.add_argument("--tracks", required=True, help="Tracks as JSON: [{'file': 'a.wav', 'volume': 0.5, 'start': 0}]")
+    acomp_p.add_argument(
+        "--tracks", required=True, help="Tracks as JSON: [{'file': 'a.wav', 'volume': 0.5, 'start': 0}]"
+    )
 
     # audio-preset
     apreset_p = subparsers.add_parser("audio-preset", help="Generate preset sound design elements")
-    apreset_p.add_argument("preset", help="Preset name: ui-blip, ui-click, ui-tap, ui-whoosh-up, ui-whoosh-down, drone-low, drone-mid, drone-tech, drone-ominous, chime-success, chime-error, chime-notification, typing, scan, processing, data-flow, upload, download")
+    apreset_p.add_argument(
+        "preset",
+        help="Preset name: ui-blip, ui-click, ui-tap, ui-whoosh-up, ui-whoosh-down, drone-low, drone-mid, drone-tech, drone-ominous, chime-success, chime-error, chime-notification, typing, scan, processing, data-flow, upload, download",
+    )
     apreset_p.add_argument("-o", "--output", required=True, help="Output WAV file path")
-    apreset_p.add_argument("--pitch", default="mid", choices=["low", "mid", "high"], help="Pitch variation (default: mid)")
+    apreset_p.add_argument(
+        "--pitch", default="mid", choices=["low", "mid", "high"], help="Pitch variation (default: mid)"
+    )
     apreset_p.add_argument("-d", "--duration", type=float, help="Override default duration (seconds)")
     apreset_p.add_argument("-i", "--intensity", type=float, default=0.5, help="Effect intensity 0-1 (default: 0.5)")
 
     # audio-sequence
     aseq_p = subparsers.add_parser("audio-sequence", help="Compose audio events into a timed sequence")
     aseq_p.add_argument("-o", "--output", required=True, help="Output WAV file path")
-    aseq_p.add_argument("--sequence", required=True, help="Sequence as JSON: [{'type': 'tone', 'at': 0, 'duration': 1, 'freq': 440}]")
+    aseq_p.add_argument(
+        "--sequence", required=True, help="Sequence as JSON: [{'type': 'tone', 'at': 0, 'duration': 1, 'freq': 440}]"
+    )
 
     # audio-effects
     aefx_p = subparsers.add_parser("audio-effects", help="Apply audio effects chain to a WAV file")
@@ -691,11 +878,23 @@ def main() -> None:
     tanim_p.add_argument("input", help="Input video file")
     tanim_p.add_argument("text", help="Text to display")
     tanim_p.add_argument("-o", "--output", help="Output file path")
-    tanim_p.add_argument("-a", "--animation", default="fade", choices=["fade", "slide-up", "typewriter", "glitch"], help="Animation type (default: fade)")
+    tanim_p.add_argument(
+        "-a",
+        "--animation",
+        default="fade",
+        choices=["fade", "slide-up", "typewriter", "glitch"],
+        help="Animation type (default: fade)",
+    )
     tanim_p.add_argument("--font", default="Arial", help="Font family (default: Arial)")
     tanim_p.add_argument("--size", type=int, default=48, help="Font size in pixels (default: 48)")
     tanim_p.add_argument("--color", default="white", help="Text color (default: white)")
-    tanim_p.add_argument("-p", "--position", default="center", choices=["center", "top", "bottom", "top-left", "top-right", "bottom-left", "bottom-right"], help="Text position (default: center)")
+    tanim_p.add_argument(
+        "-p",
+        "--position",
+        default="center",
+        choices=["center", "top", "bottom", "top-left", "top-right", "bottom-left", "bottom-right"],
+        help="Text position (default: center)",
+    )
     tanim_p.add_argument("--start", type=float, default=0, help="Start time in seconds (default: 0)")
     tanim_p.add_argument("--duration", type=float, default=3.0, help="Display duration in seconds (default: 3.0)")
 
@@ -705,14 +904,16 @@ def main() -> None:
     mcount_p.add_argument("end", type=int, help="Ending number")
     mcount_p.add_argument("-d", "--duration", type=float, required=True, help="Animation duration in seconds")
     mcount_p.add_argument("-o", "--output", required=True, help="Output video file path")
-    mcount_p.add_argument("--style", help="Style as JSON: {\"font\": \"Arial\", \"size\": 160, \"color\": \"white\"}")
+    mcount_p.add_argument("--style", help='Style as JSON: {"font": "Arial", "size": 160, "color": "white"}')
     mcount_p.add_argument("--fps", type=int, default=30, help="Frame rate (default: 30)")
 
     # video-mograph-progress
     mprog_p = subparsers.add_parser("video-mograph-progress", help="Generate progress bar / loading animation")
     mprog_p.add_argument("-d", "--duration", type=float, required=True, help="Animation duration in seconds")
     mprog_p.add_argument("-o", "--output", required=True, help="Output video file path")
-    mprog_p.add_argument("--style", default="bar", choices=["bar", "circle", "dots"], help="Progress style (default: bar)")
+    mprog_p.add_argument(
+        "--style", default="bar", choices=["bar", "circle", "dots"], help="Progress style (default: bar)"
+    )
     mprog_p.add_argument("--color", default="#CCFF00", help="Progress color hex (default: #CCFF00)")
     mprog_p.add_argument("--track-color", default="#333333", help="Track background color hex (default: #333333)")
     mprog_p.add_argument("--fps", type=int, default=30, help="Frame rate (default: 30)")
@@ -724,7 +925,9 @@ def main() -> None:
     # video-layout-grid
     lgrid_p = subparsers.add_parser("video-layout-grid", help="Arrange multiple videos in a grid")
     lgrid_p.add_argument("inputs", nargs="+", help="Input video files")
-    lgrid_p.add_argument("-l", "--layout", default="2x2", choices=["2x2", "3x1", "1x3", "2x3"], help="Grid layout (default: 2x2)")
+    lgrid_p.add_argument(
+        "-l", "--layout", default="2x2", choices=["2x2", "3x1", "1x3", "2x3"], help="Grid layout (default: 2x2)"
+    )
     lgrid_p.add_argument("-o", "--output", required=True, help="Output file path")
     lgrid_p.add_argument("--gap", type=int, default=10, help="Gap between clips in pixels (default: 10)")
     lgrid_p.add_argument("--padding", type=int, default=20, help="Padding around grid in pixels (default: 20)")
@@ -735,15 +938,27 @@ def main() -> None:
     lpip_p.add_argument("main", help="Main video file")
     lpip_p.add_argument("pip", help="Picture-in-picture video file")
     lpip_p.add_argument("-o", "--output", required=True, help="Output file path")
-    lpip_p.add_argument("-p", "--position", default="bottom-right", choices=["top-left", "top-right", "bottom-left", "bottom-right"], help="PIP position (default: bottom-right)")
-    lpip_p.add_argument("-s", "--size", type=float, default=0.25, help="PIP size as fraction of main 0-1 (default: 0.25)")
+    lpip_p.add_argument(
+        "-p",
+        "--position",
+        default="bottom-right",
+        choices=["top-left", "top-right", "bottom-left", "bottom-right"],
+        help="PIP position (default: bottom-right)",
+    )
+    lpip_p.add_argument(
+        "-s", "--size", type=float, default=0.25, help="PIP size as fraction of main 0-1 (default: 0.25)"
+    )
     lpip_p.add_argument("--margin", type=int, default=20, help="Margin from edges in pixels (default: 20)")
     lpip_p.add_argument("--border", action="store_true", default=True, help="Add border around PIP (default: True)")
     lpip_p.add_argument("--no-border", dest="border", action="store_false", help="Disable border around PIP")
     lpip_p.add_argument("--border-color", default="#CCFF00", help="Border color hex (default: #CCFF00)")
     lpip_p.add_argument("--border-width", type=int, default=2, help="Border width in pixels (default: 2)")
-    lpip_p.add_argument("--rounded-corners", action="store_true", default=True, help="Apply rounded corners to PIP (default: True)")
-    lpip_p.add_argument("--no-rounded-corners", dest="rounded_corners", action="store_false", help="Disable rounded corners")
+    lpip_p.add_argument(
+        "--rounded-corners", action="store_true", default=True, help="Apply rounded corners to PIP (default: True)"
+    )
+    lpip_p.add_argument(
+        "--no-rounded-corners", dest="rounded_corners", action="store_false", help="Disable rounded corners"
+    )
 
     # ------------------------------------------------------------------
     # Audio-Video commands
@@ -752,15 +967,21 @@ def main() -> None:
     # video-add-generated-audio
     addgen_p = subparsers.add_parser("video-add-generated-audio", help="Add procedurally generated audio to video")
     addgen_p.add_argument("input", help="Input video file")
-    addgen_p.add_argument("--audio-config", required=True, help="Audio config as JSON: {\"drone\": {\"frequency\": 100}, \"events\": [...]}")
+    addgen_p.add_argument(
+        "--audio-config", required=True, help='Audio config as JSON: {"drone": {"frequency": 100}, "events": [...]}'
+    )
     addgen_p.add_argument("-o", "--output", help="Output file path")
 
     # video-audio-spatial
     aspat_p = subparsers.add_parser("video-audio-spatial", help="Apply 3D spatial audio positioning")
     aspat_p.add_argument("input", help="Input video file")
     aspat_p.add_argument("-o", "--output", help="Output file path")
-    aspat_p.add_argument("--positions", required=True, help="Positions as JSON: [{\"time\": 0, \"azimuth\": 0, \"elevation\": 0}]")
-    aspat_p.add_argument("--method", default="hrtf", choices=["hrtf", "vbap", "simple"], help="Spatialization method (default: hrtf)")
+    aspat_p.add_argument(
+        "--positions", required=True, help='Positions as JSON: [{"time": 0, "azimuth": 0, "elevation": 0}]'
+    )
+    aspat_p.add_argument(
+        "--method", default="hrtf", choices=["hrtf", "vbap", "simple"], help="Spatialization method (default: hrtf)"
+    )
 
     # ------------------------------------------------------------------
     # Quality / Info commands
@@ -804,25 +1025,39 @@ def main() -> None:
     # image-extract-colors
     imgcol_p = subparsers.add_parser("image-extract-colors", help="Extract dominant colors from an image")
     imgcol_p.add_argument("input", help="Input image file")
-    imgcol_p.add_argument("-n", "--n-colors", type=int, default=5, help="Number of colors to extract (default: 5, max: 20)")
+    imgcol_p.add_argument(
+        "-n", "--n-colors", type=int, default=5, help="Number of colors to extract (default: 5, max: 20)"
+    )
 
     # image-generate-palette
     imgpal_p = subparsers.add_parser("image-generate-palette", help="Generate color harmony palette from image")
     imgpal_p.add_argument("input", help="Input image file")
-    imgpal_p.add_argument("--harmony", default="complementary", choices=["complementary", "analogous", "triadic", "split_complementary"], help="Harmony type (default: complementary)")
+    imgpal_p.add_argument(
+        "--harmony",
+        default="complementary",
+        choices=["complementary", "analogous", "triadic", "split_complementary"],
+        help="Harmony type (default: complementary)",
+    )
     imgpal_p.add_argument("-n", "--n-colors", type=int, default=5, help="Number of base colors (default: 5, max: 20)")
 
     # image-analyze-product
-    imgprod_p = subparsers.add_parser("image-analyze-product", help="Analyze a product image (colors + optional AI description)")
+    imgprod_p = subparsers.add_parser(
+        "image-analyze-product", help="Analyze a product image (colors + optional AI description)"
+    )
     imgprod_p.add_argument("input", help="Input image file")
-    imgprod_p.add_argument("--use-ai", action="store_true", help="Use Claude Vision for description (requires ANTHROPIC_API_KEY)")
-    imgprod_p.add_argument("-n", "--n-colors", type=int, default=5, help="Number of colors to extract (default: 5, max: 20)")
+    imgprod_p.add_argument(
+        "--use-ai", action="store_true", help="Use Claude Vision for description (requires ANTHROPIC_API_KEY)"
+    )
+    imgprod_p.add_argument(
+        "-n", "--n-colors", type=int, default=5, help="Number of colors to extract (default: 5, max: 20)"
+    )
 
     args = parser.parse_args()
 
     # --version
     if args.version:
         from . import __version__
+
         console.print(f"mcp-video [bold]{__version__}[/bold]")
         return
 
@@ -830,6 +1065,7 @@ def main() -> None:
     if args.mcp or args.command is None:
         try:
             from .server import mcp
+
             mcp.run()
         except ImportError:
             err_console.print(
@@ -844,6 +1080,7 @@ def main() -> None:
     def _auto_output(input_path: str, suffix: str) -> str:
         """Generate an output path next to the input file."""
         import os
+
         base, ext = os.path.splitext(input_path)
         return f"{base}_{suffix}{ext}"
 
@@ -857,6 +1094,7 @@ def main() -> None:
     try:
         if args.command == "info":
             from .engine import probe
+
             info = probe(args.input)
             if use_json:
                 info_dict = info.model_dump() if hasattr(info, "model_dump") else info
@@ -866,7 +1104,10 @@ def main() -> None:
 
         elif args.command == "extract-frame":
             from .engine import thumbnail
-            result = _with_spinner("Extracting frame...", thumbnail, args.input, timestamp=args.timestamp, output_path=args.output)
+
+            result = _with_spinner(
+                "Extracting frame...", thumbnail, args.input, timestamp=args.timestamp, output_path=args.output
+            )
             if use_json:
                 result_dict = result.model_dump() if hasattr(result, "model_dump") else result
                 output_json({"success": True, **result_dict})
@@ -875,7 +1116,16 @@ def main() -> None:
 
         elif args.command == "trim":
             from .engine import trim
-            result = _with_spinner("Trimming...", trim, args.input, start=args.start, duration=args.duration, end=args.end, output_path=args.output)
+
+            result = _with_spinner(
+                "Trimming...",
+                trim,
+                args.input,
+                start=args.start,
+                duration=args.duration,
+                end=args.end,
+                output_path=args.output,
+            )
             if use_json:
                 output_json(result)
             else:
@@ -883,7 +1133,16 @@ def main() -> None:
 
         elif args.command == "merge":
             from .engine import merge
-            result = _with_spinner("Merging...", merge, args.inputs, output_path=args.output, transition=args.transition, transitions=args.transitions, transition_duration=args.transition_duration)
+
+            result = _with_spinner(
+                "Merging...",
+                merge,
+                args.inputs,
+                output_path=args.output,
+                transition=args.transition,
+                transitions=args.transitions,
+                transition_duration=args.transition_duration,
+            )
             if use_json:
                 output_json(result)
             else:
@@ -891,11 +1150,19 @@ def main() -> None:
 
         elif args.command == "add-text":
             from .engine import add_text
-            result = _with_spinner("Adding text...", add_text,
-                args.input, text=args.text, position=args.position,
-                font=args.font, size=args.size, color=args.color,
+
+            result = _with_spinner(
+                "Adding text...",
+                add_text,
+                args.input,
+                text=args.text,
+                position=args.position,
+                font=args.font,
+                size=args.size,
+                color=args.color,
                 shadow=not args.no_shadow,
-                start_time=args.start_time, duration=args.duration,
+                start_time=args.start_time,
+                duration=args.duration,
                 output_path=args.output,
             )
             if use_json:
@@ -905,10 +1172,17 @@ def main() -> None:
 
         elif args.command == "add-audio":
             from .engine import add_audio
-            result = _with_spinner("Adding audio...", add_audio,
-                args.video, args.audio, volume=args.volume,
-                fade_in=args.fade_in, fade_out=args.fade_out,
-                mix=args.mix, start_time=args.start_time,
+
+            result = _with_spinner(
+                "Adding audio...",
+                add_audio,
+                args.video,
+                args.audio,
+                volume=args.volume,
+                fade_in=args.fade_in,
+                fade_out=args.fade_out,
+                mix=args.mix,
+                start_time=args.start_time,
                 output_path=args.output,
             )
             if use_json:
@@ -918,9 +1192,15 @@ def main() -> None:
 
         elif args.command == "resize":
             from .engine import resize
-            result = _with_spinner("Resizing...", resize,
-                args.input, width=args.width, height=args.height,
-                aspect_ratio=args.aspect_ratio, quality=args.quality,
+
+            result = _with_spinner(
+                "Resizing...",
+                resize,
+                args.input,
+                width=args.width,
+                height=args.height,
+                aspect_ratio=args.aspect_ratio,
+                quality=args.quality,
                 output_path=args.output,
             )
             if use_json:
@@ -930,6 +1210,7 @@ def main() -> None:
 
         elif args.command == "speed":
             from .engine import speed
+
             result = _with_spinner("Changing speed...", speed, args.input, factor=args.factor, output_path=args.output)
             if use_json:
                 output_json(result)
@@ -938,7 +1219,10 @@ def main() -> None:
 
         elif args.command == "convert":
             from .engine import convert
-            result = _with_spinner("Converting...", convert, args.input, format=args.fmt, quality=args.quality, output_path=args.output)
+
+            result = _with_spinner(
+                "Converting...", convert, args.input, format=args.fmt, quality=args.quality, output_path=args.output
+            )
             if use_json:
                 output_json(result)
             else:
@@ -946,6 +1230,7 @@ def main() -> None:
 
         elif args.command == "thumbnail":
             from .engine import thumbnail
+
             result = thumbnail(args.input, timestamp=args.timestamp, output_path=args.output)
             if use_json:
                 output_json(result)
@@ -954,7 +1239,10 @@ def main() -> None:
 
         elif args.command == "preview":
             from .engine import preview
-            result = _with_spinner("Generating preview...", preview, args.input, output_path=args.output, scale_factor=args.scale)
+
+            result = _with_spinner(
+                "Generating preview...", preview, args.input, output_path=args.output, scale_factor=args.scale
+            )
             if use_json:
                 output_json(result)
             else:
@@ -962,7 +1250,10 @@ def main() -> None:
 
         elif args.command == "storyboard":
             from .engine import storyboard
-            result = _with_spinner("Extracting storyboard...", storyboard, args.input, output_dir=args.output_dir, frame_count=args.frames)
+
+            result = _with_spinner(
+                "Extracting storyboard...", storyboard, args.input, output_dir=args.output_dir, frame_count=args.frames
+            )
             if use_json:
                 output_json(result)
             else:
@@ -970,7 +1261,10 @@ def main() -> None:
 
         elif args.command == "subtitles":
             from .engine import subtitles
-            result = _with_spinner("Burning subtitles...", subtitles, args.input, subtitle_path=args.subtitle, output_path=args.output)
+
+            result = _with_spinner(
+                "Burning subtitles...", subtitles, args.input, subtitle_path=args.subtitle, output_path=args.output
+            )
             if use_json:
                 output_json(result)
             else:
@@ -978,9 +1272,15 @@ def main() -> None:
 
         elif args.command == "watermark":
             from .engine import watermark
-            result = _with_spinner("Adding watermark...", watermark,
-                args.input, image_path=args.image, position=args.position,
-                opacity=args.opacity, margin=args.margin,
+
+            result = _with_spinner(
+                "Adding watermark...",
+                watermark,
+                args.input,
+                image_path=args.image,
+                position=args.position,
+                opacity=args.opacity,
+                margin=args.margin,
                 output_path=args.output,
             )
             if use_json:
@@ -990,7 +1290,17 @@ def main() -> None:
 
         elif args.command == "crop":
             from .engine import crop
-            result = _with_spinner("Cropping...", crop, args.input, width=args.width, height=args.height, x=args.x, y=args.y, output_path=args.output)
+
+            result = _with_spinner(
+                "Cropping...",
+                crop,
+                args.input,
+                width=args.width,
+                height=args.height,
+                x=args.x,
+                y=args.y,
+                output_path=args.output,
+            )
             if use_json:
                 output_json(result)
             else:
@@ -998,7 +1308,16 @@ def main() -> None:
 
         elif args.command == "rotate":
             from .engine import rotate
-            result = _with_spinner("Rotating...", rotate, args.input, angle=args.angle, flip_horizontal=args.flip_h, flip_vertical=args.flip_v, output_path=args.output)
+
+            result = _with_spinner(
+                "Rotating...",
+                rotate,
+                args.input,
+                angle=args.angle,
+                flip_horizontal=args.flip_h,
+                flip_vertical=args.flip_v,
+                output_path=args.output,
+            )
             if use_json:
                 output_json(result)
             else:
@@ -1006,7 +1325,15 @@ def main() -> None:
 
         elif args.command == "fade":
             from .engine import fade
-            result = _with_spinner("Applying fade...", fade, args.input, fade_in=args.fade_in, fade_out=args.fade_out, output_path=args.output)
+
+            result = _with_spinner(
+                "Applying fade...",
+                fade,
+                args.input,
+                fade_in=args.fade_in,
+                fade_out=args.fade_out,
+                output_path=args.output,
+            )
             if use_json:
                 output_json(result)
             else:
@@ -1014,7 +1341,10 @@ def main() -> None:
 
         elif args.command == "export":
             from .engine import export_video
-            result = _with_spinner("Exporting...", export_video, args.input, quality=args.quality, format=args.fmt, output_path=args.output)
+
+            result = _with_spinner(
+                "Exporting...", export_video, args.input, quality=args.quality, format=args.fmt, output_path=args.output
+            )
             if use_json:
                 output_json(result)
             else:
@@ -1022,7 +1352,10 @@ def main() -> None:
 
         elif args.command == "extract-audio":
             from .engine import extract_audio
-            result = _with_spinner("Extracting audio...", extract_audio, args.input, output_path=args.output, format=args.audio_format)
+
+            result = _with_spinner(
+                "Extracting audio...", extract_audio, args.input, output_path=args.output, format=args.audio_format
+            )
             if use_json:
                 output_json({"success": True, "output_path": result})
             else:
@@ -1030,6 +1363,7 @@ def main() -> None:
 
         elif args.command == "edit":
             from .models import Timeline
+
             timeline_arg = args.timeline.strip()
             if timeline_arg.startswith(("{", "[")):
                 tl = Timeline.model_validate(_parse_json_arg(timeline_arg, "timeline", json_mode=use_json))
@@ -1037,6 +1371,7 @@ def main() -> None:
                 with open(timeline_arg) as f:
                     tl = Timeline.model_validate(json.load(f))
             from .engine import edit_timeline
+
             result = _with_spinner("Editing timeline...", edit_timeline, tl, output_path=args.output)
             if use_json:
                 output_json(result)
@@ -1045,8 +1380,16 @@ def main() -> None:
 
         elif args.command == "filter":
             from .engine import apply_filter
+
             params = _parse_json_arg(args.params, "params", json_mode=use_json) if args.params else {}
-            result = _with_spinner("Applying filter...", apply_filter, args.input, filter_type=args.filter_type, params=params, output_path=args.output)
+            result = _with_spinner(
+                "Applying filter...",
+                apply_filter,
+                args.input,
+                filter_type=args.filter_type,
+                params=params,
+                output_path=args.output,
+            )
             if use_json:
                 output_json(result)
             else:
@@ -1054,7 +1397,15 @@ def main() -> None:
 
         elif args.command == "blur":
             from .engine import apply_filter
-            result = _with_spinner("Applying blur...", apply_filter, args.input, filter_type="blur", params={"radius": args.radius, "strength": args.strength}, output_path=args.output)
+
+            result = _with_spinner(
+                "Applying blur...",
+                apply_filter,
+                args.input,
+                filter_type="blur",
+                params={"radius": args.radius, "strength": args.strength},
+                output_path=args.output,
+            )
             if use_json:
                 output_json(result)
             else:
@@ -1062,6 +1413,7 @@ def main() -> None:
 
         elif args.command == "reverse":
             from .engine import reverse
+
             result = _with_spinner("Reversing...", reverse, args.input, output_path=args.output)
             if use_json:
                 output_json(result)
@@ -1070,7 +1422,16 @@ def main() -> None:
 
         elif args.command == "chroma-key":
             from .engine import chroma_key
-            result = _with_spinner("Removing green screen...", chroma_key, args.input, color=args.color, similarity=args.similarity, blend=args.blend, output_path=args.output)
+
+            result = _with_spinner(
+                "Removing green screen...",
+                chroma_key,
+                args.input,
+                color=args.color,
+                similarity=args.similarity,
+                blend=args.blend,
+                output_path=args.output,
+            )
             if use_json:
                 output_json(result)
             else:
@@ -1078,7 +1439,15 @@ def main() -> None:
 
         elif args.command == "color-grade":
             from .engine import apply_filter
-            result = _with_spinner("Applying color grade...", apply_filter, args.input, filter_type="color_preset", params={"preset": args.preset}, output_path=args.output)
+
+            result = _with_spinner(
+                "Applying color grade...",
+                apply_filter,
+                args.input,
+                filter_type="color_preset",
+                params={"preset": args.preset},
+                output_path=args.output,
+            )
             if use_json:
                 output_json(result)
             else:
@@ -1086,7 +1455,10 @@ def main() -> None:
 
         elif args.command == "normalize-audio":
             from .engine import normalize_audio
-            result = _with_spinner("Normalizing audio...", normalize_audio, args.input, target_lufs=args.lufs, output_path=args.output)
+
+            result = _with_spinner(
+                "Normalizing audio...", normalize_audio, args.input, target_lufs=args.lufs, output_path=args.output
+            )
             if use_json:
                 output_json(result)
             else:
@@ -1094,10 +1466,18 @@ def main() -> None:
 
         elif args.command == "overlay-video":
             from .engine import overlay_video
-            result = _with_spinner("Compositing overlay...", overlay_video,
-                args.background, overlay_path=args.overlay, position=args.position,
-                width=args.width, height=args.height, opacity=args.opacity,
-                start_time=args.start_time, duration=args.duration,
+
+            result = _with_spinner(
+                "Compositing overlay...",
+                overlay_video,
+                args.background,
+                overlay_path=args.overlay,
+                position=args.position,
+                width=args.width,
+                height=args.height,
+                opacity=args.opacity,
+                start_time=args.start_time,
+                duration=args.duration,
                 output_path=args.output,
             )
             if use_json:
@@ -1107,7 +1487,15 @@ def main() -> None:
 
         elif args.command == "split-screen":
             from .engine import split_screen
-            result = _with_spinner("Creating split screen...", split_screen, args.left, right_path=args.right, layout=args.layout, output_path=args.output)
+
+            result = _with_spinner(
+                "Creating split screen...",
+                split_screen,
+                args.left,
+                right_path=args.right,
+                layout=args.layout,
+                output_path=args.output,
+            )
             if use_json:
                 output_json(result)
             else:
@@ -1115,6 +1503,7 @@ def main() -> None:
 
         elif args.command == "batch":
             from .engine import video_batch
+
             params = _parse_json_arg(args.params, "params", json_mode=use_json) if args.params else {}
             result = video_batch(args.inputs, operation=args.operation, params=params, output_dir=args.output_dir)
             if use_json:
@@ -1124,7 +1513,14 @@ def main() -> None:
 
         elif args.command == "detect-scenes":
             from .engine import detect_scenes
-            result = _with_spinner("Detecting scenes...", detect_scenes, args.input, threshold=args.threshold, min_scene_duration=args.min_duration)
+
+            result = _with_spinner(
+                "Detecting scenes...",
+                detect_scenes,
+                args.input,
+                threshold=args.threshold,
+                min_scene_duration=args.min_duration,
+            )
             if use_json:
                 output_json(result)
             else:
@@ -1135,13 +1531,23 @@ def main() -> None:
                 table.add_column("End", style="cyan")
                 table.add_column("Frames")
                 for i, scene in enumerate(data.get("scenes", []), 1):
-                    table.add_row(str(i), f"{scene['start']:.2f}s", f"{scene['end']:.2f}s", f"{scene['start_frame']}-{scene['end_frame']}")
+                    table.add_row(
+                        str(i),
+                        f"{scene['start']:.2f}s",
+                        f"{scene['end']:.2f}s",
+                        f"{scene['start_frame']}-{scene['end_frame']}",
+                    )
                 console.print(table)
-                console.print(f"[bold]{data.get('scene_count', 0)} scenes detected[/bold] in {data.get('duration', 0):.2f}s")
+                console.print(
+                    f"[bold]{data.get('scene_count', 0)} scenes detected[/bold] in {data.get('duration', 0):.2f}s"
+                )
 
         elif args.command == "create-from-images":
             from .engine import create_from_images
-            result = _with_spinner("Creating video from images...", create_from_images, args.inputs, output_path=args.output, fps=args.fps)
+
+            result = _with_spinner(
+                "Creating video from images...", create_from_images, args.inputs, output_path=args.output, fps=args.fps
+            )
             if use_json:
                 output_json(result)
             else:
@@ -1149,8 +1555,11 @@ def main() -> None:
 
         elif args.command == "export-frames":
             from .engine import export_frames
+
             fmt = "mjpeg" if args.image_format == "jpg" else args.image_format
-            result = _with_spinner("Exporting frames...", export_frames, args.input, output_dir=args.output_dir, fps=args.fps, format=fmt)
+            result = _with_spinner(
+                "Exporting frames...", export_frames, args.input, output_dir=args.output_dir, fps=args.fps, format=fmt
+            )
             if use_json:
                 output_json(result)
             else:
@@ -1166,8 +1575,11 @@ def main() -> None:
 
         elif args.command == "compare-quality":
             from .engine import compare_quality
+
             metrics = args.metrics if args.metrics else None
-            result = _with_spinner("Comparing quality...", compare_quality, args.original, args.distorted, metrics=metrics)
+            result = _with_spinner(
+                "Comparing quality...", compare_quality, args.original, args.distorted, metrics=metrics
+            )
             if use_json:
                 output_json(result)
             else:
@@ -1184,6 +1596,7 @@ def main() -> None:
 
         elif args.command == "read-metadata":
             from .engine import read_metadata
+
             result = read_metadata(args.input)
             if use_json:
                 output_json(result)
@@ -1205,12 +1618,15 @@ def main() -> None:
 
         elif args.command == "write-metadata":
             from .engine import write_metadata
+
             try:
                 tags = json.loads(args.tags)
             except json.JSONDecodeError as e:
                 console.print(f"[bold red]Invalid JSON in --tags: {e}[/bold red]")
                 raise SystemExit(1) from None
-            result = _with_spinner("Writing metadata...", write_metadata, args.input, metadata=tags, output_path=args.output)
+            result = _with_spinner(
+                "Writing metadata...", write_metadata, args.input, metadata=tags, output_path=args.output
+            )
             if use_json:
                 output_json(result)
             else:
@@ -1218,7 +1634,15 @@ def main() -> None:
 
         elif args.command == "stabilize":
             from .engine import stabilize
-            result = _with_spinner("Stabilizing...", stabilize, args.input, smoothing=args.smoothing, zooming=args.zooming, output_path=args.output)
+
+            result = _with_spinner(
+                "Stabilizing...",
+                stabilize,
+                args.input,
+                smoothing=args.smoothing,
+                zooming=args.zooming,
+                output_path=args.output,
+            )
             if use_json:
                 output_json(result)
             else:
@@ -1226,7 +1650,15 @@ def main() -> None:
 
         elif args.command == "apply-mask":
             from .engine import apply_mask
-            result = _with_spinner("Applying mask...", apply_mask, args.input, mask_path=args.mask, feather=args.feather, output_path=args.output)
+
+            result = _with_spinner(
+                "Applying mask...",
+                apply_mask,
+                args.input,
+                mask_path=args.mask,
+                feather=args.feather,
+                output_path=args.output,
+            )
             if use_json:
                 output_json(result)
             else:
@@ -1234,6 +1666,7 @@ def main() -> None:
 
         elif args.command == "audio-waveform":
             from .engine import audio_waveform
+
             result = _with_spinner("Extracting waveform...", audio_waveform, args.input, bins=args.bins)
             if use_json:
                 output_json(result)
@@ -1246,14 +1679,22 @@ def main() -> None:
                 table.add_row("Mean Level", f"{data.get('mean_level', 0):.1f} dB")
                 table.add_row("Max Level", f"{data.get('max_level', 0):.1f} dB")
                 table.add_row("Min Level", f"{data.get('min_level', 0):.1f} dB")
-                silence_count = len(data.get('silence_regions', []))
+                silence_count = len(data.get("silence_regions", []))
                 table.add_row("Silence Regions", str(silence_count))
                 console.print(table)
 
         elif args.command == "generate-subtitles":
             from .engine import generate_subtitles
+
             entries = _parse_json_arg(args.entries, "entries", json_mode=use_json)
-            result = _with_spinner("Generating subtitles...", generate_subtitles, entries, args.input, burn=args.burn, output_path=args.output)
+            result = _with_spinner(
+                "Generating subtitles...",
+                generate_subtitles,
+                entries,
+                args.input,
+                burn=args.burn,
+                output_path=args.output,
+            )
             if use_json:
                 output_json(result)
             else:
@@ -1262,12 +1703,13 @@ def main() -> None:
                     f"[bold green]Entries:[/bold green] {data.get('entry_count', 0)}",
                     f"[bold green]SRT Path:[/bold green] {data.get('srt_path', 'N/A')}",
                 ]
-                if data.get('video_path'):
+                if data.get("video_path"):
                     lines.append(f"[bold green]Video Path:[/bold green] {data['video_path']}")
                 console.print(Panel("\n".join(lines), border_style="green", title="Subtitles Generated"))
 
         elif args.command == "templates":
             from .templates import TEMPLATES
+
             descriptions = {
                 "tiktok": "TikTok (9:16, 1080x1920) — vertical video with optional caption and music",
                 "youtube-shorts": "YouTube Shorts (9:16) — title at top, vertical video",
@@ -1288,6 +1730,7 @@ def main() -> None:
         elif args.command == "template":
             from .templates import TEMPLATES
             from .engine import edit_timeline
+
             template_fn = TEMPLATES[args.name]
             kwargs: dict[str, Any] = {"video_path": args.input, "output_path": args.output}
             if args.caption:
@@ -1299,7 +1742,9 @@ def main() -> None:
             if args.outro:
                 kwargs["outro_path"] = args.outro
             timeline = template_fn(**kwargs)
-            result = _with_spinner(f"Applying {args.name} template...", edit_timeline, timeline, output_path=args.output)
+            result = _with_spinner(
+                f"Applying {args.name} template...", edit_timeline, timeline, output_path=args.output
+            )
             if use_json:
                 output_json(result)
             else:
@@ -1311,15 +1756,23 @@ def main() -> None:
 
         elif args.command == "remotion-render":
             from .remotion_engine import render_composition
+
             props = _parse_json_arg(args.props, "props", json_mode=use_json) if args.props else None
             result = _with_spinner(
                 f"Rendering {args.composition_id}...",
                 render_composition,
-                args.project_path, args.composition_id,
-                output_path=args.output, codec=args.codec, crf=args.crf,
-                width=args.width, height=args.height, fps=args.fps,
-                concurrency=args.concurrency, frames=args.frames,
-                props=props, scale=args.scale,
+                args.project_path,
+                args.composition_id,
+                output_path=args.output,
+                codec=args.codec,
+                crf=args.crf,
+                width=args.width,
+                height=args.height,
+                fps=args.fps,
+                concurrency=args.concurrency,
+                frames=args.frames,
+                props=props,
+                scale=args.scale,
             )
             if use_json:
                 output_json(result)
@@ -1341,6 +1794,7 @@ def main() -> None:
 
         elif args.command == "remotion-compositions":
             from .remotion_engine import list_compositions
+
             result = _with_spinner(
                 "Listing compositions...",
                 list_compositions,
@@ -1369,6 +1823,7 @@ def main() -> None:
 
         elif args.command == "remotion-studio":
             from .remotion_engine import launch_studio
+
             result = _with_spinner(
                 "Launching Remotion Studio...",
                 launch_studio,
@@ -1378,22 +1833,31 @@ def main() -> None:
             if use_json or args.json:
                 output_json(result)
             else:
-                data = result.model_dump() if hasattr(result, "model_dump") else (result if isinstance(result, dict) else {})
-                console.print(Panel(
-                    f"[bold green]Studio running:[/bold green] {data.get('url', 'N/A')}\n"
-                    f"[bold green]Port:[/bold green] {data.get('port', 'N/A')}\n"
-                    f"[bold green]Project:[/bold green] {data.get('project_path', 'N/A')}",
-                    border_style="green",
-                    title="Remotion Studio",
-                ))
+                data = (
+                    result.model_dump()
+                    if hasattr(result, "model_dump")
+                    else (result if isinstance(result, dict) else {})
+                )
+                console.print(
+                    Panel(
+                        f"[bold green]Studio running:[/bold green] {data.get('url', 'N/A')}\n"
+                        f"[bold green]Port:[/bold green] {data.get('port', 'N/A')}\n"
+                        f"[bold green]Project:[/bold green] {data.get('project_path', 'N/A')}",
+                        border_style="green",
+                        title="Remotion Studio",
+                    )
+                )
 
         elif args.command == "remotion-still":
             from .remotion_engine import render_still
+
             result = _with_spinner(
                 f"Rendering still frame {args.frame}...",
                 render_still,
-                args.project_path, args.composition_id,
-                output_path=args.output, frame=args.frame,
+                args.project_path,
+                args.composition_id,
+                output_path=args.output,
+                frame=args.frame,
                 image_format=args.image_format,
             )
             if use_json:
@@ -1411,6 +1875,7 @@ def main() -> None:
 
         elif args.command == "remotion-create":
             from .remotion_engine import create_project
+
             result = _with_spinner(
                 f"Creating project '{args.name}'...",
                 create_project,
@@ -1432,6 +1897,7 @@ def main() -> None:
 
         elif args.command == "remotion-scaffold":
             from .remotion_engine import scaffold_composition
+
             spec = _parse_json_arg(args.spec, "spec", json_mode=use_json)
             result = _with_spinner(
                 f"Scaffolding '{args.slug}'...",
@@ -1454,6 +1920,7 @@ def main() -> None:
 
         elif args.command == "remotion-validate":
             from .remotion_engine import validate_project
+
             result = _with_spinner(
                 "Validating project...",
                 validate_project,
@@ -1477,15 +1944,23 @@ def main() -> None:
                     lines.append(f"[yellow]Warnings ({len(data['warnings'])}):[/yellow]")
                     for warning in data["warnings"]:
                         lines.append(f"  - {warning}")
-                console.print(Panel("\n".join(lines), border_style="green" if data.get("valid") else "red", title="Remotion Validate"))
+                console.print(
+                    Panel(
+                        "\n".join(lines),
+                        border_style="green" if data.get("valid") else "red",
+                        title="Remotion Validate",
+                    )
+                )
 
         elif args.command == "remotion-pipeline":
             from .remotion_engine import render_pipeline
+
             post_process = _parse_json_arg(args.post_process, "post-process", json_mode=use_json)
             result = _with_spinner(
                 f"Running pipeline for {args.composition_id}...",
                 render_pipeline,
-                args.project_path, args.composition_id,
+                args.project_path,
+                args.composition_id,
                 post_process=post_process,
                 output_path=args.output,
             )
@@ -1508,53 +1983,106 @@ def main() -> None:
 
         elif args.command == "effect-vignette":
             from .effects_engine import effect_vignette
+
             out = args.output or _auto_output(args.input, "vignette")
-            result = _with_spinner("Applying vignette...", effect_vignette, args.input, out,
-                                   intensity=args.intensity, radius=args.radius, smoothness=args.smoothness)
+            result = _with_spinner(
+                "Applying vignette...",
+                effect_vignette,
+                args.input,
+                out,
+                intensity=args.intensity,
+                radius=args.radius,
+                smoothness=args.smoothness,
+            )
             if use_json:
                 output_json({"success": True, "output_path": result})
             else:
-                console.print(Panel(f"[bold green]Vignette applied:[/bold green] {result}", border_style="green", title="Done"))
+                console.print(
+                    Panel(f"[bold green]Vignette applied:[/bold green] {result}", border_style="green", title="Done")
+                )
 
         elif args.command == "effect-glow":
             from .effects_engine import effect_glow
+
             out = args.output or _auto_output(args.input, "glow")
-            result = _with_spinner("Applying glow...", effect_glow, args.input, out,
-                                   intensity=args.intensity, radius=args.radius, threshold=args.threshold)
+            result = _with_spinner(
+                "Applying glow...",
+                effect_glow,
+                args.input,
+                out,
+                intensity=args.intensity,
+                radius=args.radius,
+                threshold=args.threshold,
+            )
             if use_json:
                 output_json({"success": True, "output_path": result})
             else:
-                console.print(Panel(f"[bold green]Glow applied:[/bold green] {result}", border_style="green", title="Done"))
+                console.print(
+                    Panel(f"[bold green]Glow applied:[/bold green] {result}", border_style="green", title="Done")
+                )
 
         elif args.command == "effect-noise":
             from .effects_engine import effect_noise
+
             out = args.output or _auto_output(args.input, "noise")
-            result = _with_spinner("Applying noise...", effect_noise, args.input, out,
-                                   intensity=args.intensity, mode=args.mode, animated=not args.static)
+            result = _with_spinner(
+                "Applying noise...",
+                effect_noise,
+                args.input,
+                out,
+                intensity=args.intensity,
+                mode=args.mode,
+                animated=not args.static,
+            )
             if use_json:
                 output_json({"success": True, "output_path": result})
             else:
-                console.print(Panel(f"[bold green]Noise applied:[/bold green] {result}", border_style="green", title="Done"))
+                console.print(
+                    Panel(f"[bold green]Noise applied:[/bold green] {result}", border_style="green", title="Done")
+                )
 
         elif args.command == "effect-scanlines":
             from .effects_engine import effect_scanlines
+
             out = args.output or _auto_output(args.input, "scanlines")
-            result = _with_spinner("Applying scanlines...", effect_scanlines, args.input, out,
-                                   line_height=args.line_height, opacity=args.opacity, flicker=args.flicker)
+            result = _with_spinner(
+                "Applying scanlines...",
+                effect_scanlines,
+                args.input,
+                out,
+                line_height=args.line_height,
+                opacity=args.opacity,
+                flicker=args.flicker,
+            )
             if use_json:
                 output_json({"success": True, "output_path": result})
             else:
-                console.print(Panel(f"[bold green]Scanlines applied:[/bold green] {result}", border_style="green", title="Done"))
+                console.print(
+                    Panel(f"[bold green]Scanlines applied:[/bold green] {result}", border_style="green", title="Done")
+                )
 
         elif args.command == "effect-chromatic-aberration":
             from .effects_engine import effect_chromatic_aberration
+
             out = args.output or _auto_output(args.input, "chromatic")
-            result = _with_spinner("Applying chromatic aberration...", effect_chromatic_aberration,
-                                   args.input, out, intensity=args.intensity, angle=args.angle)
+            result = _with_spinner(
+                "Applying chromatic aberration...",
+                effect_chromatic_aberration,
+                args.input,
+                out,
+                intensity=args.intensity,
+                angle=args.angle,
+            )
             if use_json:
                 output_json({"success": True, "output_path": result})
             else:
-                console.print(Panel(f"[bold green]Chromatic aberration applied:[/bold green] {result}", border_style="green", title="Done"))
+                console.print(
+                    Panel(
+                        f"[bold green]Chromatic aberration applied:[/bold green] {result}",
+                        border_style="green",
+                        title="Done",
+                    )
+                )
 
         # ------------------------------------------------------------------
         # Transition commands
@@ -1562,33 +2090,60 @@ def main() -> None:
 
         elif args.command == "transition-glitch":
             from .transitions_engine import transition_glitch
-            result = _with_spinner("Applying glitch transition...", transition_glitch,
-                                   args.clip1, args.clip2, args.output,
-                                   duration=args.duration, intensity=args.intensity)
+
+            result = _with_spinner(
+                "Applying glitch transition...",
+                transition_glitch,
+                args.clip1,
+                args.clip2,
+                args.output,
+                duration=args.duration,
+                intensity=args.intensity,
+            )
             if use_json:
                 output_json({"success": True, "output_path": result})
             else:
-                console.print(Panel(f"[bold green]Glitch transition:[/bold green] {result}", border_style="green", title="Done"))
+                console.print(
+                    Panel(f"[bold green]Glitch transition:[/bold green] {result}", border_style="green", title="Done")
+                )
 
         elif args.command == "transition-morph":
             from .transitions_engine import transition_morph
-            result = _with_spinner("Applying morph transition...", transition_morph,
-                                   args.clip1, args.clip2, args.output,
-                                   duration=args.duration, mesh_size=args.mesh_size)
+
+            result = _with_spinner(
+                "Applying morph transition...",
+                transition_morph,
+                args.clip1,
+                args.clip2,
+                args.output,
+                duration=args.duration,
+                mesh_size=args.mesh_size,
+            )
             if use_json:
                 output_json({"success": True, "output_path": result})
             else:
-                console.print(Panel(f"[bold green]Morph transition:[/bold green] {result}", border_style="green", title="Done"))
+                console.print(
+                    Panel(f"[bold green]Morph transition:[/bold green] {result}", border_style="green", title="Done")
+                )
 
         elif args.command == "transition-pixelate":
             from .transitions_engine import transition_pixelate
-            result = _with_spinner("Applying pixelate transition...", transition_pixelate,
-                                   args.clip1, args.clip2, args.output,
-                                   duration=args.duration, pixel_size=args.pixel_size)
+
+            result = _with_spinner(
+                "Applying pixelate transition...",
+                transition_pixelate,
+                args.clip1,
+                args.clip2,
+                args.output,
+                duration=args.duration,
+                pixel_size=args.pixel_size,
+            )
             if use_json:
                 output_json({"success": True, "output_path": result})
             else:
-                console.print(Panel(f"[bold green]Pixelate transition:[/bold green] {result}", border_style="green", title="Done"))
+                console.print(
+                    Panel(f"[bold green]Pixelate transition:[/bold green] {result}", border_style="green", title="Done")
+                )
 
         # ------------------------------------------------------------------
         # AI commands
@@ -1596,8 +2151,15 @@ def main() -> None:
 
         elif args.command == "video-ai-transcribe":
             from .ai_engine import ai_transcribe
-            result = _with_spinner("Transcribing...", ai_transcribe, args.input,
-                                   output_srt=args.output, model=args.model, language=args.language)
+
+            result = _with_spinner(
+                "Transcribing...",
+                ai_transcribe,
+                args.input,
+                output_srt=args.output,
+                model=args.model,
+                language=args.language,
+            )
             if use_json:
                 output_json(result)
             else:
@@ -1611,17 +2173,32 @@ def main() -> None:
 
         elif args.command == "video-ai-upscale":
             from .ai_engine import ai_upscale
-            result = _with_spinner("Upscaling...", ai_upscale, args.input, args.output,
-                                   scale=args.scale, model=args.model)
+
+            result = _with_spinner(
+                "Upscaling...", ai_upscale, args.input, args.output, scale=args.scale, model=args.model
+            )
             if use_json:
                 output_json({"success": True, "output_path": result})
             else:
-                console.print(Panel(f"[bold green]Upscaled ({args.scale}x):[/bold green] {result}", border_style="green", title="Done"))
+                console.print(
+                    Panel(
+                        f"[bold green]Upscaled ({args.scale}x):[/bold green] {result}",
+                        border_style="green",
+                        title="Done",
+                    )
+                )
 
         elif args.command == "video-ai-stem-separation":
             from .ai_engine import ai_stem_separation
-            result = _with_spinner("Separating stems...", ai_stem_separation, args.input,
-                                   args.output_dir, stems=args.stems, model=args.model)
+
+            result = _with_spinner(
+                "Separating stems...",
+                ai_stem_separation,
+                args.input,
+                args.output_dir,
+                stems=args.stems,
+                model=args.model,
+            )
             if use_json:
                 output_json(result)
             else:
@@ -1636,8 +2213,10 @@ def main() -> None:
 
         elif args.command == "video-ai-scene-detect":
             from .ai_engine import ai_scene_detect
-            result = _with_spinner("Detecting scenes (AI)...", ai_scene_detect, args.input,
-                                   threshold=args.threshold, use_ai=args.use_ai)
+
+            result = _with_spinner(
+                "Detecting scenes (AI)...", ai_scene_detect, args.input, threshold=args.threshold, use_ai=args.use_ai
+            )
             if use_json:
                 output_json(result if isinstance(result, dict) else {"scenes": result})
             else:
@@ -1649,7 +2228,12 @@ def main() -> None:
                 table.add_column("Confidence")
                 for i, scene in enumerate(scenes, 1):
                     if isinstance(scene, dict):
-                        table.add_row(str(i), f"{scene.get('start', 0):.2f}s", f"{scene.get('end', 0):.2f}s", f"{scene.get('confidence', 0):.2f}")
+                        table.add_row(
+                            str(i),
+                            f"{scene.get('start', 0):.2f}s",
+                            f"{scene.get('end', 0):.2f}s",
+                            f"{scene.get('confidence', 0):.2f}",
+                        )
                     else:
                         table.add_row(str(i), str(scene))
                 console.print(table)
@@ -1657,23 +2241,39 @@ def main() -> None:
 
         elif args.command == "video-ai-color-grade":
             from .ai_engine import ai_color_grade
-            result = _with_spinner("Color grading...", ai_color_grade, args.input, args.output,
-                                   reference=args.reference, style=args.style)
+
+            result = _with_spinner(
+                "Color grading...", ai_color_grade, args.input, args.output, reference=args.reference, style=args.style
+            )
             if use_json:
                 output_json({"success": True, "output_path": result})
             else:
-                console.print(Panel(f"[bold green]Color graded ({args.style}):[/bold green] {result}", border_style="green", title="Done"))
+                console.print(
+                    Panel(
+                        f"[bold green]Color graded ({args.style}):[/bold green] {result}",
+                        border_style="green",
+                        title="Done",
+                    )
+                )
 
         elif args.command == "video-ai-remove-silence":
             from .ai_engine import ai_remove_silence
-            result = _with_spinner("Removing silence...", ai_remove_silence, args.input, args.output,
-                                   silence_threshold=args.silence_threshold,
-                                   min_silence_duration=args.min_silence_duration,
-                                   keep_margin=args.keep_margin)
+
+            result = _with_spinner(
+                "Removing silence...",
+                ai_remove_silence,
+                args.input,
+                args.output,
+                silence_threshold=args.silence_threshold,
+                min_silence_duration=args.min_silence_duration,
+                keep_margin=args.keep_margin,
+            )
             if use_json:
                 output_json({"success": True, "output_path": result})
             else:
-                console.print(Panel(f"[bold green]Silence removed:[/bold green] {result}", border_style="green", title="Done"))
+                console.print(
+                    Panel(f"[bold green]Silence removed:[/bold green] {result}", border_style="green", title="Done")
+                )
 
         # ------------------------------------------------------------------
         # Audio synthesis commands
@@ -1681,51 +2281,83 @@ def main() -> None:
 
         elif args.command == "audio-synthesize":
             from .audio_engine import audio_synthesize
+
             effects = _parse_json_arg(args.effects, "effects", json_mode=use_json) if args.effects else None
-            result = _with_spinner("Synthesizing audio...", audio_synthesize, args.output,
-                                   waveform=args.waveform, frequency=args.frequency,
-                                   duration=args.duration, volume=args.volume, effects=effects)
+            result = _with_spinner(
+                "Synthesizing audio...",
+                audio_synthesize,
+                args.output,
+                waveform=args.waveform,
+                frequency=args.frequency,
+                duration=args.duration,
+                volume=args.volume,
+                effects=effects,
+            )
             if use_json:
                 output_json({"success": True, "output_path": result})
             else:
-                console.print(Panel(f"[bold green]Audio synthesized:[/bold green] {result}", border_style="green", title="Done"))
+                console.print(
+                    Panel(f"[bold green]Audio synthesized:[/bold green] {result}", border_style="green", title="Done")
+                )
 
         elif args.command == "audio-compose":
             from .audio_engine import audio_compose
+
             tracks = _parse_json_arg(args.tracks, "tracks", json_mode=use_json)
             result = _with_spinner("Composing audio...", audio_compose, tracks, args.duration, args.output)
             if use_json:
                 output_json({"success": True, "output_path": result})
             else:
-                console.print(Panel(f"[bold green]Audio composed:[/bold green] {result}", border_style="green", title="Done"))
+                console.print(
+                    Panel(f"[bold green]Audio composed:[/bold green] {result}", border_style="green", title="Done")
+                )
 
         elif args.command == "audio-preset":
             from .audio_engine import audio_preset
-            result = _with_spinner(f"Generating preset '{args.preset}'...", audio_preset,
-                                   args.preset, args.output, pitch=args.pitch,
-                                   duration=args.duration, intensity=args.intensity)
+
+            result = _with_spinner(
+                f"Generating preset '{args.preset}'...",
+                audio_preset,
+                args.preset,
+                args.output,
+                pitch=args.pitch,
+                duration=args.duration,
+                intensity=args.intensity,
+            )
             if use_json:
                 output_json({"success": True, "output_path": result})
             else:
-                console.print(Panel(f"[bold green]Preset '{args.preset}':[/bold green] {result}", border_style="green", title="Done"))
+                console.print(
+                    Panel(
+                        f"[bold green]Preset '{args.preset}':[/bold green] {result}", border_style="green", title="Done"
+                    )
+                )
 
         elif args.command == "audio-sequence":
             from .audio_engine import audio_sequence
+
             sequence = _parse_json_arg(args.sequence, "sequence", json_mode=use_json)
             result = _with_spinner("Composing audio sequence...", audio_sequence, sequence, args.output)
             if use_json:
                 output_json({"success": True, "output_path": result})
             else:
-                console.print(Panel(f"[bold green]Audio sequence:[/bold green] {result}", border_style="green", title="Done"))
+                console.print(
+                    Panel(f"[bold green]Audio sequence:[/bold green] {result}", border_style="green", title="Done")
+                )
 
         elif args.command == "audio-effects":
             from .audio_engine import audio_effects
+
             effects = _parse_json_arg(args.effects, "effects", json_mode=use_json)
             result = _with_spinner("Applying audio effects...", audio_effects, args.input, args.output, effects)
             if use_json:
                 output_json({"success": True, "output_path": result})
             else:
-                console.print(Panel(f"[bold green]Audio effects applied:[/bold green] {result}", border_style="green", title="Done"))
+                console.print(
+                    Panel(
+                        f"[bold green]Audio effects applied:[/bold green] {result}", border_style="green", title="Done"
+                    )
+                )
 
         # ------------------------------------------------------------------
         # Motion graphics commands
@@ -1733,36 +2365,80 @@ def main() -> None:
 
         elif args.command == "video-text-animated":
             from .effects_engine import text_animated
-            result = _with_spinner("Adding animated text...", text_animated,
-                                   args.input, args.text, args.output,
-                                   animation=args.animation, font=args.font, size=args.size,
-                                   color=args.color, position=args.position,
-                                   start=args.start, duration=args.duration)
+
+            result = _with_spinner(
+                "Adding animated text...",
+                text_animated,
+                args.input,
+                args.text,
+                args.output,
+                animation=args.animation,
+                font=args.font,
+                size=args.size,
+                color=args.color,
+                position=args.position,
+                start=args.start,
+                duration=args.duration,
+            )
             if use_json:
                 output_json({"success": True, "output_path": result})
             else:
-                console.print(Panel(f"[bold green]Animated text ({args.animation}):[/bold green] {result}", border_style="green", title="Done"))
+                console.print(
+                    Panel(
+                        f"[bold green]Animated text ({args.animation}):[/bold green] {result}",
+                        border_style="green",
+                        title="Done",
+                    )
+                )
 
         elif args.command == "video-mograph-count":
             from .effects_engine import mograph_count
+
             style = _parse_json_arg(args.style, "style", json_mode=use_json) if args.style else None
-            result = _with_spinner("Generating counter...", mograph_count,
-                                   args.start, args.end, args.duration, args.output,
-                                   style=style, fps=args.fps)
+            result = _with_spinner(
+                "Generating counter...",
+                mograph_count,
+                args.start,
+                args.end,
+                args.duration,
+                args.output,
+                style=style,
+                fps=args.fps,
+            )
             if use_json:
                 output_json({"success": True, "output_path": result})
             else:
-                console.print(Panel(f"[bold green]Counter ({args.start}-{args.end}):[/bold green] {result}", border_style="green", title="Done"))
+                console.print(
+                    Panel(
+                        f"[bold green]Counter ({args.start}-{args.end}):[/bold green] {result}",
+                        border_style="green",
+                        title="Done",
+                    )
+                )
 
         elif args.command == "video-mograph-progress":
             from .effects_engine import mograph_progress
-            result = _with_spinner("Generating progress animation...", mograph_progress,
-                                   args.duration, args.output, style=args.style,
-                                   color=args.color, track_color=args.track_color, fps=args.fps)
+
+            result = _with_spinner(
+                "Generating progress animation...",
+                mograph_progress,
+                args.duration,
+                args.output,
+                style=args.style,
+                color=args.color,
+                track_color=args.track_color,
+                fps=args.fps,
+            )
             if use_json:
                 output_json({"success": True, "output_path": result})
             else:
-                console.print(Panel(f"[bold green]Progress bar ({args.style}):[/bold green] {result}", border_style="green", title="Done"))
+                console.print(
+                    Panel(
+                        f"[bold green]Progress bar ({args.style}):[/bold green] {result}",
+                        border_style="green",
+                        title="Done",
+                    )
+                )
 
         # ------------------------------------------------------------------
         # Layout commands
@@ -1770,26 +2446,53 @@ def main() -> None:
 
         elif args.command == "video-layout-grid":
             from .effects_engine import layout_grid
-            result = _with_spinner("Creating grid layout...", layout_grid,
-                                   args.inputs, args.layout, args.output,
-                                   gap=args.gap, padding=args.padding, background=args.background)
+
+            result = _with_spinner(
+                "Creating grid layout...",
+                layout_grid,
+                args.inputs,
+                args.layout,
+                args.output,
+                gap=args.gap,
+                padding=args.padding,
+                background=args.background,
+            )
             if use_json:
                 output_json({"success": True, "output_path": result})
             else:
-                console.print(Panel(f"[bold green]Grid layout ({args.layout}):[/bold green] {result}", border_style="green", title="Done"))
+                console.print(
+                    Panel(
+                        f"[bold green]Grid layout ({args.layout}):[/bold green] {result}",
+                        border_style="green",
+                        title="Done",
+                    )
+                )
 
         elif args.command == "video-layout-pip":
             from .effects_engine import layout_pip
-            result = _with_spinner("Creating PIP layout...", layout_pip,
-                                   args.main, args.pip, args.output,
-                                   position=args.position, size=args.size,
-                                   margin=args.margin, border=args.border,
-                                   border_color=args.border_color, border_width=args.border_width,
-                                   rounded_corners=args.rounded_corners)
+
+            result = _with_spinner(
+                "Creating PIP layout...",
+                layout_pip,
+                args.main,
+                args.pip,
+                args.output,
+                position=args.position,
+                size=args.size,
+                margin=args.margin,
+                border=args.border,
+                border_color=args.border_color,
+                border_width=args.border_width,
+                rounded_corners=args.rounded_corners,
+            )
             if use_json:
                 output_json({"success": True, "output_path": result})
             else:
-                console.print(Panel(f"[bold green]PIP ({args.position}):[/bold green] {result}", border_style="green", title="Done"))
+                console.print(
+                    Panel(
+                        f"[bold green]PIP ({args.position}):[/bold green] {result}", border_style="green", title="Done"
+                    )
+                )
 
         # ------------------------------------------------------------------
         # Audio-Video commands
@@ -1797,23 +2500,42 @@ def main() -> None:
 
         elif args.command == "video-add-generated-audio":
             from .audio_engine import add_generated_audio
+
             audio_config = _parse_json_arg(args.audio_config, "audio-config", json_mode=use_json)
-            result = _with_spinner("Adding generated audio...", add_generated_audio,
-                                   args.input, audio_config, args.output)
+            result = _with_spinner(
+                "Adding generated audio...", add_generated_audio, args.input, audio_config, args.output
+            )
             if use_json:
                 output_json({"success": True, "output_path": result})
             else:
-                console.print(Panel(f"[bold green]Generated audio added:[/bold green] {result}", border_style="green", title="Done"))
+                console.print(
+                    Panel(
+                        f"[bold green]Generated audio added:[/bold green] {result}", border_style="green", title="Done"
+                    )
+                )
 
         elif args.command == "video-audio-spatial":
             from .ai_engine import audio_spatial
+
             positions = _parse_json_arg(args.positions, "positions", json_mode=use_json)
-            result = _with_spinner("Applying spatial audio...", audio_spatial,
-                                   args.input, args.output, positions=positions, method=args.method)
+            result = _with_spinner(
+                "Applying spatial audio...",
+                audio_spatial,
+                args.input,
+                args.output,
+                positions=positions,
+                method=args.method,
+            )
             if use_json:
                 output_json({"success": True, "output_path": result})
             else:
-                console.print(Panel(f"[bold green]Spatial audio ({args.method}):[/bold green] {result}", border_style="green", title="Done"))
+                console.print(
+                    Panel(
+                        f"[bold green]Spatial audio ({args.method}):[/bold green] {result}",
+                        border_style="green",
+                        title="Done",
+                    )
+                )
 
         # ------------------------------------------------------------------
         # Quality / Info commands
@@ -1821,9 +2543,20 @@ def main() -> None:
 
         elif args.command == "video-auto-chapters":
             from .effects_engine import auto_chapters
+
             result = _with_spinner("Detecting chapters...", auto_chapters, args.input, threshold=args.threshold)
             if use_json:
-                output_json({"chapters": [{"timestamp": (c[0] if isinstance(c, (list, tuple)) else c.get("timestamp", "")), "description": (c[1] if isinstance(c, (list, tuple)) else c.get("description", ""))} for c in result]})
+                output_json(
+                    {
+                        "chapters": [
+                            {
+                                "timestamp": (c[0] if isinstance(c, (list, tuple)) else c.get("timestamp", "")),
+                                "description": (c[1] if isinstance(c, (list, tuple)) else c.get("description", "")),
+                            }
+                            for c in result
+                        ]
+                    }
+                )
             else:
                 table = Table(title="Auto Chapters")
                 table.add_column("#", style="bold", justify="right")
@@ -1841,7 +2574,10 @@ def main() -> None:
 
         elif args.command == "video-extract-frame":
             from .engine import thumbnail
-            result = _with_spinner("Extracting frame...", thumbnail, args.input, timestamp=args.timestamp, output_path=args.output)
+
+            result = _with_spinner(
+                "Extracting frame...", thumbnail, args.input, timestamp=args.timestamp, output_path=args.output
+            )
             if use_json:
                 output_json(result)
             else:
@@ -1849,6 +2585,7 @@ def main() -> None:
 
         elif args.command == "video-info-detailed":
             from .effects_engine import video_info_detailed
+
             result = _with_spinner("Getting detailed info...", video_info_detailed, args.input)
             if use_json:
                 output_json(result)
@@ -1868,7 +2605,10 @@ def main() -> None:
 
         elif args.command == "video-quality-check":
             from .quality_guardrails import quality_check
-            result = _with_spinner("Running quality check...", quality_check, args.input, fail_on_warning=args.fail_on_warning)
+
+            result = _with_spinner(
+                "Running quality check...", quality_check, args.input, fail_on_warning=args.fail_on_warning
+            )
             if use_json:
                 output_json(result)
             else:
@@ -1888,8 +2628,14 @@ def main() -> None:
 
         elif args.command == "video-design-quality-check":
             from .design_quality import design_quality_check
-            result = _with_spinner("Running design quality check...", design_quality_check,
-                                   args.input, auto_fix=args.auto_fix, strict=args.strict)
+
+            result = _with_spinner(
+                "Running design quality check...",
+                design_quality_check,
+                args.input,
+                auto_fix=args.auto_fix,
+                strict=args.strict,
+            )
             if use_json:
                 output_json(result.model_dump() if hasattr(result, "model_dump") else result)
             else:
@@ -1910,11 +2656,14 @@ def main() -> None:
 
         elif args.command == "video-fix-design-issues":
             from .design_quality import fix_design_issues
+
             result = _with_spinner("Fixing design issues...", fix_design_issues, args.input, args.output)
             if use_json:
                 output_json({"success": True, "output_path": result})
             else:
-                console.print(Panel(f"[bold green]Design fixed:[/bold green] {result}", border_style="green", title="Done"))
+                console.print(
+                    Panel(f"[bold green]Design fixed:[/bold green] {result}", border_style="green", title="Done")
+                )
 
         # ------------------------------------------------------------------
         # Image analysis commands
@@ -1922,6 +2671,7 @@ def main() -> None:
 
         elif args.command == "image-extract-colors":
             from .image_engine import extract_colors
+
             result = _with_spinner("Extracting colors...", extract_colors, args.input, n_colors=args.n_colors)
             if use_json:
                 output_json(result.model_dump() if hasattr(result, "model_dump") else result)
@@ -1945,8 +2695,10 @@ def main() -> None:
 
         elif args.command == "image-generate-palette":
             from .image_engine import generate_palette
-            result = _with_spinner("Generating palette...", generate_palette, args.input,
-                                   harmony=args.harmony, n_colors=args.n_colors)
+
+            result = _with_spinner(
+                "Generating palette...", generate_palette, args.input, harmony=args.harmony, n_colors=args.n_colors
+            )
             if use_json:
                 output_json(result.model_dump() if hasattr(result, "model_dump") else result)
             else:
@@ -1963,8 +2715,10 @@ def main() -> None:
 
         elif args.command == "image-analyze-product":
             from .image_engine import analyze_product
-            result = _with_spinner("Analyzing product...", analyze_product, args.input,
-                                   use_ai=args.use_ai, n_colors=args.n_colors)
+
+            result = _with_spinner(
+                "Analyzing product...", analyze_product, args.input, use_ai=args.use_ai, n_colors=args.n_colors
+            )
             if use_json:
                 output_json(result.model_dump() if hasattr(result, "model_dump") else result)
             else:
@@ -1974,7 +2728,9 @@ def main() -> None:
                 if colors:
                     lines.append("[bold green]Colors:[/bold green]")
                     for c in colors[:5]:
-                        lines.append(f"  {c.get('hex', '')} ({c.get('css_name', '')}) - {c.get('coverage_pct', 0):.1f}%")
+                        lines.append(
+                            f"  {c.get('hex', '')} ({c.get('css_name', '')}) - {c.get('coverage_pct', 0):.1f}%"
+                        )
                 desc = data.get("description")
                 if desc:
                     lines.append(f"\n[bold green]AI Description:[/bold green] {desc}")
@@ -1983,6 +2739,7 @@ def main() -> None:
     except Exception as e:
         if use_json:
             from .errors import MCPVideoError
+
             if isinstance(e, MCPVideoError):
                 try:
                     err_data = e.to_dict()
@@ -1990,7 +2747,10 @@ def main() -> None:
                     err_data = {"type": "internal_error", "code": "to_dict_failed", "message": str(e)}
                 print(json.dumps({"success": False, "error": err_data}, indent=2), file=sys.stderr)
             else:
-                print(json.dumps({"success": False, "error": {"type": "unknown", "message": str(e)}}, indent=2), file=sys.stderr)
+                print(
+                    json.dumps({"success": False, "error": {"type": "unknown", "message": str(e)}}, indent=2),
+                    file=sys.stderr,
+                )
         else:
             _format_error(e)
         sys.exit(1)

--- a/mcp_video/ai_engine.py
+++ b/mcp_video/ai_engine.py
@@ -47,9 +47,7 @@ def ai_transcribe(
     try:
         import whisper
     except ImportError:
-        raise RuntimeError(
-            "Whisper not installed. Install with: pip install openai-whisper"
-        ) from None
+        raise RuntimeError("Whisper not installed. Install with: pip install openai-whisper") from None
 
     # Validate input file
     video_path = Path(video)
@@ -63,12 +61,17 @@ def ai_transcribe(
     try:
         # Extract audio using ffmpeg: 16kHz mono 16-bit PCM (Whisper optimal format)
         cmd = [
-            "ffmpeg", "-y",
-            "-i", str(video_path),
+            "ffmpeg",
+            "-y",
+            "-i",
+            str(video_path),
             "-vn",  # No video
-            "-acodec", "pcm_s16le",  # 16-bit PCM
-            "-ar", "16000",  # 16kHz (Whisper expects this)
-            "-ac", "1",  # Mono
+            "-acodec",
+            "pcm_s16le",  # 16-bit PCM
+            "-ar",
+            "16000",  # 16kHz (Whisper expects this)
+            "-ac",
+            "1",  # Mono
             audio_path,
         ]
         try:
@@ -130,9 +133,7 @@ def _format_srt(segments: list[dict[str, Any]]) -> str:
 
         # Format: index, time range, text, blank line
         srt_lines.append(str(index))
-        srt_lines.append(
-            f"{_seconds_to_srt_time(start_time)} --> {_seconds_to_srt_time(end_time)}"
-        )
+        srt_lines.append(f"{_seconds_to_srt_time(start_time)} --> {_seconds_to_srt_time(end_time)}")
         srt_lines.append(text)
         srt_lines.append("")  # Blank line between entries
         index += 1
@@ -152,10 +153,15 @@ def _seconds_to_srt_time(seconds: float) -> str:
 def _run_ffprobe(video: str) -> dict[str, Any]:
     """Get video info using ffprobe."""
     cmd = [
-        "ffprobe", "-v", "error",
-        "-show_entries", "format=duration",
-        "-show_entries", "stream=codec_type",
-        "-of", "json",
+        "ffprobe",
+        "-v",
+        "error",
+        "-show_entries",
+        "format=duration",
+        "-show_entries",
+        "stream=codec_type",
+        "-of",
+        "json",
         video,
     ]
     try:
@@ -176,11 +182,7 @@ def _standard_scene_detect(video: str, threshold: float) -> list[dict]:
         raise FileNotFoundError(f"Video file not found: {video}")
     if not isinstance(threshold, (int, float)) or not (0.0 <= threshold <= 1.0):
         raise ValueError(f"threshold must be between 0.0 and 1.0, got {threshold}")
-    cmd = [
-        "ffmpeg", "-i", video,
-        "-filter:v", f"select='gt(scene,{threshold})',showinfo",
-        "-f", "null", "-"
-    ]
+    cmd = ["ffmpeg", "-i", video, "-filter:v", f"select='gt(scene,{threshold})',showinfo", "-f", "null", "-"]
     try:
         result = subprocess.run(cmd, capture_output=True, text=True, timeout=600)
     except subprocess.TimeoutExpired:
@@ -192,10 +194,12 @@ def _standard_scene_detect(video: str, threshold: float) -> list[dict]:
             # Extract timestamp
             match = re.search(r"pts_time:([\d.]+)", line)
             if match:
-                scenes.append({
-                    "timestamp": float(match.group(1)),
-                    "frame": None  # Could extract from output
-                })
+                scenes.append(
+                    {
+                        "timestamp": float(match.group(1)),
+                        "frame": None,  # Could extract from output
+                    }
+                )
 
     return scenes
 
@@ -357,16 +361,26 @@ def _apply_simple_spatial(
             )
 
             cmd = [
-                "ffmpeg", "-y",
-                "-ss", str(time_start),
-                "-t", str(segment_duration),
-                "-i", video,
-                "-filter_complex", filter_complex,
-                "-map", "0:v",  # Copy video stream
-                "-map", "[aout]",  # Use processed audio
-                "-c:v", "copy",  # Copy video without re-encoding
-                "-c:a", "aac",  # Re-encode audio
-                "-b:a", "192k",
+                "ffmpeg",
+                "-y",
+                "-ss",
+                str(time_start),
+                "-t",
+                str(segment_duration),
+                "-i",
+                video,
+                "-filter_complex",
+                filter_complex,
+                "-map",
+                "0:v",  # Copy video stream
+                "-map",
+                "[aout]",  # Use processed audio
+                "-c:v",
+                "copy",  # Copy video without re-encoding
+                "-c:a",
+                "aac",  # Re-encode audio
+                "-b:a",
+                "192k",
                 str(segment_file),
             ]
 
@@ -397,11 +411,16 @@ def _apply_simple_spatial(
                     f.write(f"file '{escaped_path}'\n")
 
             cmd = [
-                "ffmpeg", "-y",
-                "-f", "concat",
-                "-safe", "0",
-                "-i", str(concat_list),
-                "-c", "copy",
+                "ffmpeg",
+                "-y",
+                "-f",
+                "concat",
+                "-safe",
+                "0",
+                "-i",
+                str(concat_list),
+                "-c",
+                "copy",
                 output,
             ]
 
@@ -418,9 +437,13 @@ def _apply_simple_spatial(
 def _get_video_duration(video_path: str) -> float | None:
     """Get video duration in seconds using ffprobe."""
     cmd = [
-        "ffprobe", "-v", "error",
-        "-show_entries", "format=duration",
-        "-of", "default=noprint_wrappers=1:nokey=1",
+        "ffprobe",
+        "-v",
+        "error",
+        "-show_entries",
+        "format=duration",
+        "-of",
+        "default=noprint_wrappers=1:nokey=1",
         video_path,
     ]
     try:
@@ -477,11 +500,15 @@ def ai_scene_detect(
         # Extract frames at regular intervals
         frame_pattern = Path(tmpdir) / "frame_%04d.jpg"
         cmd = [
-            "ffmpeg", "-y",
-            "-i", video,
-            "-vf", f"fps=1/{frame_interval},scale=320:-1",
-            "-q:v", "2",
-            str(frame_pattern).replace("%04d", "%04d")
+            "ffmpeg",
+            "-y",
+            "-i",
+            video,
+            "-vf",
+            f"fps=1/{frame_interval},scale=320:-1",
+            "-q:v",
+            "2",
+            str(frame_pattern).replace("%04d", "%04d"),
         ]
         try:
             result = subprocess.run(cmd, capture_output=True, text=True, timeout=600)
@@ -506,11 +533,7 @@ def ai_scene_detect(
                 # frame_0001.jpg corresponds to 0.0s, frame_0002.jpg to 0.5s, etc.
                 frame_num = int(frame_path.stem.split("_")[1])
                 timestamp = (frame_num - 1) * frame_interval
-                hashes.append({
-                    "timestamp": timestamp,
-                    "hash": phash,
-                    "path": frame_path
-                })
+                hashes.append({"timestamp": timestamp, "hash": phash, "path": frame_path})
             except Exception:
                 continue
 
@@ -526,11 +549,7 @@ def ai_scene_detect(
             hash_diff = prev_hash - curr_hash
 
             if hash_diff > hash_threshold:
-                scenes.append({
-                    "timestamp": hashes[i]["timestamp"],
-                    "frame": None,
-                    "hash_diff": hash_diff
-                })
+                scenes.append({"timestamp": hashes[i]["timestamp"], "frame": None, "hash_diff": hash_diff})
 
     return scenes
 
@@ -552,9 +571,14 @@ def _detect_silence_regions(
     """
     # Run silencedetect filter
     cmd = [
-        "ffmpeg", "-i", video,
-        "-af", f"silencedetect=noise={silence_threshold}dB:d={min_silence_duration}",
-        "-f", "null", "-",
+        "ffmpeg",
+        "-i",
+        video,
+        "-af",
+        f"silencedetect=noise={silence_threshold}dB:d={min_silence_duration}",
+        "-f",
+        "null",
+        "-",
     ]
 
     try:
@@ -643,11 +667,16 @@ def _concat_segments(
         start, end = segments[0]
         duration = end - start
         cmd = [
-            "ffmpeg", "-y",
-            "-i", video,
-            "-ss", str(start),
-            "-t", str(duration),
-            "-c", "copy",
+            "ffmpeg",
+            "-y",
+            "-i",
+            video,
+            "-ss",
+            str(start),
+            "-t",
+            str(duration),
+            "-c",
+            "copy",
             output,
         ]
         try:
@@ -667,11 +696,16 @@ def _concat_segments(
             duration = end - start
 
             cmd = [
-                "ffmpeg", "-y",
-                "-i", video,
-                "-ss", str(start),
-                "-t", str(duration),
-                "-c", "copy",
+                "ffmpeg",
+                "-y",
+                "-i",
+                video,
+                "-ss",
+                str(start),
+                "-t",
+                str(duration),
+                "-c",
+                "copy",
                 str(segment_file),
             ]
             try:
@@ -693,11 +727,16 @@ def _concat_segments(
 
         # Concatenate using concat demuxer
         cmd = [
-            "ffmpeg", "-y",
-            "-f", "concat",
-            "-safe", "0",
-            "-i", str(concat_list),
-            "-c", "copy",
+            "ffmpeg",
+            "-y",
+            "-f",
+            "concat",
+            "-safe",
+            "0",
+            "-i",
+            str(concat_list),
+            "-c",
+            "copy",
             output,
         ]
         try:
@@ -798,9 +837,7 @@ def ai_stem_separation(
     try:
         import demucs.separate
     except ImportError:
-        raise RuntimeError(
-            "Demucs not installed. Install with: pip install demucs"
-        ) from None
+        raise RuntimeError("Demucs not installed. Install with: pip install demucs") from None
 
     # Validate input file
     video_path = Path(video)
@@ -821,12 +858,17 @@ def ai_stem_separation(
     try:
         # Extract audio using ffmpeg: 16-bit PCM stereo (Demucs works best with stereo)
         cmd = [
-            "ffmpeg", "-y",
-            "-i", str(video_path),
+            "ffmpeg",
+            "-y",
+            "-i",
+            str(video_path),
             "-vn",  # No video
-            "-acodec", "pcm_s16le",  # 16-bit PCM
-            "-ar", "44100",  # 44.1kHz (CD quality)
-            "-ac", "2",  # Stereo (Demucs expects stereo)
+            "-acodec",
+            "pcm_s16le",  # 16-bit PCM
+            "-ar",
+            "44100",  # 44.1kHz (CD quality)
+            "-ac",
+            "2",  # Stereo (Demucs expects stereo)
             audio_path,
         ]
         try:
@@ -842,8 +884,10 @@ def ai_stem_separation(
 
         # Build demucs command arguments
         demucs_args = [
-            "--out", str(output_path),
-            "--name", model,
+            "--out",
+            str(output_path),
+            "--name",
+            model,
             audio_path,
         ]
 
@@ -866,7 +910,6 @@ def ai_stem_separation(
     finally:
         # Clean up temp audio file
         Path(audio_path).unlink(missing_ok=True)
-
 
 
 def ai_color_grade(
@@ -943,11 +986,16 @@ def ai_color_grade(
 
     # Build FFmpeg command
     cmd = [
-        "ffmpeg", "-y",
-        "-i", str(video_path),
-        "-vf", filter_string,
-        "-c:a", "copy",  # Copy audio without re-encoding
-        "-pix_fmt", "yuv420p",  # Ensure compatibility
+        "ffmpeg",
+        "-y",
+        "-i",
+        str(video_path),
+        "-vf",
+        filter_string,
+        "-c:a",
+        "copy",  # Copy audio without re-encoding
+        "-pix_fmt",
+        "yuv420p",  # Ensure compatibility
         output,
     ]
 
@@ -976,13 +1024,10 @@ def _match_reference_colors(video: str, reference: str) -> dict:
     Returns:
         Dict with color adjustment parameters
     """
+
     def extract_mean_color(video_path: str) -> dict:
         """Extract mean RGB values from video using signalstats filter."""
-        cmd = [
-            "ffmpeg", "-i", video_path,
-            "-vf", "signalstats=out=JSON:stat=tout+vrep+brng",
-            "-f", "null", "-"
-        ]
+        cmd = ["ffmpeg", "-i", video_path, "-vf", "signalstats=out=JSON:stat=tout+vrep+brng", "-f", "null", "-"]
         try:
             result = subprocess.run(cmd, capture_output=True, text=True, timeout=600)
         except subprocess.TimeoutExpired:
@@ -997,9 +1042,9 @@ def _match_reference_colors(video: str, reference: str) -> dict:
 
         # Try to extract mean Y/U/V or R/G/B values
         # This is a simplified extraction - signalstats outputs in YUV by default
-        y_match = re.search(r'YAVG ([\d.]+)', stderr)
-        u_match = re.search(r'UAVG ([\d.]+)', stderr)
-        v_match = re.search(r'VAVG ([\d.]+)', stderr)
+        y_match = re.search(r"YAVG ([\d.]+)", stderr)
+        u_match = re.search(r"UAVG ([\d.]+)", stderr)
+        v_match = re.search(r"VAVG ([\d.]+)", stderr)
 
         if y_match and u_match and v_match:
             # Convert YUV to approximate RGB (simplified)
@@ -1115,6 +1160,7 @@ def _ai_upscale_opencv(video_path: str, output_path: str, scale: int) -> str:
 
     if not model_path.exists():
         import urllib.request
+
         url = model_urls[scale]
         print(f"Downloading FSRCNN x{scale} model...")
         urllib.request.urlretrieve(url, model_path)
@@ -1150,12 +1196,7 @@ def _ai_upscale_opencv(video_path: str, output_path: str, scale: int) -> str:
 
         # Extract frames
         frame_pattern = frames_dir / "frame_%04d.png"
-        cmd = [
-            "ffmpeg", "-y",
-            "-i", str(video_file),
-            "-vsync", "0",
-            str(frame_pattern)
-        ]
+        cmd = ["ffmpeg", "-y", "-i", str(video_file), "-vsync", "0", str(frame_pattern)]
         try:
             result = subprocess.run(cmd, capture_output=True, text=True, timeout=600)
         except subprocess.TimeoutExpired:
@@ -1184,21 +1225,19 @@ def _ai_upscale_opencv(video_path: str, output_path: str, scale: int) -> str:
         # Reconstruct video
         upscaled_pattern = upscaled_dir / "frame_%04d.png"
         cmd = [
-            "ffmpeg", "-y",
-            "-framerate", str(fps),
-            "-i", str(upscaled_pattern),
+            "ffmpeg",
+            "-y",
+            "-framerate",
+            str(fps),
+            "-i",
+            str(upscaled_pattern),
         ]
 
         if has_audio:
             # Copy audio from original
             cmd.extend(["-i", str(video_file), "-c:a", "copy", "-shortest"])
 
-        cmd.extend([
-            "-c:v", "libx264",
-            "-pix_fmt", "yuv420p",
-            "-crf", "18",
-            str(output_file)
-        ])
+        cmd.extend(["-c:v", "libx264", "-pix_fmt", "yuv420p", "-crf", "18", str(output_file)])
 
         try:
             result = subprocess.run(cmd, capture_output=True, text=True, timeout=600)
@@ -1243,6 +1282,7 @@ def ai_upscale(
     try:
         from realesrgan import RealESRGANer
         from basicsr.archs.rrdbnet_arch import RRDBNet
+
         has_realesrgan = True
     except ImportError:
         has_realesrgan = False
@@ -1292,12 +1332,7 @@ def ai_upscale(
 
         # Step 2: Extract frames from video
         frame_pattern = frames_dir / "frame_%04d.png"
-        cmd = [
-            "ffmpeg", "-y",
-            "-i", str(video_path),
-            "-vsync", "0",
-            str(frame_pattern)
-        ]
+        cmd = ["ffmpeg", "-y", "-i", str(video_path), "-vsync", "0", str(frame_pattern)]
         try:
             result = subprocess.run(cmd, capture_output=True, text=True, timeout=600)
         except subprocess.TimeoutExpired:
@@ -1318,7 +1353,7 @@ def ai_upscale(
             num_feat=config["num_feat"],
             num_block=config["num_block"],
             num_grow_ch=32,
-            scale=scale
+            scale=scale,
         )
 
         # Determine model URL/path based on model and scale
@@ -1330,7 +1365,7 @@ def ai_upscale(
             tile=0,  # No tiling - process whole image
             tile_pad=10,
             pre_pad=0,
-            half=False  # Use FP32
+            half=False,  # Use FP32
         )
 
         # Step 4: Upscale each frame
@@ -1355,11 +1390,14 @@ def ai_upscale(
         if has_audio:
             audio_path = tmpdir_path / "audio.aac"
             cmd = [
-                "ffmpeg", "-y",
-                "-i", str(video_path),
+                "ffmpeg",
+                "-y",
+                "-i",
+                str(video_path),
                 "-vn",  # No video
-                "-c:a", "copy",
-                str(audio_path)
+                "-c:a",
+                "copy",
+                str(audio_path),
             ]
             try:
                 result = subprocess.run(cmd, capture_output=True, text=True, timeout=600)
@@ -1377,25 +1415,37 @@ def ai_upscale(
         if audio_path and audio_path.exists():
             # Reconstruct with audio
             cmd = [
-                "ffmpeg", "-y",
-                "-framerate", str(fps),
-                "-i", str(upscaled_pattern),
-                "-i", str(audio_path),
-                "-c:v", "libx264",
-                "-pix_fmt", "yuv420p",
-                "-c:a", "copy",
+                "ffmpeg",
+                "-y",
+                "-framerate",
+                str(fps),
+                "-i",
+                str(upscaled_pattern),
+                "-i",
+                str(audio_path),
+                "-c:v",
+                "libx264",
+                "-pix_fmt",
+                "yuv420p",
+                "-c:a",
+                "copy",
                 "-shortest",
-                str(output_path)
+                str(output_path),
             ]
         else:
             # Reconstruct without audio
             cmd = [
-                "ffmpeg", "-y",
-                "-framerate", str(fps),
-                "-i", str(upscaled_pattern),
-                "-c:v", "libx264",
-                "-pix_fmt", "yuv420p",
-                str(output_path)
+                "ffmpeg",
+                "-y",
+                "-framerate",
+                str(fps),
+                "-i",
+                str(upscaled_pattern),
+                "-c:v",
+                "libx264",
+                "-pix_fmt",
+                "yuv420p",
+                str(output_path),
             ]
 
         try:
@@ -1411,11 +1461,16 @@ def ai_upscale(
 def _get_video_fps(video_path: str) -> float | None:
     """Get video frame rate using ffprobe."""
     cmd = [
-        "ffprobe", "-v", "error",
-        "-select_streams", "v:0",
-        "-show_entries", "stream=r_frame_rate",
-        "-of", "default=noprint_wrappers=1:nokey=1",
-        video_path
+        "ffprobe",
+        "-v",
+        "error",
+        "-select_streams",
+        "v:0",
+        "-show_entries",
+        "stream=r_frame_rate",
+        "-of",
+        "default=noprint_wrappers=1:nokey=1",
+        video_path,
     ]
     try:
         result = subprocess.run(cmd, capture_output=True, text=True, timeout=600)
@@ -1442,11 +1497,16 @@ def _get_video_fps(video_path: str) -> float | None:
 def _has_audio_stream(video_path: str) -> bool:
     """Check if video has an audio stream."""
     cmd = [
-        "ffprobe", "-v", "error",
-        "-select_streams", "a",
-        "-show_entries", "stream=codec_type",
-        "-of", "default=noprint_wrappers=1:nokey=1",
-        video_path
+        "ffprobe",
+        "-v",
+        "error",
+        "-select_streams",
+        "a",
+        "-show_entries",
+        "stream=codec_type",
+        "-of",
+        "default=noprint_wrappers=1:nokey=1",
+        video_path,
     ]
     try:
         result = subprocess.run(cmd, capture_output=True, text=True, timeout=600)

--- a/mcp_video/audio_engine.py
+++ b/mcp_video/audio_engine.py
@@ -250,15 +250,15 @@ def _float_to_pcm(samples: list[float]) -> bytes:
         # Clamp to [-1, 1]
         sample = max(-1, min(1, sample))
         # Convert to 16-bit signed int
-        pcm_data.append(struct.pack('<h', int(sample * 32767)))
-    return b''.join(pcm_data)
+        pcm_data.append(struct.pack("<h", int(sample * 32767)))
+    return b"".join(pcm_data)
 
 
 def _pcm_to_float(pcm_bytes: bytes) -> list[float]:
     """Convert 16-bit PCM bytes to float samples."""
     samples = []
     for i in range(0, len(pcm_bytes), 2):
-        value = struct.unpack('<h', pcm_bytes[i:i+2])[0]
+        value = struct.unpack("<h", pcm_bytes[i : i + 2])[0]
         samples.append(value / 32767)
     return samples
 
@@ -270,7 +270,7 @@ def write_wav(
     channels: int = DEFAULT_CHANNELS,
 ) -> str:
     """Write PCM data to a WAV file."""
-    with wave.open(output_path, 'wb') as wav_file:
+    with wave.open(output_path, "wb") as wav_file:
         wav_file.setnchannels(channels)
         wav_file.setsampwidth(DEFAULT_SAMPLE_WIDTH)
         wav_file.setframerate(sample_rate)
@@ -530,7 +530,11 @@ def audio_preset(
             "frequency": 200,
             "duration": duration or 0.5,
             "volume": 0.25,
-            "effects": {"fade_in": 0.1, "fade_out": 0.2, "reverb": {"room_size": 0.3, "damping": 0.5, "wet_level": 0.2}},
+            "effects": {
+                "fade_in": 0.1,
+                "fade_out": 0.2,
+                "reverb": {"room_size": 0.3, "damping": 0.5, "wet_level": 0.2},
+            },
         },
         "upload": {
             "waveform": "sine",
@@ -635,7 +639,7 @@ def audio_sequence(
                     intensity=event.get("intensity", 0.5),
                 )
 
-                with wave.open(tmp_path, 'rb') as wav_file:
+                with wave.open(tmp_path, "rb") as wav_file:
                     frames = wav_file.readframes(wav_file.getnframes())
                     samples = _pcm_to_float(frames)
             finally:
@@ -701,7 +705,7 @@ def audio_compose(
             continue
 
         # Read WAV file
-        with wave.open(file_path, 'rb') as wav_file:
+        with wave.open(file_path, "rb") as wav_file:
             frames = wav_file.readframes(wav_file.getnframes())
             track_samples = _pcm_to_float(frames)
 
@@ -747,7 +751,7 @@ def audio_effects(
         Path to processed WAV file
     """
     # Read input
-    with wave.open(input_path, 'rb') as wav_file:
+    with wave.open(input_path, "rb") as wav_file:
         sample_rate = wav_file.getframerate()
         frames = wav_file.readframes(wav_file.getnframes())
         samples = _pcm_to_float(frames)
@@ -816,14 +820,17 @@ def add_generated_audio(
     # Add drone if specified
     drone_config = audio_config.get("drone")
     if drone_config:
-        events.insert(0, {
-            "type": "tone",
-            "at": 0,
-            "duration": 60,  # Will be truncated to video length
-            "freq": drone_config.get("frequency", 100),
-            "volume": drone_config.get("volume", 0.2),
-            "waveform": "sine",
-        })
+        events.insert(
+            0,
+            {
+                "type": "tone",
+                "at": 0,
+                "duration": 60,  # Will be truncated to video length
+                "freq": drone_config.get("frequency", 100),
+                "volume": drone_config.get("volume", 0.2),
+                "waveform": "sine",
+            },
+        )
 
     if not events:
         raise ValueError("No audio events specified")
@@ -841,11 +848,16 @@ def add_generated_audio(
         if out_dir:
             os.makedirs(out_dir, exist_ok=True)
         cmd = [
-            "ffmpeg", "-y",
-            "-i", video,
-            "-i", audio_path,
-            "-c:v", "copy",
-            "-c:a", "aac",
+            "ffmpeg",
+            "-y",
+            "-i",
+            video,
+            "-i",
+            audio_path,
+            "-c:v",
+            "copy",
+            "-c:a",
+            "aac",
             "-shortest",
             output,
         ]

--- a/mcp_video/client.py
+++ b/mcp_video/client.py
@@ -121,10 +121,18 @@ class Client:
     ) -> EditResult:
         """Overlay text on a video."""
         return _add_text(
-            video, text=text, position=position, font=font,
-            size=size, color=color, shadow=shadow,
-            start_time=start_time, duration=duration,
-            output_path=output, crf=crf, preset=preset,
+            video,
+            text=text,
+            position=position,
+            font=font,
+            size=size,
+            color=color,
+            shadow=shadow,
+            start_time=start_time,
+            duration=duration,
+            output_path=output,
+            crf=crf,
+            preset=preset,
         )
 
     def add_audio(
@@ -140,9 +148,14 @@ class Client:
     ) -> EditResult:
         """Add or replace audio track."""
         return _add_audio(
-            video, audio_path=audio, volume=volume,
-            fade_in=fade_in, fade_out=fade_out, mix=mix,
-            start_time=start_time, output_path=output,
+            video,
+            audio_path=audio,
+            volume=volume,
+            fade_in=fade_in,
+            fade_out=fade_out,
+            mix=mix,
+            start_time=start_time,
+            output_path=output,
         )
 
     def resize(
@@ -156,8 +169,11 @@ class Client:
     ) -> EditResult:
         """Resize a video or change aspect ratio."""
         return _resize(
-            video, width=width, height=height,
-            aspect_ratio=aspect_ratio, quality=quality,
+            video,
+            width=width,
+            height=height,
+            aspect_ratio=aspect_ratio,
+            quality=quality,
             output_path=output,
         )
 
@@ -190,7 +206,9 @@ class Client:
             raise ValueError(f"format must be one of {sorted(self._VALID_FORMATS)}, got {format}")
         if quality not in self._VALID_QUALITIES:
             raise ValueError(f"quality must be one of {sorted(self._VALID_QUALITIES)}, got {quality}")
-        return _convert(video, format=format, quality=quality, output_path=output, two_pass=two_pass, target_bitrate=target_bitrate)
+        return _convert(
+            video, format=format, quality=quality, output_path=output, two_pass=two_pass, target_bitrate=target_bitrate
+        )
 
     def speed(
         self,
@@ -259,9 +277,14 @@ class Client:
     ) -> EditResult:
         """Add image watermark."""
         return _watermark(
-            video, image_path=image, position=position,
-            opacity=opacity, margin=margin, output_path=output,
-            crf=crf, preset=preset,
+            video,
+            image_path=image,
+            position=position,
+            opacity=opacity,
+            margin=margin,
+            output_path=output,
+            crf=crf,
+            preset=preset,
         )
 
     def crop(
@@ -285,7 +308,9 @@ class Client:
         output: str | None = None,
     ) -> EditResult:
         """Rotate and/or flip a video."""
-        return _rotate(video, angle=angle, flip_horizontal=flip_horizontal, flip_vertical=flip_vertical, output_path=output)
+        return _rotate(
+            video, angle=angle, flip_horizontal=flip_horizontal, flip_vertical=flip_vertical, output_path=output
+        )
 
     def fade(
         self,
@@ -298,8 +323,12 @@ class Client:
     ) -> EditResult:
         """Add fade in/out effect to a video."""
         return _fade(
-            video, fade_in=fade_in, fade_out=fade_out,
-            output_path=output, crf=crf, preset=preset,
+            video,
+            fade_in=fade_in,
+            fade_out=fade_out,
+            output_path=output,
+            crf=crf,
+            preset=preset,
         )
 
     def export(
@@ -355,8 +384,12 @@ class Client:
     ) -> EditResult:
         """Apply a visual filter to a video."""
         return _apply_filter(
-            video, filter_type=filter_type, params=params,
-            output_path=output, crf=crf, preset=preset,
+            video,
+            filter_type=filter_type,
+            params=params,
+            output_path=output,
+            crf=crf,
+            preset=preset,
         )
 
     def blur(
@@ -368,7 +401,8 @@ class Client:
     ) -> EditResult:
         """Apply blur effect to a video."""
         return _apply_filter(
-            video, filter_type="blur",
+            video,
+            filter_type="blur",
             params={"radius": radius, "strength": strength},
             output_path=output,
         )
@@ -380,6 +414,7 @@ class Client:
     ) -> EditResult:
         """Reverse video and audio playback."""
         from .engine import reverse as _reverse
+
         return _reverse(input_path=video, output_path=output)
 
     def chroma_key(
@@ -392,6 +427,7 @@ class Client:
     ) -> EditResult:
         """Remove a solid color background (green screen / chroma key)."""
         from .engine import chroma_key as _chroma_key
+
         return _chroma_key(input_path=video, color=color, similarity=similarity, blend=blend, output_path=output)
 
     def color_grade(
@@ -402,7 +438,8 @@ class Client:
     ) -> EditResult:
         """Apply a color grading preset to a video."""
         return _apply_filter(
-            video, filter_type="color_preset",
+            video,
+            filter_type="color_preset",
             params={"preset": preset},
             output_path=output,
         )
@@ -432,10 +469,17 @@ class Client:
     ) -> EditResult:
         """Picture-in-picture: overlay a video on top of another."""
         return _overlay_video(
-            background_path=background, overlay_path=overlay, position=position,
-            width=width, height=height, opacity=opacity,
-            start_time=start_time, duration=duration,
-            output_path=output, crf=crf, preset=preset,
+            background_path=background,
+            overlay_path=overlay,
+            position=position,
+            width=width,
+            height=height,
+            opacity=opacity,
+            start_time=start_time,
+            duration=duration,
+            output_path=output,
+            crf=crf,
+            preset=preset,
         )
 
     def split_screen(
@@ -548,6 +592,7 @@ class Client:
     ) -> dict:
         """Apply the same operation to multiple video files."""
         from .engine import video_batch
+
         return video_batch(inputs, operation=operation, params=params, output_dir=output_dir)
 
     # ------------------------------------------------------------------
@@ -561,6 +606,7 @@ class Client:
     ) -> dict:
         """Extract dominant colors from an image using K-means clustering."""
         from .image_engine import extract_colors
+
         return extract_colors(image_path, n_colors=n_colors)
 
     def generate_palette(
@@ -571,6 +617,7 @@ class Client:
     ) -> dict:
         """Generate a color harmony palette from an image's dominant color."""
         from .image_engine import generate_palette
+
         return generate_palette(image_path, harmony=harmony, n_colors=n_colors)
 
     def analyze_product(
@@ -581,6 +628,7 @@ class Client:
     ) -> dict:
         """Analyze a product image — extract colors and optionally generate AI description."""
         from .image_engine import analyze_product
+
         return analyze_product(image_path, use_ai=use_ai, n_colors=n_colors)
 
     # ------------------------------------------------------------------
@@ -604,16 +652,32 @@ class Client:
     ):
         """Render a Remotion composition to video."""
         from .remotion_engine import render
-        return render(project_path, composition_id, output_path=output, codec=codec, crf=crf, width=width, height=height, fps=fps, concurrency=concurrency, frames=frames, props=props, scale=scale)
+
+        return render(
+            project_path,
+            composition_id,
+            output_path=output,
+            codec=codec,
+            crf=crf,
+            width=width,
+            height=height,
+            fps=fps,
+            concurrency=concurrency,
+            frames=frames,
+            props=props,
+            scale=scale,
+        )
 
     def remotion_compositions(self, project_path: str) -> list[dict]:
         """List compositions in a Remotion project."""
         from .remotion_engine import compositions
+
         return compositions(project_path)
 
     def remotion_studio(self, project_path: str, port: int = 3000) -> dict:
         """Launch Remotion Studio for live preview."""
         from .remotion_engine import studio
+
         return studio(project_path, port=port)
 
     def remotion_still(
@@ -626,6 +690,7 @@ class Client:
     ) -> dict:
         """Render a single frame as image."""
         from .remotion_engine import still
+
         return still(project_path, composition_id, output_path=output, frame=frame, image_format=image_format)
 
     def remotion_create_project(
@@ -645,6 +710,7 @@ class Client:
             dict with key "project_path" (str): absolute path to the new project
         """
         from .remotion_engine import create_project
+
         return create_project(name, output_dir=output_dir, template=template)
 
     def remotion_scaffold_template(
@@ -655,6 +721,7 @@ class Client:
     ) -> None:
         """Generate composition from spec."""
         from .remotion_engine import scaffold_template
+
         return scaffold_template(project_path, spec, slug)
 
     def remotion_validate(self, project_path: str, composition_id: str | None = None) -> dict:
@@ -669,6 +736,7 @@ class Client:
             RemotionValidationResult with pass/fail status and issues list
         """
         from .remotion_engine import validate
+
         return validate(project_path, composition_id=composition_id)
 
     def remotion_to_mcpvideo(
@@ -692,6 +760,7 @@ class Client:
             RemotionPipelineResult with output path and applied operations
         """
         from .remotion_engine import render_and_post
+
         return render_and_post(project_path, composition_id, post_process, output_path=output)
 
     # ------------------------------------------------------------------
@@ -721,6 +790,7 @@ class Client:
             Path to generated WAV file
         """
         from .audio_engine import audio_synthesize
+
         return audio_synthesize(
             output=output,
             waveform=waveform,
@@ -750,6 +820,7 @@ class Client:
             Path to generated WAV file
         """
         from .audio_engine import audio_preset
+
         return audio_preset(
             preset=preset,
             output=output,
@@ -773,6 +844,7 @@ class Client:
             Path to generated WAV file
         """
         from .audio_engine import audio_sequence
+
         return audio_sequence(sequence=sequence, output=output)
 
     def audio_compose(
@@ -798,6 +870,7 @@ class Client:
             Path to generated WAV file
         """
         from .audio_engine import audio_compose
+
         return audio_compose(tracks=tracks, duration=duration, output=output)
 
     def audio_effects(
@@ -817,6 +890,7 @@ class Client:
             Path to processed WAV file
         """
         from .audio_engine import audio_effects
+
         return audio_effects(input_path=input_path, output=output, effects=effects)
 
     def add_generated_audio(
@@ -836,6 +910,7 @@ class Client:
             Path to output video
         """
         from .audio_engine import add_generated_audio
+
         return add_generated_audio(input_path=video, audio_config=audio_config, output_path=output)
 
     # ------------------------------------------------------------------
@@ -852,7 +927,10 @@ class Client:
     ) -> str:
         """Apply vignette effect - darkened edges."""
         from .effects_engine import effect_vignette
-        return effect_vignette(input_path=video, output=output, intensity=intensity, radius=radius, smoothness=smoothness)
+
+        return effect_vignette(
+            input_path=video, output=output, intensity=intensity, radius=radius, smoothness=smoothness
+        )
 
     def effect_chromatic_aberration(
         self,
@@ -863,6 +941,7 @@ class Client:
     ) -> str:
         """Apply RGB channel separation effect."""
         from .effects_engine import effect_chromatic_aberration
+
         return effect_chromatic_aberration(input_path=video, output=output, intensity=intensity, angle=angle)
 
     def effect_scanlines(
@@ -875,7 +954,10 @@ class Client:
     ) -> str:
         """Apply CRT-style scanline overlay."""
         from .effects_engine import effect_scanlines
-        return effect_scanlines(input_path=video, output=output, line_height=line_height, opacity=opacity, flicker=flicker)
+
+        return effect_scanlines(
+            input_path=video, output=output, line_height=line_height, opacity=opacity, flicker=flicker
+        )
 
     def effect_noise(
         self,
@@ -887,6 +969,7 @@ class Client:
     ) -> str:
         """Apply film grain / digital noise."""
         from .effects_engine import effect_noise
+
         return effect_noise(input_path=video, output=output, intensity=intensity, mode=mode, animated=animated)
 
     def effect_glow(
@@ -899,6 +982,7 @@ class Client:
     ) -> str:
         """Apply bloom/glow effect for highlights."""
         from .effects_engine import effect_glow
+
         return effect_glow(input_path=video, output=output, intensity=intensity, radius=radius, threshold=threshold)
 
     # ------------------------------------------------------------------
@@ -933,6 +1017,7 @@ class Client:
         if layout not in self._VALID_LAYOUTS:
             raise ValueError(f"layout must be one of {sorted(self._VALID_LAYOUTS)}, got {layout}")
         from .effects_engine import layout_grid
+
         return layout_grid(clips, layout, output, gap, padding, background)
 
     def layout_pip(
@@ -968,7 +1053,10 @@ class Client:
         if position not in self._VALID_PIP_POSITIONS:
             raise ValueError(f"position must be one of {sorted(self._VALID_PIP_POSITIONS)}, got {position}")
         from .effects_engine import layout_pip
-        return layout_pip(main, pip, output, position, size, margin, rounded_corners, border, border_color, border_width)
+
+        return layout_pip(
+            main, pip, output, position, size, margin, rounded_corners, border, border_color, border_width
+        )
 
     # ------------------------------------------------------------------
     # Text & Typography
@@ -989,6 +1077,7 @@ class Client:
     ) -> str:
         """Add animated text to video."""
         from .effects_engine import text_animated
+
         return text_animated(video, text, output, animation, font, size, color, position, start, duration)
 
     def text_subtitles(
@@ -1000,6 +1089,7 @@ class Client:
     ) -> str:
         """Burn subtitles from SRT/VTT with styling."""
         from .effects_engine import text_subtitles
+
         return text_subtitles(video=video, subtitles=subtitles, output=output, style=style)
 
     # ------------------------------------------------------------------
@@ -1030,6 +1120,7 @@ class Client:
             In the Python client, they must be passed as named arguments.
         """
         from .effects_engine import mograph_count
+
         return mograph_count(start, end, duration, output, style, fps)
 
     def mograph_progress(
@@ -1043,6 +1134,7 @@ class Client:
     ) -> str:
         """Generate progress bar / loading animation."""
         from .effects_engine import mograph_progress
+
         return mograph_progress(duration, output, style, color, track_color, fps)
 
     # ------------------------------------------------------------------
@@ -1052,18 +1144,22 @@ class Client:
     def video_info_detailed(self, video: str) -> dict:
         """Get extended video metadata."""
         from .effects_engine import video_info_detailed
+
         return video_info_detailed(video)
 
     def auto_chapters(self, video: str, threshold: float = 0.3) -> list[tuple[float, str]]:
         """Auto-detect scene changes and create chapters."""
         from .effects_engine import auto_chapters
+
         return auto_chapters(video, threshold)
 
     # ------------------------------------------------------------------
     # Transitions (Wave 2)
     # ------------------------------------------------------------------
 
-    def transition_glitch(self, clip1: str, clip2: str, output: str, duration: float = 0.5, intensity: float = 0.3) -> str:
+    def transition_glitch(
+        self, clip1: str, clip2: str, output: str, duration: float = 0.5, intensity: float = 0.3
+    ) -> str:
         """Apply glitch transition between two video clips.
 
         Args:
@@ -1074,9 +1170,12 @@ class Client:
             intensity: Glitch intensity 0-1. CLI: -i/--intensity
         """
         from .transitions_engine import transition_glitch
+
         return transition_glitch(clip1, clip2, output, duration, intensity)
 
-    def transition_pixelate(self, clip1: str, clip2: str, output: str, duration: float = 0.4, pixel_size: int = 50) -> str:
+    def transition_pixelate(
+        self, clip1: str, clip2: str, output: str, duration: float = 0.4, pixel_size: int = 50
+    ) -> str:
         """Apply pixelate transition between two video clips.
 
         Args:
@@ -1087,6 +1186,7 @@ class Client:
             pixel_size: Maximum pixel size during transition. CLI: -p/--pixel-size
         """
         from .transitions_engine import transition_pixelate
+
         return transition_pixelate(clip1, clip2, output, duration, pixel_size)
 
     def transition_morph(self, clip1: str, clip2: str, output: str, duration: float = 0.6, mesh_size: int = 10) -> str:
@@ -1100,18 +1200,29 @@ class Client:
             mesh_size: Grid subdivisions. CLI: -m/--mesh-size
         """
         from .transitions_engine import transition_morph
+
         return transition_morph(clip1, clip2, output, duration, mesh_size)
 
     # ------------------------------------------------------------------
     # AI Features (Wave 3)
     # ------------------------------------------------------------------
 
-    def ai_remove_silence(self, video: str, output: str, silence_threshold: float = -50, min_silence_duration: float = 0.5, keep_margin: float = 0.1) -> str:
+    def ai_remove_silence(
+        self,
+        video: str,
+        output: str,
+        silence_threshold: float = -50,
+        min_silence_duration: float = 0.5,
+        keep_margin: float = 0.1,
+    ) -> str:
         """Remove silent sections from video."""
         from .ai_engine import ai_remove_silence
+
         return ai_remove_silence(video, output, silence_threshold, min_silence_duration, keep_margin)
 
-    def ai_transcribe(self, video: str, output_srt: str | None = None, model: str = "base", language: str | None = None) -> dict:
+    def ai_transcribe(
+        self, video: str, output_srt: str | None = None, model: str = "base", language: str | None = None
+    ) -> dict:
         """Transcribe speech to text using Whisper.
 
         Args:
@@ -1127,14 +1238,18 @@ class Client:
                 - language (str): Detected language
         """
         from .ai_engine import ai_transcribe
+
         return ai_transcribe(video, output_srt, model, language)
 
     def ai_scene_detect(self, video: str, threshold: float = 0.3, use_ai: bool = False) -> list[dict]:
         """Detect scene changes in video."""
         from .ai_engine import ai_scene_detect
+
         return ai_scene_detect(video, threshold, use_ai)
 
-    def ai_stem_separation(self, video: str, output_dir: str, stems: list[str] | None = None, model: str = "htdemucs") -> dict[str, str]:
+    def ai_stem_separation(
+        self, video: str, output_dir: str, stems: list[str] | None = None, model: str = "htdemucs"
+    ) -> dict[str, str]:
         """Separate audio into stems using Demucs.
 
         Args:
@@ -1149,6 +1264,7 @@ class Client:
             {"vocals": "/path/to/vocals.wav", "drums": "/path/to/drums.wav", ...}
         """
         from .ai_engine import ai_stem_separation
+
         return ai_stem_separation(video, output_dir, stems, model)
 
     def ai_upscale(self, video: str, output: str, scale: int = 2, model: str = "realesrgan") -> str:
@@ -1164,16 +1280,19 @@ class Client:
             ValueError: If scale is not 2 or 4
         """
         from .ai_engine import ai_upscale
+
         return ai_upscale(video, output, scale, model)
 
     def ai_color_grade(self, video: str, output: str, reference: str | None = None, style: str = "auto") -> str:
         """Auto color grade video."""
         from .ai_engine import ai_color_grade
+
         return ai_color_grade(video, output, reference, style)
 
     def audio_spatial(self, video: str, output: str, positions: list[dict], method: str = "hrtf") -> str:
         """Apply 3D spatial audio positioning."""
         from .ai_engine import audio_spatial
+
         return audio_spatial(video, output, positions, method)
 
     def quality_check(self, video: str, fail_on_warning: bool = False) -> dict:
@@ -1192,6 +1311,7 @@ class Client:
                 - recommendations (list[str]): improvement suggestions
         """
         from .quality_guardrails import quality_check
+
         return quality_check(video, fail_on_warning)
 
     def design_quality_check(
@@ -1224,6 +1344,7 @@ class Client:
                 - recommendations (list[str]): improvement suggestions
         """
         from .design_quality import design_quality_check
+
         return design_quality_check(video, auto_fix=auto_fix, strict=strict)
 
     def fix_design_issues(
@@ -1241,6 +1362,7 @@ class Client:
             Path to fixed video
         """
         from .design_quality import fix_design_issues
+
         return fix_design_issues(video, output=output)
 
 

--- a/mcp_video/design_quality.py
+++ b/mcp_video/design_quality.py
@@ -20,8 +20,9 @@ import contextlib
 @dataclass
 class DesignIssue:
     """A design quality issue with severity and fix recommendation."""
+
     category: str  # 'layout', 'typography', 'color', 'motion', 'composition', 'hierarchy', 'timing'
-    severity: Literal['error', 'warning', 'info']
+    severity: Literal["error", "warning", "info"]
     message: str
     frame: int | None = None
     fix_available: bool = False
@@ -32,6 +33,7 @@ class DesignIssue:
 @dataclass
 class DesignQualityReport:
     """Comprehensive design quality report."""
+
     video_path: str
     overall_score: float  # 0-100
     technical_score: float  # brightness, contrast, etc
@@ -43,10 +45,10 @@ class DesignQualityReport:
     recommendations: list[str] = field(default_factory=list)
 
     def get_errors(self) -> list[DesignIssue]:
-        return [i for i in self.issues if i.severity == 'error']
+        return [i for i in self.issues if i.severity == "error"]
 
     def get_warnings(self) -> list[DesignIssue]:
-        return [i for i in self.issues if i.severity == 'warning']
+        return [i for i in self.issues if i.severity == "warning"]
 
     def has_fixable_issues(self) -> bool:
         return any(i.fix_available for i in self.issues)
@@ -54,25 +56,25 @@ class DesignQualityReport:
     def get_score_breakdown(self) -> dict:
         """Get detailed score breakdown with improvement potential."""
         return {
-            'technical': {
-                'score': self.technical_score,
-                'weight': 0.25,
-                'potential': 100 - self.technical_score,
+            "technical": {
+                "score": self.technical_score,
+                "weight": 0.25,
+                "potential": 100 - self.technical_score,
             },
-            'design': {
-                'score': self.design_score,
-                'weight': 0.25,
-                'potential': 100 - self.design_score,
+            "design": {
+                "score": self.design_score,
+                "weight": 0.25,
+                "potential": 100 - self.design_score,
             },
-            'hierarchy': {
-                'score': self.hierarchy_score,
-                'weight': 0.25,
-                'potential': 100 - self.hierarchy_score,
+            "hierarchy": {
+                "score": self.hierarchy_score,
+                "weight": 0.25,
+                "potential": 100 - self.hierarchy_score,
             },
-            'motion': {
-                'score': self.motion_score,
-                'weight': 0.25,
-                'potential': 100 - self.motion_score,
+            "motion": {
+                "score": self.motion_score,
+                "weight": 0.25,
+                "potential": 100 - self.motion_score,
             },
         }
 
@@ -85,42 +87,48 @@ class DesignQualityReport:
         warnings = self.get_warnings()
 
         for issue in errors:
-            recs.append({
-                'priority': 'CRITICAL',
-                'category': issue.category,
-                'issue': issue.message,
-                'fix': issue.fix_description if issue.fix_available else 'Manual fix required',
-                'impact': '-20 points',
-                'auto_fixable': issue.fix_available,
-            })
+            recs.append(
+                {
+                    "priority": "CRITICAL",
+                    "category": issue.category,
+                    "issue": issue.message,
+                    "fix": issue.fix_description if issue.fix_available else "Manual fix required",
+                    "impact": "-20 points",
+                    "auto_fixable": issue.fix_available,
+                }
+            )
 
         for issue in warnings:
-            recs.append({
-                'priority': 'HIGH',
-                'category': issue.category,
-                'issue': issue.message,
-                'fix': issue.fix_description if issue.fix_available else 'Review and adjust',
-                'impact': '-10 points',
-                'auto_fixable': issue.fix_available,
-            })
+            recs.append(
+                {
+                    "priority": "HIGH",
+                    "category": issue.category,
+                    "issue": issue.message,
+                    "fix": issue.fix_description if issue.fix_available else "Review and adjust",
+                    "impact": "-10 points",
+                    "auto_fixable": issue.fix_available,
+                }
+            )
 
         # Add score-specific recommendations
         breakdown = self.get_score_breakdown()
-        lowest_score = min(breakdown.items(), key=lambda x: x[1]['score'])
+        lowest_score = min(breakdown.items(), key=lambda x: x[1]["score"])
 
-        if lowest_score[1]['score'] < 80:
-            recs.append({
-                'priority': 'HIGH',
-                'category': lowest_score[0],
-                'issue': f"Lowest score: {lowest_score[1]['score']:.1f}/100",
-                'fix': f"Focus on improving {lowest_score[0]} quality",
-                'impact': f"+{lowest_score[1]['potential']:.0f} points potential",
-                'auto_fixable': False,
-            })
+        if lowest_score[1]["score"] < 80:
+            recs.append(
+                {
+                    "priority": "HIGH",
+                    "category": lowest_score[0],
+                    "issue": f"Lowest score: {lowest_score[1]['score']:.1f}/100",
+                    "fix": f"Focus on improving {lowest_score[0]} quality",
+                    "impact": f"+{lowest_score[1]['potential']:.0f} points potential",
+                    "auto_fixable": False,
+                }
+            )
 
         # Sort by priority
-        priority_order = {'CRITICAL': 0, 'HIGH': 1, 'MEDIUM': 2, 'LOW': 3}
-        recs.sort(key=lambda x: priority_order.get(x['priority'], 4))
+        priority_order = {"CRITICAL": 0, "HIGH": 1, "MEDIUM": 2, "LOW": 3}
+        recs.sort(key=lambda x: priority_order.get(x["priority"], 4))
 
         return recs
 
@@ -144,8 +152,8 @@ class DesignQualityReport:
         if self.recommendations:
             print("\n🎯 RECOMMENDATIONS TO REACH 100/100:")
             for i, rec in enumerate(self.recommendations[:10], 1):
-                icon = "🔴" if rec['priority'] == 'CRITICAL' else "🟡" if rec['priority'] == 'HIGH' else "🔵"
-                auto = " [AUTO]" if rec.get('auto_fixable') else ""
+                icon = "🔴" if rec["priority"] == "CRITICAL" else "🟡" if rec["priority"] == "HIGH" else "🔵"
+                auto = " [AUTO]" if rec.get("auto_fixable") else ""
                 print(f"   {icon} {i}. [{rec['category'].upper()}] {rec['issue']}{auto}")
                 print(f"      Fix: {rec['fix']}")
                 print(f"      Impact: {rec['impact']}")
@@ -198,7 +206,7 @@ class DesignQualityGuardrails:
     MIN_ELEMENT_SPACING = 20  # pixels between elements
 
     # Brand standards
-    BRAND_COLORS: ClassVar[list[str]] = ['#CCFF00', '#5B2E91', '#7C3AED', '#6366F1']  # Electric Lime x Midnight Violet
+    BRAND_COLORS: ClassVar[list[str]] = ["#CCFF00", "#5B2E91", "#7C3AED", "#6366F1"]  # Electric Lime x Midnight Violet
 
     def __init__(self):
         self.issues: list[DesignIssue] = []
@@ -273,33 +281,37 @@ class DesignQualityGuardrails:
     def _check_layout(self, video_path: str):
         """Check layout quality: safe areas, centering, alignment, spacing."""
         probe = self._probe_video(video_path)
-        width = probe.get('width', 1920)
-        height = probe.get('height', 1080)
+        width = probe.get("width", 1920)
+        height = probe.get("height", 1080)
 
         width * self.SAFE_AREA_MARGIN
         height * self.SAFE_AREA_MARGIN
 
         # Check aspect ratio consistency
         aspect = width / height
-        standard_aspects = [16/9, 9/16, 1/1, 4/3, 21/9]
+        standard_aspects = [16 / 9, 9 / 16, 1 / 1, 4 / 3, 21 / 9]
         closest = min(standard_aspects, key=lambda x: abs(x - aspect))
 
         if abs(aspect - closest) > 0.01:
-            self.issues.append(DesignIssue(
-                category='layout',
-                severity='warning',
-                message=f'Non-standard aspect ratio ({aspect:.2f}). Consider {closest:.2f} for better compatibility.',
-                fix_available=False,
-            ))
+            self.issues.append(
+                DesignIssue(
+                    category="layout",
+                    severity="warning",
+                    message=f"Non-standard aspect ratio ({aspect:.2f}). Consider {closest:.2f} for better compatibility.",
+                    fix_available=False,
+                )
+            )
 
         # Check if resolution is sufficient for text
         if width < 1920 and height < 1080:
-            self.issues.append(DesignIssue(
-                category='layout',
-                severity='warning',
-                message=f'Low resolution ({width}x{height}). Text may appear blurry on high-DPI displays.',
-                fix_available=False,
-            ))
+            self.issues.append(
+                DesignIssue(
+                    category="layout",
+                    severity="warning",
+                    message=f"Low resolution ({width}x{height}). Text may appear blurry on high-DPI displays.",
+                    fix_available=False,
+                )
+            )
 
     def _check_typography(self, video_path: str):
         """Check typography: readability, contrast, hierarchy, line length.
@@ -315,29 +327,35 @@ class DesignQualityGuardrails:
         # Check if text would be readable
         if mean_luma < 30 and not is_dark_brand:
             # Only flag dark videos if they don't appear to be intentional brand themes
-            self.issues.append(DesignIssue(
-                category='typography',
-                severity='warning',
-                message='Very dark video may affect text readability. Consider brighter backgrounds for text overlays.',
-                fix_available=True,
-                auto_fix=lambda v: self._auto_fix_brightness(v, target=40),
-                fix_description='Increase brightness slightly for better text readability',
-            ))
+            self.issues.append(
+                DesignIssue(
+                    category="typography",
+                    severity="warning",
+                    message="Very dark video may affect text readability. Consider brighter backgrounds for text overlays.",
+                    fix_available=True,
+                    auto_fix=lambda v: self._auto_fix_brightness(v, target=40),
+                    fix_description="Increase brightness slightly for better text readability",
+                )
+            )
         elif mean_luma < 30 and is_dark_brand:
             # Dark brand theme detected - info only
-            self.issues.append(DesignIssue(
-                category='typography',
-                severity='info',
-                message='Dark theme detected. Ensure text has sufficient contrast with background.',
-                fix_available=False,
-            ))
+            self.issues.append(
+                DesignIssue(
+                    category="typography",
+                    severity="info",
+                    message="Dark theme detected. Ensure text has sufficient contrast with background.",
+                    fix_available=False,
+                )
+            )
         elif mean_luma > 220:
-            self.issues.append(DesignIssue(
-                category='typography',
-                severity='warning',
-                message='Very bright video may wash out light-colored text. Consider darker text or backgrounds.',
-                fix_available=False,
-            ))
+            self.issues.append(
+                DesignIssue(
+                    category="typography",
+                    severity="warning",
+                    message="Very bright video may wash out light-colored text. Consider darker text or backgrounds.",
+                    fix_available=False,
+                )
+            )
 
     def _check_color(self, video_path: str):
         """Check color: brand consistency, accessibility, harmony.
@@ -351,66 +369,78 @@ class DesignQualityGuardrails:
         is_brand_theme = self._is_dark_brand_theme(mean_luma, color_stats)
 
         # Check for color casts (only flag non-brand colors)
-        rgb_means = color_stats.get('rgb_means', [128, 128, 128])
+        rgb_means = color_stats.get("rgb_means", [128, 128, 128])
         max_deviation = max(abs(c - 128) for c in rgb_means)
 
         if max_deviation > 80 and not is_brand_theme:
-            dominant = ['R', 'G', 'B'][rgb_means.index(max(rgb_means))]
-            self.issues.append(DesignIssue(
-                category='color',
-                severity='info',
-                message=f'Strong {dominant} color cast detected. This may be intentional stylistic choice.',
-                fix_available=False,
-            ))
+            dominant = ["R", "G", "B"][rgb_means.index(max(rgb_means))]
+            self.issues.append(
+                DesignIssue(
+                    category="color",
+                    severity="info",
+                    message=f"Strong {dominant} color cast detected. This may be intentional stylistic choice.",
+                    fix_available=False,
+                )
+            )
 
         # Check saturation
-        saturation = color_stats.get('saturation', 50)
+        saturation = color_stats.get("saturation", 50)
         if saturation < 10:
-            self.issues.append(DesignIssue(
-                category='color',
-                severity='warning',
-                message=f'Very low saturation ({saturation:.1f}%). Video appears desaturated.',
-                fix_available=True,
-                auto_fix=lambda v: self._auto_fix_saturation(v, boost=1.2),
-                fix_description='Increase color saturation',
-            ))
+            self.issues.append(
+                DesignIssue(
+                    category="color",
+                    severity="warning",
+                    message=f"Very low saturation ({saturation:.1f}%). Video appears desaturated.",
+                    fix_available=True,
+                    auto_fix=lambda v: self._auto_fix_saturation(v, boost=1.2),
+                    fix_description="Increase color saturation",
+                )
+            )
         elif saturation > 90 and not is_brand_theme:
             # Only flag high saturation if not a brand theme (Electric Lime is intentionally vibrant)
-            self.issues.append(DesignIssue(
-                category='color',
-                severity='info',
-                message=f'High saturation ({saturation:.1f}%). Ensure this is intentional.',
-                fix_available=False,
-            ))
+            self.issues.append(
+                DesignIssue(
+                    category="color",
+                    severity="info",
+                    message=f"High saturation ({saturation:.1f}%). Ensure this is intentional.",
+                    fix_available=False,
+                )
+            )
 
     def _check_motion(self, video_path: str):
         """Check motion: animation smoothness, timing, judder."""
         fps = self._get_fps(video_path)
 
         if fps < self.MIN_ANIMATION_FPS:
-            self.issues.append(DesignIssue(
-                category='motion',
-                severity='error',
-                message=f'Low frame rate ({fps} fps). Animation may appear choppy. Minimum recommended: {self.MIN_ANIMATION_FPS} fps.',
-                fix_available=False,
-            ))
+            self.issues.append(
+                DesignIssue(
+                    category="motion",
+                    severity="error",
+                    message=f"Low frame rate ({fps} fps). Animation may appear choppy. Minimum recommended: {self.MIN_ANIMATION_FPS} fps.",
+                    fix_available=False,
+                )
+            )
         elif fps < self.IDEAL_ANIMATION_FPS:
-            self.issues.append(DesignIssue(
-                category='motion',
-                severity='warning',
-                message=f'Frame rate ({fps} fps) below ideal ({self.IDEAL_ANIMATION_FPS} fps). Consider increasing for smoother motion.',
-                fix_available=False,
-            ))
+            self.issues.append(
+                DesignIssue(
+                    category="motion",
+                    severity="warning",
+                    message=f"Frame rate ({fps} fps) below ideal ({self.IDEAL_ANIMATION_FPS} fps). Consider increasing for smoother motion.",
+                    fix_available=False,
+                )
+            )
 
         # Check for motion judder
         judder_score = self._analyze_motion_smoothness(video_path)
         if judder_score < 0.7:
-            self.issues.append(DesignIssue(
-                category='motion',
-                severity='warning',
-                message='Motion judder detected. Consider using smoother easing or higher frame rate.',
-                fix_available=False,
-            ))
+            self.issues.append(
+                DesignIssue(
+                    category="motion",
+                    severity="warning",
+                    message="Motion judder detected. Consider using smoother easing or higher frame rate.",
+                    fix_available=False,
+                )
+            )
 
     def _check_composition(self, video_path: str):
         """Check composition: balance, focal points, visual weight."""
@@ -418,12 +448,14 @@ class DesignQualityGuardrails:
         composition_score = self._analyze_composition(video_path)
 
         if composition_score < 0.6:
-            self.issues.append(DesignIssue(
-                category='composition',
-                severity='warning',
-                message='Composition appears unbalanced. Consider rule of thirds or centering focal points.',
-                fix_available=False,
-            ))
+            self.issues.append(
+                DesignIssue(
+                    category="composition",
+                    severity="warning",
+                    message="Composition appears unbalanced. Consider rule of thirds or centering focal points.",
+                    fix_available=False,
+                )
+            )
 
     def _check_hierarchy(self, video_path: str):
         """Check visual hierarchy: text size progression, dominance, emphasis.
@@ -434,45 +466,53 @@ class DesignQualityGuardrails:
         text_elements = self._detect_text_elements(video_path)
 
         if text_elements:
-            sizes = sorted(set([t.get('size', 24) for t in text_elements]), reverse=True)
+            sizes = sorted(set([t.get("size", 24) for t in text_elements]), reverse=True)
 
             # Check size ratios
             if len(sizes) >= 2:
                 ratio = sizes[0] / sizes[1]
                 if ratio < 1.5:
-                    self.issues.append(DesignIssue(
-                        category='hierarchy',
-                        severity='warning',
-                        message=f'Text size ratio ({ratio:.1f}x) is too small. Use at least 1.5x between heading and body.',
-                        fix_available=False,
-                    ))
+                    self.issues.append(
+                        DesignIssue(
+                            category="hierarchy",
+                            severity="warning",
+                            message=f"Text size ratio ({ratio:.1f}x) is too small. Use at least 1.5x between heading and body.",
+                            fix_available=False,
+                        )
+                    )
                 elif ratio < 2.0:
-                    self.issues.append(DesignIssue(
-                        category='hierarchy',
-                        severity='info',
-                        message=f'Text size ratio ({ratio:.1f}x) could be stronger. Ideal is 2.0x or more.',
-                        fix_available=False,
-                    ))
+                    self.issues.append(
+                        DesignIssue(
+                            category="hierarchy",
+                            severity="info",
+                            message=f"Text size ratio ({ratio:.1f}x) could be stronger. Ideal is 2.0x or more.",
+                            fix_available=False,
+                        )
+                    )
 
             # Check number of levels
             if len(sizes) > 4:
-                self.issues.append(DesignIssue(
-                    category='hierarchy',
-                    severity='info',
-                    message=f'Many hierarchy levels ({len(sizes)}). Consider simplifying to 3-4 levels maximum.',
-                    fix_available=False,
-                ))
+                self.issues.append(
+                    DesignIssue(
+                        category="hierarchy",
+                        severity="info",
+                        message=f"Many hierarchy levels ({len(sizes)}). Consider simplifying to 3-4 levels maximum.",
+                        fix_available=False,
+                    )
+                )
         else:
             # Fallback to estimated check
             hierarchy_score = self._analyze_text_hierarchy(video_path)
 
             if hierarchy_score < 0.5:
-                self.issues.append(DesignIssue(
-                    category='hierarchy',
-                    severity='warning',
-                    message='Unclear visual hierarchy. Use larger size differences between headings and body text.',
-                    fix_available=False,
-                ))
+                self.issues.append(
+                    DesignIssue(
+                        category="hierarchy",
+                        severity="warning",
+                        message="Unclear visual hierarchy. Use larger size differences between headings and body text.",
+                        fix_available=False,
+                    )
+                )
 
     def _check_timing(self, video_path: str):
         """Check timing: pacing, rhythm, animation duration."""
@@ -480,31 +520,37 @@ class DesignQualityGuardrails:
 
         # Check if video is too short or too long for content
         if duration < 5:
-            self.issues.append(DesignIssue(
-                category='timing',
-                severity='info',
-                message=f'Very short duration ({duration:.1f}s). Ensure viewers have time to process content.',
-                fix_available=False,
-            ))
+            self.issues.append(
+                DesignIssue(
+                    category="timing",
+                    severity="info",
+                    message=f"Very short duration ({duration:.1f}s). Ensure viewers have time to process content.",
+                    fix_available=False,
+                )
+            )
         elif duration > 180:
-            self.issues.append(DesignIssue(
-                category='timing',
-                severity='info',
-                message=f'Long duration ({duration:.1f}s). Consider if content could be condensed.',
-                fix_available=False,
-            ))
+            self.issues.append(
+                DesignIssue(
+                    category="timing",
+                    severity="info",
+                    message=f"Long duration ({duration:.1f}s). Consider if content could be condensed.",
+                    fix_available=False,
+                )
+            )
 
         # Check scene pacing
         scene_changes = self._detect_scene_changes(video_path)
         if len(scene_changes) > 0:
             avg_scene_duration = duration / (len(scene_changes) + 1)
             if avg_scene_duration < 2:
-                self.issues.append(DesignIssue(
-                    category='timing',
-                    severity='warning',
-                    message=f'Rapid scene changes (avg {avg_scene_duration:.1f}s). May feel rushed.',
-                    fix_available=False,
-                ))
+                self.issues.append(
+                    DesignIssue(
+                        category="timing",
+                        severity="warning",
+                        message=f"Rapid scene changes (avg {avg_scene_duration:.1f}s). May feel rushed.",
+                        fix_available=False,
+                    )
+                )
 
     def _check_brand(self, video_path: str):
         """Check brand consistency: color palette adherence."""
@@ -512,24 +558,28 @@ class DesignQualityGuardrails:
         brand_score = self._analyze_brand_colors(video_path)
 
         if brand_score < 0.3:
-            self.issues.append(DesignIssue(
-                category='color',
-                severity='info',
-                message='Video uses colors outside brand palette. Consider if this is intentional.',
-                fix_available=False,
-            ))
+            self.issues.append(
+                DesignIssue(
+                    category="color",
+                    severity="info",
+                    message="Video uses colors outside brand palette. Consider if this is intentional.",
+                    fix_available=False,
+                )
+            )
 
     def _check_clutter(self, video_path: str):
         """Check for visual clutter: too many elements."""
         clutter_score = self._analyze_visual_clutter(video_path)
 
         if clutter_score > 0.8:  # High clutter
-            self.issues.append(DesignIssue(
-                category='composition',
-                severity='warning',
-                message='Visual clutter detected. Consider reducing number of elements per scene.',
-                fix_available=False,
-            ))
+            self.issues.append(
+                DesignIssue(
+                    category="composition",
+                    severity="warning",
+                    message="Visual clutter detected. Consider reducing number of elements per scene.",
+                    fix_available=False,
+                )
+            )
 
     def _check_caption_duration(self, video_path: str):
         """Check if text/captions are on screen long enough to read."""
@@ -538,72 +588,84 @@ class DesignQualityGuardrails:
         text_events = self._detect_text_events(video_path)
 
         for event in text_events:
-            if event['duration'] < self.MIN_CAPTION_DURATION:
-                self.issues.append(DesignIssue(
-                    category='timing',
-                    severity='error',
-                    message=f"Text appears for only {event['duration']:.1f}s. Minimum recommended: {self.MIN_CAPTION_DURATION}s for readability.",
-                    frame=event['frame'],
-                    fix_available=False,
-                ))
+            if event["duration"] < self.MIN_CAPTION_DURATION:
+                self.issues.append(
+                    DesignIssue(
+                        category="timing",
+                        severity="error",
+                        message=f"Text appears for only {event['duration']:.1f}s. Minimum recommended: {self.MIN_CAPTION_DURATION}s for readability.",
+                        frame=event["frame"],
+                        fix_available=False,
+                    )
+                )
 
     def _check_transition_timing(self, video_path: str):
         """Check transition durations are appropriate."""
         transitions = self._detect_transitions(video_path)
 
         for trans in transitions:
-            if trans['duration'] < self.MIN_TRANSITION_DURATION:
-                self.issues.append(DesignIssue(
-                    category='motion',
-                    severity='warning',
-                    message=f"Transition too fast ({trans['duration']:.2f}s). May be jarring. Minimum: {self.MIN_TRANSITION_DURATION}s.",
-                    frame=trans['frame'],
-                    fix_available=False,
-                ))
-            elif trans['duration'] > self.MAX_TRANSITION_DURATION:
-                self.issues.append(DesignIssue(
-                    category='motion',
-                    severity='info',
-                    message=f"Long transition ({trans['duration']:.2f}s). Consider if this slows pacing.",
-                    frame=trans['frame'],
-                    fix_available=False,
-                ))
+            if trans["duration"] < self.MIN_TRANSITION_DURATION:
+                self.issues.append(
+                    DesignIssue(
+                        category="motion",
+                        severity="warning",
+                        message=f"Transition too fast ({trans['duration']:.2f}s). May be jarring. Minimum: {self.MIN_TRANSITION_DURATION}s.",
+                        frame=trans["frame"],
+                        fix_available=False,
+                    )
+                )
+            elif trans["duration"] > self.MAX_TRANSITION_DURATION:
+                self.issues.append(
+                    DesignIssue(
+                        category="motion",
+                        severity="info",
+                        message=f"Long transition ({trans['duration']:.2f}s). Consider if this slows pacing.",
+                        frame=trans["frame"],
+                        fix_available=False,
+                    )
+                )
 
     def _check_visual_rhythm(self, video_path: str):
         """Check for consistent visual rhythm and pacing."""
         rhythm_score = self._analyze_visual_rhythm(video_path)
 
         if rhythm_score < 0.5:
-            self.issues.append(DesignIssue(
-                category='timing',
-                severity='info',
-                message='Inconsistent visual rhythm. Consider more regular pacing between scenes.',
-                fix_available=False,
-            ))
+            self.issues.append(
+                DesignIssue(
+                    category="timing",
+                    severity="info",
+                    message="Inconsistent visual rhythm. Consider more regular pacing between scenes.",
+                    fix_available=False,
+                )
+            )
 
     def _check_spacing_consistency(self, video_path: str):
         """Check for consistent spacing between elements."""
         spacing_variance = self._analyze_spacing(video_path)
 
         if spacing_variance > 0.3:  # High variance
-            self.issues.append(DesignIssue(
-                category='layout',
-                severity='info',
-                message='Inconsistent spacing detected. Consider using a spacing scale for uniformity.',
-                fix_available=False,
-            ))
+            self.issues.append(
+                DesignIssue(
+                    category="layout",
+                    severity="info",
+                    message="Inconsistent spacing detected. Consider using a spacing scale for uniformity.",
+                    fix_available=False,
+                )
+            )
 
     def _check_focal_points(self, video_path: str):
         """Check for clear focal points in each scene."""
         focal_score = self._analyze_focal_points(video_path)
 
         if focal_score < 0.6:
-            self.issues.append(DesignIssue(
-                category='composition',
-                severity='warning',
-                message='Unclear focal points. Each scene should have one primary element that draws attention.',
-                fix_available=False,
-            ))
+            self.issues.append(
+                DesignIssue(
+                    category="composition",
+                    severity="warning",
+                    message="Unclear focal points. Each scene should have one primary element that draws attention.",
+                    fix_available=False,
+                )
+            )
 
     # ============== SCORE CALCULATIONS ==============
 
@@ -653,13 +715,13 @@ class DesignQualityGuardrails:
         if mean_luma > 60:
             return False
 
-        rgb_means = color_stats.get('rgb_means', [128, 128, 128])
+        rgb_means = color_stats.get("rgb_means", [128, 128, 128])
 
         # Check for purple/violet tint (Midnight Violet family)
         has_violet_tint = rgb_means[0] > rgb_means[1] and rgb_means[2] > rgb_means[1]
 
         # Check for high saturation accents (Electric Lime)
-        saturation = color_stats.get('saturation', 50)
+        saturation = color_stats.get("saturation", 50)
         has_vibrant_accents = saturation > 30
 
         return has_violet_tint or has_vibrant_accents
@@ -679,28 +741,22 @@ class DesignQualityGuardrails:
         filtered_issues = []
         for issue in self.issues:
             # Skip dark video warnings for brand themes
-            if (issue.category == 'typography' and
-                'dark video' in issue.message.lower() and
-                issue.severity == 'warning'):
+            if issue.category == "typography" and "dark video" in issue.message.lower() and issue.severity == "warning":
                 continue
 
             # Skip color cast warnings for brand colors
-            if (issue.category == 'color' and
-                'color cast' in issue.message.lower() and
-                issue.severity == 'info'):
+            if issue.category == "color" and "color cast" in issue.message.lower() and issue.severity == "info":
                 continue
 
             # Skip high saturation warnings (Electric Lime is intentionally vibrant)
-            if (issue.category == 'color' and
-                'saturation' in issue.message.lower() and
-                issue.severity == 'info'):
+            if issue.category == "color" and "saturation" in issue.message.lower() and issue.severity == "info":
                 continue
 
             filtered_issues.append(issue)
 
-        errors = len([i for i in filtered_issues if i.severity == 'error'])
-        warnings = len([i for i in filtered_issues if i.severity == 'warning'])
-        infos = len([i for i in filtered_issues if i.severity == 'info'])
+        errors = len([i for i in filtered_issues if i.severity == "error"])
+        warnings = len([i for i in filtered_issues if i.severity == "warning"])
+        infos = len([i for i in filtered_issues if i.severity == "info"])
 
         score = 100
         score -= errors * 20
@@ -725,7 +781,7 @@ class DesignQualityGuardrails:
             return self._estimate_hierarchy_score(video_path)
 
         # Calculate size ratios
-        sizes = [t.get('size', 24) for t in text_elements]
+        sizes = [t.get("size", 24) for t in text_elements]
         if len(sizes) < 2:
             return 70.0
 
@@ -758,14 +814,14 @@ class DesignQualityGuardrails:
             level_score = 0.6  # Too many levels
 
         # Combined score
-        hierarchy_score = (avg_ratio_score * 0.6 + level_score * 0.4)
+        hierarchy_score = avg_ratio_score * 0.6 + level_score * 0.4
         return min(100, hierarchy_score * 100)
 
     def _estimate_hierarchy_score(self, video_path: str) -> float:
         """Estimate hierarchy score based on video characteristics."""
         # Check resolution (higher res = more room for hierarchy)
         probe = self._probe_video(video_path)
-        height = probe.get('height', 1080)
+        height = probe.get("height", 1080)
 
         # Base score on resolution tier
         if height >= 1080:
@@ -790,8 +846,7 @@ class DesignQualityGuardrails:
         """
         # Sample frames at different timestamps
         duration = self._get_duration(video_path)
-        sample_times = [duration * 0.1, duration * 0.3, duration * 0.5,
-                       duration * 0.7, duration * 0.9]
+        sample_times = [duration * 0.1, duration * 0.3, duration * 0.5, duration * 0.7, duration * 0.9]
 
         text_elements = []
 
@@ -809,15 +864,10 @@ class DesignQualityGuardrails:
         import os
 
         # Extract frame securely
-        with tempfile.NamedTemporaryFile(suffix='.png', delete=False) as tmp_file:
+        with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as tmp_file:
             frame_path = tmp_file.name
         try:
-            cmd = [
-                'ffmpeg', '-y', '-i', video_path,
-                '-ss', str(time_sec),
-                '-vframes', '1',
-                frame_path
-            ]
+            cmd = ["ffmpeg", "-y", "-i", video_path, "-ss", str(time_sec), "-vframes", "1", frame_path]
             subprocess.run(cmd, capture_output=True, timeout=30)
 
             if not os.path.exists(frame_path):
@@ -825,11 +875,7 @@ class DesignQualityGuardrails:
 
             # Analyze frame for text regions using ffmpeg's signature filter
             # This gives us an estimate of complexity which correlates with text amount
-            cmd = [
-                'ffmpeg', '-y', '-i', frame_path,
-                '-vf', 'signature=format=xml',
-                '-f', 'null', '-'
-            ]
+            cmd = ["ffmpeg", "-y", "-i", frame_path, "-vf", "signature=format=xml", "-f", "null", "-"]
             subprocess.run(cmd, capture_output=True, text=True)
 
             # Return estimated text elements based on common video patterns
@@ -838,9 +884,9 @@ class DesignQualityGuardrails:
             # - Medium subheadings (24-32px)
             # - Body text (16-20px)
             return [
-                {'size': 64, 'type': 'headline'},
-                {'size': 28, 'type': 'subheading'},
-                {'size': 18, 'type': 'body'},
+                {"size": 64, "type": "headline"},
+                {"size": 28, "type": "subheading"},
+                {"size": 18, "type": "body"},
             ]
 
         except Exception:
@@ -862,55 +908,45 @@ class DesignQualityGuardrails:
 
     def _auto_fix_brightness(self, video_path: str, target: float = 128) -> str:
         """Auto-fix brightness by applying gamma correction."""
-        output_path = video_path.replace('.mp4', '_fixed.mp4')
+        output_path = video_path.replace(".mp4", "_fixed.mp4")
 
-        cmd = [
-            'ffmpeg', '-y', '-i', video_path,
-            '-vf', 'eq=brightness=0.1:gamma=1.1',
-            '-c:a', 'copy',
-            output_path
-        ]
+        cmd = ["ffmpeg", "-y", "-i", video_path, "-vf", "eq=brightness=0.1:gamma=1.1", "-c:a", "copy", output_path]
 
         subprocess.run(cmd, capture_output=True, check=True)
         return output_path
 
     def _auto_fix_contrast(self, video_path: str) -> str:
         """Auto-fix contrast."""
-        output_path = video_path.replace('.mp4', '_fixed.mp4')
+        output_path = video_path.replace(".mp4", "_fixed.mp4")
 
-        cmd = [
-            'ffmpeg', '-y', '-i', video_path,
-            '-vf', 'eq=contrast=1.1',
-            '-c:a', 'copy',
-            output_path
-        ]
+        cmd = ["ffmpeg", "-y", "-i", video_path, "-vf", "eq=contrast=1.1", "-c:a", "copy", output_path]
 
         subprocess.run(cmd, capture_output=True, check=True)
         return output_path
 
     def _auto_fix_saturation(self, video_path: str, boost: float = 1.2) -> str:
         """Auto-fix saturation."""
-        output_path = video_path.replace('.mp4', '_fixed.mp4')
+        output_path = video_path.replace(".mp4", "_fixed.mp4")
 
-        cmd = [
-            'ffmpeg', '-y', '-i', video_path,
-            '-vf', f'eq=saturation={boost}',
-            '-c:a', 'copy',
-            output_path
-        ]
+        cmd = ["ffmpeg", "-y", "-i", video_path, "-vf", f"eq=saturation={boost}", "-c:a", "copy", output_path]
 
         subprocess.run(cmd, capture_output=True, check=True)
         return output_path
 
     def _auto_fix_color_cast(self, video_path: str) -> str:
         """Auto-fix color casts."""
-        output_path = video_path.replace('.mp4', '_fixed.mp4')
+        output_path = video_path.replace(".mp4", "_fixed.mp4")
 
         cmd = [
-            'ffmpeg', '-y', '-i', video_path,
-            '-vf', 'colorbalance=rm=0.1:gm=0.1:bm=0.1',
-            '-c:a', 'copy',
-            output_path
+            "ffmpeg",
+            "-y",
+            "-i",
+            video_path,
+            "-vf",
+            "colorbalance=rm=0.1:gm=0.1:bm=0.1",
+            "-c:a",
+            "copy",
+            output_path,
         ]
 
         subprocess.run(cmd, capture_output=True, check=True)
@@ -918,14 +954,9 @@ class DesignQualityGuardrails:
 
     def _auto_normalize_audio(self, video_path: str) -> str:
         """Auto-normalize audio to -16 LUFS."""
-        output_path = video_path.replace('.mp4', '_fixed.mp4')
+        output_path = video_path.replace(".mp4", "_fixed.mp4")
 
-        cmd = [
-            'ffmpeg', '-y', '-i', video_path,
-            '-af', 'loudnorm=I=-16:TP=-1.5:LRA=11',
-            '-c:v', 'copy',
-            output_path
-        ]
+        cmd = ["ffmpeg", "-y", "-i", video_path, "-af", "loudnorm=I=-16:TP=-1.5:LRA=11", "-c:v", "copy", output_path]
 
         subprocess.run(cmd, capture_output=True, check=True)
         return output_path
@@ -941,63 +972,59 @@ class DesignQualityGuardrails:
     def _probe_video(self, video_path: str) -> dict:
         """Get video metadata."""
         cmd = [
-            'ffprobe', '-v', 'error',
-            '-show_entries', 'stream=width,height,r_frame_rate,duration',
-            '-of', 'json',
-            video_path
+            "ffprobe",
+            "-v",
+            "error",
+            "-show_entries",
+            "stream=width,height,r_frame_rate,duration",
+            "-of",
+            "json",
+            video_path,
         ]
         result = subprocess.run(cmd, capture_output=True, text=True)
         data = json.loads(result.stdout)
 
-        if data.get('streams'):
-            return data['streams'][0]
+        if data.get("streams"):
+            return data["streams"][0]
         return {}
 
     def _get_fps(self, video_path: str) -> float:
         """Get video frame rate."""
         probe = self._probe_video(video_path)
-        fps_str = probe.get('r_frame_rate', '30/1')
-        if '/' in fps_str:
-            num, den = fps_str.split('/')
+        fps_str = probe.get("r_frame_rate", "30/1")
+        if "/" in fps_str:
+            num, den = fps_str.split("/")
             return float(num) / float(den)
         return float(fps_str)
 
     def _get_duration(self, video_path: str) -> float:
         """Get video duration in seconds."""
         probe = self._probe_video(video_path)
-        duration = probe.get('duration', 0)
+        duration = probe.get("duration", 0)
         return float(duration) if duration else 0
 
     def _get_mean_luma(self, video_path: str) -> float:
         """Get mean luminance."""
-        cmd = [
-            'ffmpeg', '-i', video_path,
-            '-vf', 'signalstats,metadata=mode=print',
-            '-f', 'null', '-'
-        ]
+        cmd = ["ffmpeg", "-i", video_path, "-vf", "signalstats,metadata=mode=print", "-f", "null", "-"]
         result = subprocess.run(cmd, capture_output=True, text=True)
 
-        for line in result.stderr.split('\n'):
-            if 'lavfi.signalstats.YAVG' in line:
+        for line in result.stderr.split("\n"):
+            if "lavfi.signalstats.YAVG" in line:
                 try:
-                    return float(line.split('=')[-1].strip())
+                    return float(line.split("=")[-1].strip())
                 except Exception:
                     pass
         return 128
 
     def _get_contrast(self, video_path: str) -> float:
         """Get contrast (standard deviation of luminance)."""
-        cmd = [
-            'ffmpeg', '-i', video_path,
-            '-vf', 'signalstats,metadata=mode=print',
-            '-f', 'null', '-'
-        ]
+        cmd = ["ffmpeg", "-i", video_path, "-vf", "signalstats,metadata=mode=print", "-f", "null", "-"]
         result = subprocess.run(cmd, capture_output=True, text=True)
 
-        for line in result.stderr.split('\n'):
-            if 'lavfi.signalstats.YSTD' in line:
+        for line in result.stderr.split("\n"):
+            if "lavfi.signalstats.YSTD" in line:
                 try:
-                    return float(line.split('=')[-1].strip())
+                    return float(line.split("=")[-1].strip())
                 except Exception:
                     pass
         return 50
@@ -1005,21 +1032,17 @@ class DesignQualityGuardrails:
     def _analyze_colors(self, video_path: str) -> dict:
         """Analyze color distribution."""
         # Get mean RGB values
-        cmd = [
-            'ffmpeg', '-i', video_path,
-            '-vf', 'signalstats,metadata=mode=print',
-            '-f', 'null', '-'
-        ]
+        cmd = ["ffmpeg", "-i", video_path, "-vf", "signalstats,metadata=mode=print", "-f", "null", "-"]
         result = subprocess.run(cmd, capture_output=True, text=True)
 
         rgb_means = [128, 128, 128]
-        for line in result.stderr.split('\n'):
-            if 'lavfi.signalstats.UAVG' in line:
+        for line in result.stderr.split("\n"):
+            if "lavfi.signalstats.UAVG" in line:
                 with contextlib.suppress(BaseException):
-                    rgb_means[1] = float(line.split('=')[-1].strip()) + 128
-            elif 'lavfi.signalstats.VAVG' in line:
+                    rgb_means[1] = float(line.split("=")[-1].strip()) + 128
+            elif "lavfi.signalstats.VAVG" in line:
                 try:
-                    val = float(line.split('=')[-1].strip()) + 128
+                    val = float(line.split("=")[-1].strip()) + 128
                     rgb_means[0] = val  # Simplified conversion
                     rgb_means[2] = 255 - val
                 except Exception:
@@ -1028,10 +1051,7 @@ class DesignQualityGuardrails:
         # Calculate saturation estimate
         saturation = max(abs(c - 128) for c in rgb_means) / 128 * 100
 
-        return {
-            'rgb_means': rgb_means,
-            'saturation': saturation
-        }
+        return {"rgb_means": rgb_means, "saturation": saturation}
 
     def _analyze_motion_smoothness(self, video_path: str) -> float:
         """Analyze motion smoothness (0-1)."""
@@ -1061,19 +1081,15 @@ class DesignQualityGuardrails:
 
     def _detect_scene_changes(self, video_path: str) -> list[dict]:
         """Detect scene change timestamps."""
-        cmd = [
-            'ffmpeg', '-i', video_path,
-            '-vf', "select='gt(scene,0.3)',showinfo",
-            '-f', 'null', '-'
-        ]
+        cmd = ["ffmpeg", "-i", video_path, "-vf", "select='gt(scene,0.3)',showinfo", "-f", "null", "-"]
         result = subprocess.run(cmd, capture_output=True, text=True)
 
         scenes = []
-        for line in result.stderr.split('\n'):
-            if 'pts_time:' in line:
+        for line in result.stderr.split("\n"):
+            if "pts_time:" in line:
                 try:
-                    time = float(line.split('pts_time:')[1].split()[0])
-                    scenes.append({'time': time})
+                    time = float(line.split("pts_time:")[1].split()[0])
+                    scenes.append({"time": time})
                 except Exception:
                     pass
         return scenes
@@ -1099,11 +1115,13 @@ class DesignQualityGuardrails:
         transitions = []
 
         for _i, scene in enumerate(scenes):
-            transitions.append({
-                'frame': int(scene['time'] * 30),
-                'time': scene['time'],
-                'duration': 0.5  # estimated
-            })
+            transitions.append(
+                {
+                    "frame": int(scene["time"] * 30),
+                    "time": scene["time"],
+                    "duration": 0.5,  # estimated
+                }
+            )
 
         return transitions
 
@@ -1124,19 +1142,15 @@ class DesignQualityGuardrails:
 
     def _calculate_audio_score(self, video_path: str) -> float:
         """Calculate audio quality score."""
-        cmd = [
-            'ffmpeg', '-i', video_path,
-            '-af', 'loudnorm=print_format=json',
-            '-f', 'null', '-'
-        ]
+        cmd = ["ffmpeg", "-i", video_path, "-af", "loudnorm=print_format=json", "-f", "null", "-"]
         result = subprocess.run(cmd, capture_output=True, text=True)
 
         try:
-            loudness_start = result.stderr.find('{')
-            loudness_end = result.stderr.rfind('}') + 1
+            loudness_start = result.stderr.find("{")
+            loudness_end = result.stderr.rfind("}") + 1
             loudness_data = json.loads(result.stderr[loudness_start:loudness_end])
 
-            input_lufs = float(loudness_data.get('input_i', -70))
+            input_lufs = float(loudness_data.get("input_i", -70))
 
             distance = abs(input_lufs - (-16))
             return max(0, 100 - distance * 5)
@@ -1145,6 +1159,7 @@ class DesignQualityGuardrails:
 
 
 # ============== PUBLIC API ==============
+
 
 def design_quality_check(
     video: str,
@@ -1166,8 +1181,8 @@ def design_quality_check(
 
     if strict:
         for issue in report.issues:
-            if issue.severity == 'warning':
-                issue.severity = 'error'
+            if issue.severity == "warning":
+                issue.severity = "error"
 
     return report
 
@@ -1183,7 +1198,7 @@ def fix_design_issues(video: str, output: str | None = None) -> str:
         Path to fixed video
     """
     if output is None:
-        base, ext = video.rsplit('.', 1)
+        base, ext = video.rsplit(".", 1)
         output = f"{base}_design_fixed.{ext}"
 
     # Run quality check with auto-fix
@@ -1194,25 +1209,26 @@ def fix_design_issues(video: str, output: str | None = None) -> str:
         guardrails = DesignQualityGuardrails()
 
         # Apply brightness fix if needed
-        brightness_issues = [i for i in report.issues if 'brightness' in i.message.lower()]
+        brightness_issues = [i for i in report.issues if "brightness" in i.message.lower()]
         if brightness_issues:
             temp = guardrails._auto_fix_brightness(video)
             video = temp
 
         # Apply saturation fix if needed
-        saturation_issues = [i for i in report.issues if 'saturation' in i.message.lower()]
+        saturation_issues = [i for i in report.issues if "saturation" in i.message.lower()]
         if saturation_issues:
             temp = guardrails._auto_fix_saturation(video)
             video = temp
 
         # Apply audio fix if needed
-        audio_issues = [i for i in report.issues if 'audio' in i.message.lower() or 'lufs' in i.message.lower()]
+        audio_issues = [i for i in report.issues if "audio" in i.message.lower() or "lufs" in i.message.lower()]
         if audio_issues:
             temp = guardrails._auto_normalize_audio(video)
             video = temp
 
         # Copy final result to output
         import shutil
+
         shutil.copy(video, output)
 
     return output

--- a/mcp_video/effects_engine.py
+++ b/mcp_video/effects_engine.py
@@ -58,13 +58,20 @@ def effect_vignette(
     )
 
     cmd = [
-        "ffmpeg", "-y",
-        "-i", input_path,
-        "-vf", filters,
-        "-c:a", "copy",
-        "-c:v", "libx264",
-        "-pix_fmt", "yuv420p",
-        "-crf", "23",
+        "ffmpeg",
+        "-y",
+        "-i",
+        input_path,
+        "-vf",
+        filters,
+        "-c:a",
+        "copy",
+        "-c:v",
+        "libx264",
+        "-pix_fmt",
+        "yuv420p",
+        "-crf",
+        "23",
         output,
     ]
 
@@ -102,19 +109,23 @@ def effect_chromatic_aberration(
     shift_x = int(offset_x)
     shift_y = int(offset_y)
 
-    filters = (
-        f"chromashift=cbh={shift_x}:cbv={shift_y}:"
-        f"crh=-{shift_x}:crv=-{shift_y}"
-    )
+    filters = f"chromashift=cbh={shift_x}:cbv={shift_y}:crh=-{shift_x}:crv=-{shift_y}"
 
     cmd = [
-        "ffmpeg", "-y",
-        "-i", input_path,
-        "-vf", filters,
-        "-c:a", "copy",
-        "-c:v", "libx264",
-        "-pix_fmt", "yuv420p",
-        "-crf", "23",
+        "ffmpeg",
+        "-y",
+        "-i",
+        input_path,
+        "-vf",
+        filters,
+        "-c:a",
+        "copy",
+        "-c:v",
+        "libx264",
+        "-pix_fmt",
+        "yuv420p",
+        "-crf",
+        "23",
         output,
     ]
 
@@ -123,9 +134,7 @@ def effect_chromatic_aberration(
 
     # Fallback if chromashift not available
     if result.returncode != 0 and "chromashift" in result.stderr:
-        filters = (
-            f"colorbalance=rs={intensity/100}:bs=-{intensity/100}"
-        )
+        filters = f"colorbalance=rs={intensity / 100}:bs=-{intensity / 100}"
         cmd[4] = filters
         _run_ffmpeg(cmd)
     elif result.returncode != 0:
@@ -167,13 +176,20 @@ def effect_scanlines(
         filters += f",eq=brightness={flicker}*sin(t*10)"
 
     cmd = [
-        "ffmpeg", "-y",
-        "-i", input_path,
-        "-vf", filters,
-        "-c:a", "copy",
-        "-c:v", "libx264",
-        "-pix_fmt", "yuv420p",
-        "-crf", "23",
+        "ffmpeg",
+        "-y",
+        "-i",
+        input_path,
+        "-vf",
+        filters,
+        "-c:a",
+        "copy",
+        "-c:v",
+        "libx264",
+        "-pix_fmt",
+        "yuv420p",
+        "-crf",
+        "23",
         output,
     ]
 
@@ -207,21 +223,28 @@ def effect_noise(
 
     if mode == "color":
         # Color noise
-        noise_expr = f"lum(X,Y)+{intensity*50}*({seed_expr}*2-1)"
-        filters = f"geq=lum='{noise_expr}':cb='cb(X,Y)+{intensity*30}*({seed_expr}*2-1)':cr='cr(X,Y)+{intensity*30}*({seed_expr}*2-1)'"
+        noise_expr = f"lum(X,Y)+{intensity * 50}*({seed_expr}*2-1)"
+        filters = f"geq=lum='{noise_expr}':cb='cb(X,Y)+{intensity * 30}*({seed_expr}*2-1)':cr='cr(X,Y)+{intensity * 30}*({seed_expr}*2-1)'"
     else:
         # Luminance noise only
         noise_expr = f"lum(X,Y)*(1+{intensity}*({seed_expr}*2-1))"
         filters = f"geq=lum='{noise_expr}'"
 
     cmd = [
-        "ffmpeg", "-y",
-        "-i", input_path,
-        "-vf", filters,
-        "-c:a", "copy",
-        "-c:v", "libx264",
-        "-pix_fmt", "yuv420p",
-        "-crf", "23",
+        "ffmpeg",
+        "-y",
+        "-i",
+        input_path,
+        "-vf",
+        filters,
+        "-c:a",
+        "copy",
+        "-c:v",
+        "libx264",
+        "-pix_fmt",
+        "yuv420p",
+        "-crf",
+        "23",
         output,
     ]
 
@@ -261,13 +284,20 @@ def effect_glow(
     )
 
     cmd = [
-        "ffmpeg", "-y",
-        "-i", input_path,
-        "-vf", filters,
-        "-c:a", "copy",
-        "-c:v", "libx264",
-        "-pix_fmt", "yuv420p",
-        "-crf", "23",
+        "ffmpeg",
+        "-y",
+        "-i",
+        input_path,
+        "-vf",
+        filters,
+        "-c:a",
+        "copy",
+        "-c:v",
+        "libx264",
+        "-pix_fmt",
+        "yuv420p",
+        "-crf",
+        "23",
         output,
     ]
 
@@ -321,12 +351,14 @@ def layout_grid(
         raise ValueError("At least one clip required")
 
     if gap < 0 or padding < 0:
-        raise MCPVideoError("gap and padding must be non-negative", error_type="validation_error", code="invalid_parameter")
+        raise MCPVideoError(
+            "gap and padding must be non-negative", error_type="validation_error", code="invalid_parameter"
+        )
 
     clips = [_validate_input_path(clip) for clip in clips]
 
     # Parse layout
-    cols, rows = map(int, layout.split('x'))
+    cols, rows = map(int, layout.split("x"))
     n_clips = min(len(clips), cols * rows)
 
     # Use even dimensions that work for x264
@@ -376,13 +408,19 @@ def layout_grid(
     filter_complex = "".join(filter_parts).rstrip(";")
 
     cmd = [
-        "ffmpeg", "-y",
+        "ffmpeg",
+        "-y",
         *inputs,
-        "-filter_complex", filter_complex,
-        "-map", "[out]",
-        "-c:v", "libx264",
-        "-pix_fmt", "yuv420p",
-        "-crf", "23",
+        "-filter_complex",
+        filter_complex,
+        "-map",
+        "[out]",
+        "-c:v",
+        "libx264",
+        "-pix_fmt",
+        "yuv420p",
+        "-crf",
+        "23",
         "-shortest",
         output,
     ]
@@ -426,12 +464,19 @@ def layout_pip(
 
     # Get main video dimensions
     probe_cmd = [
-        "ffprobe", "-v", "error", "-select_streams", "v:0",
-        "-show_entries", "stream=width,height", "-of", "csv=s=x:p=0", main,
+        "ffprobe",
+        "-v",
+        "error",
+        "-select_streams",
+        "v:0",
+        "-show_entries",
+        "stream=width,height",
+        "-of",
+        "csv=s=x:p=0",
+        main,
     ]
     probe = _run_ffmpeg(probe_cmd)
-    main_w, main_h = map(int, probe.stdout.strip().split('x'))
-
+    main_w, main_h = map(int, probe.stdout.strip().split("x"))
 
     # Calculate PIP dimensions
     pip_w = int(main_w * size)
@@ -451,27 +496,32 @@ def layout_pip(
 
     if border:
         # Add border using pad
-        pip_filters += f",pad={pip_w + border_width*2}:{pip_h + border_width*2}:{border_width}:{border_width}:color={border_color}"
+        pip_filters += f",pad={pip_w + border_width * 2}:{pip_h + border_width * 2}:{border_width}:{border_width}:color={border_color}"
 
     if rounded_corners:
         # Use format and drawbox for rounded corners simulation
         # This is a simplified version - full rounded corners need more complex filter
         pass
 
-    filter_complex = (
-        f"[1:v]{pip_filters}[pip];"
-        f"[0:v][pip]overlay={x}:{y}"
-    )
+    filter_complex = f"[1:v]{pip_filters}[pip];[0:v][pip]overlay={x}:{y}"
 
     cmd = [
-        "ffmpeg", "-y",
-        "-i", main,
-        "-i", pip,
-        "-filter_complex", filter_complex,
-        "-c:v", "libx264",
-        "-c:a", "copy",
-        "-pix_fmt", "yuv420p",
-        "-crf", "23",
+        "ffmpeg",
+        "-y",
+        "-i",
+        main,
+        "-i",
+        pip,
+        "-filter_complex",
+        filter_complex,
+        "-c:v",
+        "libx264",
+        "-c:a",
+        "copy",
+        "-pix_fmt",
+        "yuv420p",
+        "-crf",
+        "23",
         output,
     ]
 
@@ -561,13 +611,20 @@ def text_animated(
     )
 
     cmd = [
-        "ffmpeg", "-y",
-        "-i", video,
-        "-vf", filter_complex,
-        "-c:v", "libx264",
-        "-c:a", "copy",
-        "-pix_fmt", "yuv420p",
-        "-crf", "23",
+        "ffmpeg",
+        "-y",
+        "-i",
+        video,
+        "-vf",
+        filter_complex,
+        "-c:v",
+        "libx264",
+        "-c:a",
+        "copy",
+        "-pix_fmt",
+        "yuv420p",
+        "-crf",
+        "23",
         output,
     ]
 
@@ -628,13 +685,20 @@ def text_subtitles(
     )
 
     cmd = [
-        "ffmpeg", "-y",
-        "-i", video,
-        "-vf", filter_complex,
-        "-c:v", "libx264",
-        "-c:a", "copy",
-        "-pix_fmt", "yuv420p",
-        "-crf", "23",
+        "ffmpeg",
+        "-y",
+        "-i",
+        video,
+        "-vf",
+        filter_complex,
+        "-c:v",
+        "libx264",
+        "-c:a",
+        "copy",
+        "-pix_fmt",
+        "yuv420p",
+        "-crf",
+        "23",
         output,
     ]
 
@@ -694,10 +758,16 @@ def mograph_count(
                 text_filter += f":box=1:boxcolor={color}@0.3:boxborderw=10"
 
             cmd = [
-                "ffmpeg", "-y",
-                "-f", "lavfi", "-i", "color=c=black:s=1920x1080:d=1",
-                "-vf", text_filter,
-                "-vframes", "1",
+                "ffmpeg",
+                "-y",
+                "-f",
+                "lavfi",
+                "-i",
+                "color=c=black:s=1920x1080:d=1",
+                "-vf",
+                text_filter,
+                "-vframes",
+                "1",
                 str(frame_file),
             ]
 
@@ -705,12 +775,18 @@ def mograph_count(
 
         # Combine frames into video
         cmd = [
-            "ffmpeg", "-y",
-            "-framerate", str(fps),
-            "-i", str(tmp_path / "frame_%05d.png"),
-            "-c:v", "libx264",
-            "-pix_fmt", "yuv420p",
-            "-crf", "23",
+            "ffmpeg",
+            "-y",
+            "-framerate",
+            str(fps),
+            "-i",
+            str(tmp_path / "frame_%05d.png"),
+            "-c:v",
+            "libx264",
+            "-pix_fmt",
+            "yuv420p",
+            "-crf",
+            "23",
             output,
         ]
 
@@ -774,10 +850,16 @@ def mograph_progress(
                 filter_chain = filter_chain.rstrip(",")
 
             cmd = [
-                "ffmpeg", "-y",
-                "-f", "lavfi", "-i", "color=c=black:s=1920x1080:d=1",
-                "-vf", filter_chain,
-                "-vframes", "1",
+                "ffmpeg",
+                "-y",
+                "-f",
+                "lavfi",
+                "-i",
+                "color=c=black:s=1920x1080:d=1",
+                "-vf",
+                filter_chain,
+                "-vframes",
+                "1",
                 str(frame_file),
             ]
 
@@ -785,12 +867,18 @@ def mograph_progress(
 
         # Combine frames
         cmd = [
-            "ffmpeg", "-y",
-            "-framerate", str(fps),
-            "-i", str(tmp_path / "frame_%05d.png"),
-            "-c:v", "libx264",
-            "-pix_fmt", "yuv420p",
-            "-crf", "23",
+            "ffmpeg",
+            "-y",
+            "-framerate",
+            str(fps),
+            "-i",
+            str(tmp_path / "frame_%05d.png"),
+            "-c:v",
+            "libx264",
+            "-pix_fmt",
+            "yuv420p",
+            "-crf",
+            "23",
             output,
         ]
 
@@ -820,9 +908,13 @@ def video_info_detailed(video: str) -> dict[str, Any]:
 
     # Get basic info
     cmd = [
-        "ffprobe", "-v", "error",
-        "-show_format", "-show_streams",
-        "-print_format", "json",
+        "ffprobe",
+        "-v",
+        "error",
+        "-show_format",
+        "-show_streams",
+        "-print_format",
+        "json",
         video,
     ]
 
@@ -860,9 +952,14 @@ def video_info_detailed(video: str) -> dict[str, Any]:
     scene_changes = []
     try:
         scene_cmd = [
-            "ffmpeg", "-i", video,
-            "-filter:v", "select='gt(scene,0.3)',showinfo",
-            "-f", "null", "-",
+            "ffmpeg",
+            "-i",
+            video,
+            "-filter:v",
+            "select='gt(scene,0.3)',showinfo",
+            "-f",
+            "null",
+            "-",
         ]
         scene_result = subprocess.run(scene_cmd, capture_output=True, text=True, timeout=30)
         # Parse scene change timestamps from stderr
@@ -909,16 +1006,19 @@ def auto_chapters(
     _validate_input_path(video)
 
     if not isinstance(threshold, (int, float)) or not (0.0 <= threshold <= 1.0):
-        raise MCPVideoError(
-            f"threshold must be a number between 0.0 and 1.0, got {threshold!r}"
-        )
+        raise MCPVideoError(f"threshold must be a number between 0.0 and 1.0, got {threshold!r}")
 
     chapters = []
 
     cmd = [
-        "ffmpeg", "-i", video,
-        "-filter:v", f"select='gt(scene,{threshold})',showinfo",
-        "-f", "null", "-",
+        "ffmpeg",
+        "-i",
+        video,
+        "-filter:v",
+        f"select='gt(scene,{threshold})',showinfo",
+        "-f",
+        "null",
+        "-",
     ]
 
     result = _run_ffmpeg(cmd, timeout=60)

--- a/mcp_video/engine.py
+++ b/mcp_video/engine.py
@@ -51,6 +51,7 @@ from .ffmpeg_helpers import _escape_ffmpeg_filter_value
 # FFmpeg / FFprobe availability
 # ---------------------------------------------------------------------------
 
+
 def _find_executable(name: str) -> str:
     path = shutil.which(name)
     if path is None:
@@ -82,7 +83,9 @@ def _check_filter_available(name: str) -> bool:
     if _AVAILABLE_FILTERS is None:
         proc = subprocess.run(
             [_ffmpeg(), "-filters"],
-            capture_output=True, text=True, timeout=10,
+            capture_output=True,
+            text=True,
+            timeout=10,
         )
         _AVAILABLE_FILTERS = set()
         for line in proc.stdout.split("\n"):
@@ -104,8 +107,7 @@ def _require_filter(name: str, feature: str) -> None:
             code=f"missing_filter_{name}",
             suggested_action={
                 "auto_fix": False,
-                "description": f"Reinstall FFmpeg with {name} support. "
-                               "On macOS: brew reinstall ffmpeg",
+                "description": f"Reinstall FFmpeg with {name} support. On macOS: brew reinstall ffmpeg",
             },
         )
 
@@ -113,6 +115,7 @@ def _require_filter(name: str, feature: str) -> None:
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def _validate_input(path: str) -> None:
     if "\x00" in path:
@@ -128,33 +131,127 @@ def _sanitize_ffmpeg_number(value: Any, name: str) -> float:
     except (TypeError, ValueError):
         raise MCPVideoError(
             f"Invalid {name}: expected number, got {type(value).__name__}",
-            error_type="validation_error", code="invalid_parameter",
+            error_type="validation_error",
+            code="invalid_parameter",
         ) from None
 
 
-_CSS_COLOR_NAMES = frozenset({
-    "white", "black", "red", "green", "blue", "yellow", "cyan", "magenta",
-    "orange", "purple", "pink", "brown", "gray", "grey", "silver", "gold",
-    "navy", "teal", "maroon", "olive", "lime", "aqua", "fuchsia", "indigo",
-    "violet", "coral", "salmon", "tomato", "khaki", "lavender", "turquoise",
-    "tan", "wheat", "ivory", "beige", "linen", "snow", "mintcream", "azure",
-    "aliceblue", "ghostwhite", "honeydew", "seashell", "whitesmoke",
-    "oldlace", "floralwhite", "cornsilk", "lemonchiffon", "lightyellow",
-    "lightcyan", "paleturquoise", "powderblue", "lightblue", "skyblue",
-    "lightskyblue", "steelblue", "dodgerblue", "deepskyblue",
-    "cornflowerblue", "royalblue", "mediumblue", "darkblue", "midnightblue",
-    "slateblue", "darkslateblue", "mediumpurple", "blueviolet", "darkviolet",
-    "darkorchid", "mediumorchid", "orchid", "plum", "mediumvioletred",
-    "palevioletred", "hotpink", "deeppink", "lightpink", "rosybrown",
-    "indianred", "firebrick", "darkred", "crimson", "orangered",
-    "lightsalmon", "darksalmon", "lightcoral", "peachpuff", "bisque",
-    "moccasin", "navajowhite", "sandybrown", "chocolate", "saddlebrown",
-    "sienna", "burlywood", "peru", "darkgoldenrod", "goldenrod",
-    "lightgoldenrod", "darkkhaki", "chartreuse", "greenyellow",
-    "springgreen", "mediumspringgreen", "lawngreen", "darkgreen",
-    "forestgreen", "seagreen", "darkseagreen", "lightgreen", "palegreen",
-    "limegreen",
-})
+_CSS_COLOR_NAMES = frozenset(
+    {
+        "white",
+        "black",
+        "red",
+        "green",
+        "blue",
+        "yellow",
+        "cyan",
+        "magenta",
+        "orange",
+        "purple",
+        "pink",
+        "brown",
+        "gray",
+        "grey",
+        "silver",
+        "gold",
+        "navy",
+        "teal",
+        "maroon",
+        "olive",
+        "lime",
+        "aqua",
+        "fuchsia",
+        "indigo",
+        "violet",
+        "coral",
+        "salmon",
+        "tomato",
+        "khaki",
+        "lavender",
+        "turquoise",
+        "tan",
+        "wheat",
+        "ivory",
+        "beige",
+        "linen",
+        "snow",
+        "mintcream",
+        "azure",
+        "aliceblue",
+        "ghostwhite",
+        "honeydew",
+        "seashell",
+        "whitesmoke",
+        "oldlace",
+        "floralwhite",
+        "cornsilk",
+        "lemonchiffon",
+        "lightyellow",
+        "lightcyan",
+        "paleturquoise",
+        "powderblue",
+        "lightblue",
+        "skyblue",
+        "lightskyblue",
+        "steelblue",
+        "dodgerblue",
+        "deepskyblue",
+        "cornflowerblue",
+        "royalblue",
+        "mediumblue",
+        "darkblue",
+        "midnightblue",
+        "slateblue",
+        "darkslateblue",
+        "mediumpurple",
+        "blueviolet",
+        "darkviolet",
+        "darkorchid",
+        "mediumorchid",
+        "orchid",
+        "plum",
+        "mediumvioletred",
+        "palevioletred",
+        "hotpink",
+        "deeppink",
+        "lightpink",
+        "rosybrown",
+        "indianred",
+        "firebrick",
+        "darkred",
+        "crimson",
+        "orangered",
+        "lightsalmon",
+        "darksalmon",
+        "lightcoral",
+        "peachpuff",
+        "bisque",
+        "moccasin",
+        "navajowhite",
+        "sandybrown",
+        "chocolate",
+        "saddlebrown",
+        "sienna",
+        "burlywood",
+        "peru",
+        "darkgoldenrod",
+        "goldenrod",
+        "lightgoldenrod",
+        "darkkhaki",
+        "chartreuse",
+        "greenyellow",
+        "springgreen",
+        "mediumspringgreen",
+        "lawngreen",
+        "darkgreen",
+        "forestgreen",
+        "seagreen",
+        "darkseagreen",
+        "lightgreen",
+        "palegreen",
+        "limegreen",
+    }
+)
 
 _HEX_COLOR_RE = re.compile(r"^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$")
 _FFMPEG_SPECIAL_CHARS = set(":=;'[]\\")
@@ -169,12 +266,14 @@ def _validate_color(color: str) -> None:
     if not isinstance(color, str):
         raise MCPVideoError(
             "invalid_color: value must be a string",
-            error_type="validation_error", code="invalid_color",
+            error_type="validation_error",
+            code="invalid_color",
         )
     if any(c in _FFMPEG_SPECIAL_CHARS for c in color):
         raise MCPVideoError(
             "invalid_color: contains FFmpeg special characters",
-            error_type="validation_error", code="invalid_color",
+            error_type="validation_error",
+            code="invalid_color",
         )
     if color.lower() in _CSS_COLOR_NAMES:
         return
@@ -182,7 +281,8 @@ def _validate_color(color: str) -> None:
         return
     raise MCPVideoError(
         "invalid_color: not a recognized CSS name or hex color",
-        error_type="validation_error", code="invalid_color",
+        error_type="validation_error",
+        code="invalid_color",
     )
 
 
@@ -195,13 +295,15 @@ def _validate_chroma_color(color: str) -> None:
     if not isinstance(color, str) or len(color) != 8 or not color.startswith("0x"):
         raise MCPVideoError(
             "color must be in 0xRRGGBB format (e.g. 0x00FF00)",
-            error_type="validation_error", code="invalid_parameter",
+            error_type="validation_error",
+            code="invalid_parameter",
         )
     hex_part = color[2:]
     if not all(c in "0123456789abcdefABCDEF" for c in hex_part):
         raise MCPVideoError(
             "color must contain only hex characters (0-9, a-f, A-F) after 0x prefix",
-            error_type="validation_error", code="invalid_parameter",
+            error_type="validation_error",
+            code="invalid_parameter",
         )
 
 
@@ -295,7 +397,10 @@ def _run_ffmpeg_with_progress(
     on_progress(100.0)
 
     return subprocess.CompletedProcess(
-        cmd, proc.returncode, "", stderr,
+        cmd,
+        proc.returncode,
+        "",
+        stderr,
     )
 
 
@@ -310,11 +415,16 @@ def _generate_thumbnail_base64(video_path: str) -> str | None:
 
         proc = subprocess.run(
             [
-                _ffmpeg(), "-y",
-                "-i", video_path,
-                "-vframes", "1",
-                "-q:v", "5",
-                "-vf", "scale=320:-1",
+                _ffmpeg(),
+                "-y",
+                "-i",
+                video_path,
+                "-vframes",
+                "1",
+                "-q:v",
+                "5",
+                "-vf",
+                "scale=320:-1",
                 tmp_path,
             ],
             capture_output=True,
@@ -336,8 +446,10 @@ def _generate_thumbnail_base64(video_path: str) -> str | None:
 def _run_ffprobe_json(path: str) -> dict[str, Any]:
     cmd = [
         _ffprobe(),
-        "-v", "quiet",
-        "-print_format", "json",
+        "-v",
+        "quiet",
+        "-print_format",
+        "json",
         "-show_format",
         "-show_streams",
         path,
@@ -380,14 +492,26 @@ def _validate_position(position: Position) -> None:
         for key in ("x_pct", "y_pct"):
             val = position[key]
             if not isinstance(val, (int, float)) or isinstance(val, bool):
-                raise MCPVideoError(f"Invalid position: {position}. Must be a named position (top-left, top-center, etc.) or a dict with 'x'/'y' keys", error_type="validation_error", code="invalid_parameter")
+                raise MCPVideoError(
+                    f"Invalid position: {position}. Must be a named position (top-left, top-center, etc.) or a dict with 'x'/'y' keys",
+                    error_type="validation_error",
+                    code="invalid_parameter",
+                )
             if not (0.0 <= float(val) <= 1.0):
-                raise MCPVideoError(f"Invalid position: {position}. Must be a named position (top-left, top-center, etc.) or a dict with 'x'/'y' keys", error_type="validation_error", code="invalid_parameter")
+                raise MCPVideoError(
+                    f"Invalid position: {position}. Must be a named position (top-left, top-center, etc.) or a dict with 'x'/'y' keys",
+                    error_type="validation_error",
+                    code="invalid_parameter",
+                )
     elif "x" in position and "y" in position:
         for key in ("x", "y"):
             val = position[key]
             if not isinstance(val, (int, float)) or isinstance(val, bool):
-                raise MCPVideoError(f"Invalid position: {position}. Must be a named position (top-left, top-center, etc.) or a dict with 'x'/'y' keys", error_type="validation_error", code="invalid_parameter")
+                raise MCPVideoError(
+                    f"Invalid position: {position}. Must be a named position (top-left, top-center, etc.) or a dict with 'x'/'y' keys",
+                    error_type="validation_error",
+                    code="invalid_parameter",
+                )
     else:
         raise MCPVideoError(
             "Position dict must have 'x'+'y' (pixels) or 'x_pct'+'y_pct' (percentage)",
@@ -460,6 +584,7 @@ def _resolve_position(
 def _default_font() -> str:
     """Return a sensible default font path for the current OS."""
     import platform
+
     system = platform.system()
     if system == "Darwin":
         return "/System/Library/Fonts/Helvetica.ttc"
@@ -498,6 +623,7 @@ def _has_audio(data: dict) -> bool:
 # ---------------------------------------------------------------------------
 # Probe
 # ---------------------------------------------------------------------------
+
 
 def probe(path: str) -> VideoInfo:
     """Get metadata about a video file using ffprobe."""
@@ -563,17 +689,36 @@ def get_duration(path: str) -> float:
 # Normalize — convert to H.264/AAC for editing
 # ---------------------------------------------------------------------------
 
+
 def normalize(input_path: str, output_path: str | None = None) -> str:
     """Normalize a video to H.264 video + AAC audio for reliable editing."""
     _validate_input(input_path)
     output = output_path or _auto_output(input_path, "normalized")
-    _run_ffmpeg(["-i", input_path, "-c:v", "libx264", "-preset", "fast", "-crf", "23", "-c:a", "aac", "-b:a", "128k", *_movflags_args(output), output])
+    _run_ffmpeg(
+        [
+            "-i",
+            input_path,
+            "-c:v",
+            "libx264",
+            "-preset",
+            "fast",
+            "-crf",
+            "23",
+            "-c:a",
+            "aac",
+            "-b:a",
+            "128k",
+            *_movflags_args(output),
+            output,
+        ]
+    )
     return output
 
 
 # ---------------------------------------------------------------------------
 # Core operations
 # ---------------------------------------------------------------------------
+
 
 def trim(
     input_path: str,
@@ -594,7 +739,22 @@ def trim(
         args.extend(["-t", str(duration)])
     elif end:
         args.extend(["-to", str(end)])
-    args.extend(["-c:v", "libx264", "-preset", "fast", "-crf", "23", "-c:a", "aac", "-b:a", "128k", *_movflags_args(output), output])
+    args.extend(
+        [
+            "-c:v",
+            "libx264",
+            "-preset",
+            "fast",
+            "-crf",
+            "23",
+            "-c:a",
+            "aac",
+            "-b:a",
+            "128k",
+            *_movflags_args(output),
+            output,
+        ]
+    )
     _run_ffmpeg(args)
 
     info = probe(output)
@@ -647,15 +807,31 @@ def merge(
         if needs_normalize:
             for i, clip in enumerate(clips):
                 norm_path = os.path.join(tmpdir, f"clip_{i:04d}.mp4")
-                _run_ffmpeg([
-                    "-i", clip,
-                    "-vf", f"scale={target_w}:{target_h}:force_original_aspect_ratio=decrease,pad={target_w}:{target_h}:(ow-iw)/2:(oh-ih)/2",
-                    "-c:v", "libx264", "-preset", "fast", "-crf", "23",
-                    "-c:a", "aac", "-b:a", "128k",
-                    "-r", "30",
-                    "-ar", "44100", "-ac", "2",
-                    norm_path,
-                ])
+                _run_ffmpeg(
+                    [
+                        "-i",
+                        clip,
+                        "-vf",
+                        f"scale={target_w}:{target_h}:force_original_aspect_ratio=decrease,pad={target_w}:{target_h}:(ow-iw)/2:(oh-ih)/2",
+                        "-c:v",
+                        "libx264",
+                        "-preset",
+                        "fast",
+                        "-crf",
+                        "23",
+                        "-c:a",
+                        "aac",
+                        "-b:a",
+                        "128k",
+                        "-r",
+                        "30",
+                        "-ar",
+                        "44100",
+                        "-ac",
+                        "2",
+                        norm_path,
+                    ]
+                )
                 working_clips.append(norm_path)
         else:
             working_clips = list(clips)
@@ -680,7 +856,9 @@ def merge(
                     # Escape single quotes for FFmpeg concat demuxer
                     abs_path = os.path.abspath(clip).replace("'", "'\\''")
                     f.write(f"file '{abs_path}'\n")
-            _run_ffmpeg(["-f", "concat", "-safe", "0", "-i", concat_file, "-c", "copy", *_movflags_args(output), output])
+            _run_ffmpeg(
+                ["-f", "concat", "-safe", "0", "-i", concat_file, "-c", "copy", *_movflags_args(output), output]
+            )
 
     finally:
         shutil.rmtree(tmpdir, ignore_errors=True)
@@ -727,7 +905,7 @@ def _merge_with_transitions(
         if transition_duration >= clip_dur:
             raise MCPVideoError(
                 f"Transition duration ({transition_duration}s) must be less than "
-                f"clip {i+1} duration ({clip_dur:.1f}s)",
+                f"clip {i + 1} duration ({clip_dur:.1f}s)",
                 code="transition_too_long",
             )
         cumulative += clip_dur - transition_duration
@@ -749,7 +927,9 @@ def _merge_with_transitions(
         in2 = labels[i + 1]
         out = f"xt{i}" if i < pairs - 1 else "vout"
         xfade_type = transition_types[i].replace("-", "")
-        filter_parts.append(f"[{in1}][{in2}]xfade=transition={xfade_type}:offset={offsets[i]:.3f}:duration={transition_duration:.3f}[{out}]")
+        filter_parts.append(
+            f"[{in1}][{in2}]xfade=transition={xfade_type}:offset={offsets[i]:.3f}:duration={transition_duration:.3f}[{out}]"
+        )
         labels[i + 1] = out
 
     filter_str = ";".join(filter_parts)
@@ -770,7 +950,21 @@ def _merge_with_transitions(
         audio_codec_args = ["-an"]
 
     _run_ffmpeg(
-        [*inputs, "-filter_complex", filter_complex, *map_args, "-c:v", "libx264", "-preset", "fast", "-crf", "23", *audio_codec_args, *_movflags_args(output), output]
+        [
+            *inputs,
+            "-filter_complex",
+            filter_complex,
+            *map_args,
+            "-c:v",
+            "libx264",
+            "-preset",
+            "fast",
+            "-crf",
+            "23",
+            *audio_codec_args,
+            *_movflags_args(output),
+            output,
+        ]
     )
 
 
@@ -807,7 +1001,14 @@ def add_text(
     # Escape FFmpeg drawtext special characters
     # Colons and backslashes must be escaped even inside single quotes
     # because FFmpeg parses filter options as key=value pairs with : delimiters
-    escaped_text = text.replace("\\", "\\\\").replace("'", "'\\''").replace(":", "\\:").replace("[", "\\[").replace("]", "\\]").replace(";", "\\;")
+    escaped_text = (
+        text.replace("\\", "\\\\")
+        .replace("'", "'\\''")
+        .replace(":", "\\:")
+        .replace("[", "\\[")
+        .replace("]", "\\]")
+        .replace(";", "\\;")
+    )
 
     filter_parts = [
         f"drawtext=text='{escaped_text}'",
@@ -829,7 +1030,21 @@ def add_text(
 
     vf = ":".join(filter_parts)
 
-    _run_ffmpeg(["-i", input_path, "-vf", vf, "-c:v", "libx264", *_quality_args(crf=crf, preset=preset), "-c:a", "copy", *_movflags_args(output), output])
+    _run_ffmpeg(
+        [
+            "-i",
+            input_path,
+            "-vf",
+            vf,
+            "-c:v",
+            "libx264",
+            *_quality_args(crf=crf, preset=preset),
+            "-c:a",
+            "copy",
+            *_movflags_args(output),
+            output,
+        ]
+    )
 
     info = probe(output)
     return EditResult(
@@ -875,13 +1090,30 @@ def add_audio(
         if start_time:
             delay = f"[1:a]adelay={int(start_time * 1000)}|{int(start_time * 1000)},"
 
-        filter_complex = (
-            f"[0:a]anull[a0];"
-            f"{delay}[1:a]{af}[a1];"
-            f"[a0][a1]amix=inputs=2:duration=longest[aout]"
-        )
+        filter_complex = f"[0:a]anull[a0];{delay}[1:a]{af}[a1];[a0][a1]amix=inputs=2:duration=longest[aout]"
 
-        _run_ffmpeg(["-i", video_path, "-i", audio_path, "-filter_complex", filter_complex, "-map", "0:v", "-map", "[aout]", "-c:v", "copy", "-c:a", "aac", "-b:a", "128k", *_movflags_args(output), output])
+        _run_ffmpeg(
+            [
+                "-i",
+                video_path,
+                "-i",
+                audio_path,
+                "-filter_complex",
+                filter_complex,
+                "-map",
+                "0:v",
+                "-map",
+                "[aout]",
+                "-c:v",
+                "copy",
+                "-c:a",
+                "aac",
+                "-b:a",
+                "128k",
+                *_movflags_args(output),
+                output,
+            ]
+        )
     else:
         # Replace audio (or add if no existing audio)
         args = ["-i", video_path, "-i", audio_path]
@@ -940,8 +1172,7 @@ def resize(
         w, h = ASPECT_RATIOS[aspect_ratio]
     elif aspect_ratio:
         raise MCPVideoError(
-            f"Unknown aspect ratio: {aspect_ratio}. "
-            f"Available: {', '.join(ASPECT_RATIOS.keys())}",
+            f"Unknown aspect ratio: {aspect_ratio}. Available: {', '.join(ASPECT_RATIOS.keys())}",
             error_type="input_error",
             code="invalid_aspect_ratio",
         )
@@ -960,12 +1191,28 @@ def resize(
     output = output_path or _auto_output(input_path, f"{w}x{h}")
 
     # Scale to fit within target, then pad to exact dimensions
-    vf = (
-        f"scale={w}:{h}:force_original_aspect_ratio=decrease,"
-        f"pad={w}:{h}:(ow-iw)/2:(oh-ih)/2:black"
-    )
+    vf = f"scale={w}:{h}:force_original_aspect_ratio=decrease,pad={w}:{h}:(ow-iw)/2:(oh-ih)/2:black"
 
-    _run_ffmpeg(["-i", input_path, "-vf", vf, "-c:v", "libx264", "-crf", str(preset["crf"]), "-preset", preset["preset"], "-c:a", "aac", "-b:a", "128k", *_movflags_args(output), output])
+    _run_ffmpeg(
+        [
+            "-i",
+            input_path,
+            "-vf",
+            vf,
+            "-c:v",
+            "libx264",
+            "-crf",
+            str(preset["crf"]),
+            "-preset",
+            preset["preset"],
+            "-c:a",
+            "aac",
+            "-b:a",
+            "128k",
+            *_movflags_args(output),
+            output,
+        ]
+    )
 
     info = probe(output)
     return EditResult(
@@ -1015,45 +1262,106 @@ def convert(
         passlogdir = tempfile.mkdtemp(prefix="mcp_video_2pass_")
         try:
             passlogfile = os.path.join(passlogdir, "pass")
-            _run_ffmpeg([
-                "-i", input_path,
-                "-c:v", "libx264",
-                "-b:v", f"{target_bitrate}k",
-                "-pass", "1",
-                "-passlogfile", passlogfile,
-                "-an", "-f", "null", os.devnull,
-            ])
-            _run_ffmpeg(["-i", input_path, "-c:v", "libx264", "-b:v", f"{target_bitrate}k", "-pass", "2", "-passlogfile", passlogfile, "-preset", preset["preset"], "-c:a", "aac", "-b:a", "128k", *_movflags_args(output), output])
+            _run_ffmpeg(
+                [
+                    "-i",
+                    input_path,
+                    "-c:v",
+                    "libx264",
+                    "-b:v",
+                    f"{target_bitrate}k",
+                    "-pass",
+                    "1",
+                    "-passlogfile",
+                    passlogfile,
+                    "-an",
+                    "-f",
+                    "null",
+                    os.devnull,
+                ]
+            )
+            _run_ffmpeg(
+                [
+                    "-i",
+                    input_path,
+                    "-c:v",
+                    "libx264",
+                    "-b:v",
+                    f"{target_bitrate}k",
+                    "-pass",
+                    "2",
+                    "-passlogfile",
+                    passlogfile,
+                    "-preset",
+                    preset["preset"],
+                    "-c:a",
+                    "aac",
+                    "-b:a",
+                    "128k",
+                    *_movflags_args(output),
+                    output,
+                ]
+            )
         finally:
             shutil.rmtree(passlogdir, ignore_errors=True)
     elif format == "mp4":
-        _run_ffmpeg_with_progress([
-            "-i", input_path,
-            "-c:v", "libx264",
-            "-crf", str(preset["crf"]),
-            "-preset", preset["preset"],
-            "-c:a", "aac", "-b:a", "128k",
-            "-movflags", "+faststart",
-            output,
-        ], estimated_duration=input_info.duration, on_progress=on_progress)
+        _run_ffmpeg_with_progress(
+            [
+                "-i",
+                input_path,
+                "-c:v",
+                "libx264",
+                "-crf",
+                str(preset["crf"]),
+                "-preset",
+                preset["preset"],
+                "-c:a",
+                "aac",
+                "-b:a",
+                "128k",
+                "-movflags",
+                "+faststart",
+                output,
+            ],
+            estimated_duration=input_info.duration,
+            on_progress=on_progress,
+        )
     elif format == "webm":
-        _run_ffmpeg_with_progress([
-            "-i", input_path,
-            "-c:v", "libvpx-vp9",
-            "-crf", str(preset["crf"]),
-            "-b:v", "0",
-            "-c:a", "libopus",
-            output,
-        ], estimated_duration=input_info.duration, on_progress=on_progress)
+        _run_ffmpeg_with_progress(
+            [
+                "-i",
+                input_path,
+                "-c:v",
+                "libvpx-vp9",
+                "-crf",
+                str(preset["crf"]),
+                "-b:v",
+                "0",
+                "-c:a",
+                "libopus",
+                output,
+            ],
+            estimated_duration=input_info.duration,
+            on_progress=on_progress,
+        )
     elif format == "mov":
-        _run_ffmpeg_with_progress([
-            "-i", input_path,
-            "-c:v", "libx264",
-            "-crf", str(preset["crf"]),
-            "-preset", preset["preset"],
-            "-c:a", "pcm_s16le",
-            output,
-        ], estimated_duration=input_info.duration, on_progress=on_progress)
+        _run_ffmpeg_with_progress(
+            [
+                "-i",
+                input_path,
+                "-c:v",
+                "libx264",
+                "-crf",
+                str(preset["crf"]),
+                "-preset",
+                preset["preset"],
+                "-c:a",
+                "pcm_s16le",
+                output,
+            ],
+            estimated_duration=input_info.duration,
+            on_progress=on_progress,
+        )
     elif format == "gif":
         # Two-pass palette-based GIF generation for quality
         # Scale by quality level: low=320, medium=480, high=640, ultra=800
@@ -1062,17 +1370,30 @@ def convert(
         tmpdir = tempfile.mkdtemp(prefix="mcp_video_gif_")
         try:
             palette = os.path.join(tmpdir, "palette.png")
-            _run_ffmpeg([
-                "-i", input_path,
-                "-vf", f"fps=15,scale={width}:-1:flags=lanczos,palettegen",
-                "-y", palette,
-            ])
-            _run_ffmpeg_with_progress([
-                "-i", input_path,
-                "-i", palette,
-                "-lavfi", f"fps=15,scale={width}:-1:flags=lanczos [x]; [x][1:v] paletteuse",
-                "-y", output,
-            ], estimated_duration=input_info.duration, on_progress=on_progress)
+            _run_ffmpeg(
+                [
+                    "-i",
+                    input_path,
+                    "-vf",
+                    f"fps=15,scale={width}:-1:flags=lanczos,palettegen",
+                    "-y",
+                    palette,
+                ]
+            )
+            _run_ffmpeg_with_progress(
+                [
+                    "-i",
+                    input_path,
+                    "-i",
+                    palette,
+                    "-lavfi",
+                    f"fps=15,scale={width}:-1:flags=lanczos [x]; [x][1:v] paletteuse",
+                    "-y",
+                    output,
+                ],
+                estimated_duration=input_info.duration,
+                on_progress=on_progress,
+            )
         finally:
             shutil.rmtree(tmpdir, ignore_errors=True)
     else:
@@ -1120,7 +1441,7 @@ def speed(
     output = output_path or _auto_output(input_path, f"speed_{factor}x")
 
     # Use setpts for video, atempo for audio
-    video_filter = f"setpts={1/factor}*PTS"
+    video_filter = f"setpts={1 / factor}*PTS"
     audio_filter = f"atempo={factor}"
 
     # atempo only supports 0.5 to 100.0; chain if needed
@@ -1130,7 +1451,11 @@ def speed(
         while factor ** (1 / chain_count) < 0.5:
             chain_count += 1
             if chain_count > MAX_SPEED_CHAIN_COUNT:
-                raise MCPVideoError("Speed factor too extreme: would require more than 20 atempo filters", error_type="validation_error", code="invalid_parameter")
+                raise MCPVideoError(
+                    "Speed factor too extreme: would require more than 20 atempo filters",
+                    error_type="validation_error",
+                    code="invalid_parameter",
+                )
         tempo_val = factor ** (1 / chain_count)
         audio_filter = ",".join([f"atempo={tempo_val}"] * chain_count)
     elif factor > 100:
@@ -1138,7 +1463,11 @@ def speed(
         while factor ** (1 / chain_count) > 100:
             chain_count += 1
             if chain_count > MAX_SPEED_CHAIN_COUNT:
-                raise MCPVideoError("Speed factor too extreme: would require more than 20 atempo filters", error_type="validation_error", code="invalid_parameter")
+                raise MCPVideoError(
+                    "Speed factor too extreme: would require more than 20 atempo filters",
+                    error_type="validation_error",
+                    code="invalid_parameter",
+                )
         tempo_val = factor ** (1 / chain_count)
         audio_filter = ",".join([f"atempo={tempo_val}"] * chain_count)
 
@@ -1147,9 +1476,48 @@ def speed(
     has_audio = info.audio_codec is not None
 
     if has_audio:
-        _run_ffmpeg(["-i", input_path, "-filter_complex", f"[0:v]{video_filter}[v];[0:a]{audio_filter}[a]", "-map", "[v]", "-map", "[a]", "-c:v", "libx264", "-preset", "fast", "-crf", "23", "-c:a", "aac", "-b:a", "128k", *_movflags_args(output), output])
+        _run_ffmpeg(
+            [
+                "-i",
+                input_path,
+                "-filter_complex",
+                f"[0:v]{video_filter}[v];[0:a]{audio_filter}[a]",
+                "-map",
+                "[v]",
+                "-map",
+                "[a]",
+                "-c:v",
+                "libx264",
+                "-preset",
+                "fast",
+                "-crf",
+                "23",
+                "-c:a",
+                "aac",
+                "-b:a",
+                "128k",
+                *_movflags_args(output),
+                output,
+            ]
+        )
     else:
-        _run_ffmpeg(["-i", input_path, "-vf", video_filter, "-an", "-c:v", "libx264", "-preset", "fast", "-crf", "23", *_movflags_args(output), output])
+        _run_ffmpeg(
+            [
+                "-i",
+                input_path,
+                "-vf",
+                video_filter,
+                "-an",
+                "-c:v",
+                "libx264",
+                "-preset",
+                "fast",
+                "-crf",
+                "23",
+                *_movflags_args(output),
+                output,
+            ]
+        )
 
     info = probe(output)
     return EditResult(
@@ -1181,13 +1549,20 @@ def thumbnail(
 
     output = output_path or _auto_output(input_path, f"frame_{timestamp:.1f}s", ext=".jpg")
 
-    _run_ffmpeg([
-        "-ss", str(timestamp),
-        "-i", input_path,
-        "-vframes", "1",
-        "-q:v", "2",
-        "-y", output,
-    ])
+    _run_ffmpeg(
+        [
+            "-ss",
+            str(timestamp),
+            "-i",
+            input_path,
+            "-vframes",
+            "1",
+            "-q:v",
+            "2",
+            "-y",
+            output,
+        ]
+    )
 
     return ThumbnailResult(
         frame_path=output,
@@ -1211,7 +1586,28 @@ def preview(
 
     output = output_path or _auto_output(input_path, "preview")
 
-    _run_ffmpeg(["-i", input_path, "-vf", f"scale={w}:{h}", "-c:v", "libx264", "-crf", str(PREVIEW_PRESETS["crf"]), "-preset", PREVIEW_PRESETS["preset"], "-c:a", "aac", "-b:a", "64k", "-ac", "2", *_movflags_args(output), output])
+    _run_ffmpeg(
+        [
+            "-i",
+            input_path,
+            "-vf",
+            f"scale={w}:{h}",
+            "-c:v",
+            "libx264",
+            "-crf",
+            str(PREVIEW_PRESETS["crf"]),
+            "-preset",
+            PREVIEW_PRESETS["preset"],
+            "-c:a",
+            "aac",
+            "-b:a",
+            "64k",
+            "-ac",
+            "2",
+            *_movflags_args(output),
+            output,
+        ]
+    )
 
     result_info = probe(output)
     return EditResult(
@@ -1246,13 +1642,20 @@ def storyboard(
         frame_name = f"frame_{i + 1:02d}_{ts:.1f}s.jpg"
         frame_path = os.path.join(out_dir, frame_name)
 
-        _run_ffmpeg([
-            "-ss", str(ts),
-            "-i", input_path,
-            "-vframes", "1",
-            "-q:v", "2",
-            "-y", frame_path,
-        ])
+        _run_ffmpeg(
+            [
+                "-ss",
+                str(ts),
+                "-i",
+                input_path,
+                "-vframes",
+                "1",
+                "-q:v",
+                "2",
+                "-y",
+                frame_path,
+            ]
+        )
         frame_paths.append(frame_path)
 
     # Create storyboard grid using FFmpeg
@@ -1271,7 +1674,9 @@ def storyboard(
         # Normalize all frames to same size
         filter_parts = []
         for i, _fp in enumerate(frame_paths):
-            filter_parts.append(f"[{i}:v]scale=480:270:force_original_aspect_ratio=decrease,pad=480:270:(ow-iw)/2:(oh-ih)/2[s{i}]")
+            filter_parts.append(
+                f"[{i}:v]scale=480:270:force_original_aspect_ratio=decrease,pad=480:270:(ow-iw)/2:(oh-ih)/2[s{i}]"
+            )
 
         # Stack horizontally first, then vertically
         # Row 0: [s0][s1][s2][s3]hstack=inputs=4[r0]
@@ -1294,9 +1699,7 @@ def storyboard(
         filter_str = ";".join(filter_parts)
 
         try:
-            _run_ffmpeg(
-                [*inputs, "-filter_complex", filter_str, "-map", "[vout]", "-q:v", "2", "-y", grid_path]
-            )
+            _run_ffmpeg([*inputs, "-filter_complex", filter_str, "-map", "[vout]", "-q:v", "2", "-y", grid_path])
         except ProcessingError:
             # Grid creation failed — frames are still useful individually
             grid_path = None
@@ -1328,7 +1731,24 @@ def subtitles(
     escaped_sub_path = _escape_ffmpeg_filter_value(subtitle_path)
     escaped_style = _escape_ffmpeg_filter_value(style)
 
-    _run_ffmpeg(["-i", input_path, "-vf", f"subtitles='{escaped_sub_path}':force_style='{escaped_style}'", "-c:v", "libx264", "-preset", "fast", "-crf", "23", "-c:a", "copy", *_movflags_args(output), output])
+    _run_ffmpeg(
+        [
+            "-i",
+            input_path,
+            "-vf",
+            f"subtitles='{escaped_sub_path}':force_style='{escaped_style}'",
+            "-c:v",
+            "libx264",
+            "-preset",
+            "fast",
+            "-crf",
+            "23",
+            "-c:a",
+            "copy",
+            *_movflags_args(output),
+            output,
+        ]
+    )
 
     info = probe(output)
     return EditResult(
@@ -1373,7 +1793,23 @@ def watermark(
     # Format opacity for FFmpeg (0.0 to 1.0)
     opacity_fmt = f"{opacity:.2f}"
 
-    _run_ffmpeg(["-i", input_path, "-i", image_path, "-filter_complex", f"[1:v]format=rgba,colorchannelmixer=aa={opacity_fmt}[wm];[0:v][wm]overlay={overlay_pos}", "-c:v", "libx264", *_quality_args(crf=crf, preset=preset), "-c:a", "copy", *_movflags_args(output), output])
+    _run_ffmpeg(
+        [
+            "-i",
+            input_path,
+            "-i",
+            image_path,
+            "-filter_complex",
+            f"[1:v]format=rgba,colorchannelmixer=aa={opacity_fmt}[wm];[0:v][wm]overlay={overlay_pos}",
+            "-c:v",
+            "libx264",
+            *_quality_args(crf=crf, preset=preset),
+            "-c:a",
+            "copy",
+            *_movflags_args(output),
+            output,
+        ]
+    )
 
     info = probe(output)
     return EditResult(
@@ -1413,7 +1849,24 @@ def crop(
 
     output = output_path or _auto_output(input_path, f"crop_{width}x{height}")
 
-    _run_ffmpeg(["-i", input_path, "-vf", f"crop={width}:{height}:{x}:{y}", "-c:v", "libx264", "-preset", "fast", "-crf", "23", "-c:a", "copy", *_movflags_args(output), output])
+    _run_ffmpeg(
+        [
+            "-i",
+            input_path,
+            "-vf",
+            f"crop={width}:{height}:{x}:{y}",
+            "-c:v",
+            "libx264",
+            "-preset",
+            "fast",
+            "-crf",
+            "23",
+            "-c:a",
+            "copy",
+            *_movflags_args(output),
+            output,
+        ]
+    )
 
     result_info = probe(output)
     return EditResult(
@@ -1462,7 +1915,26 @@ def rotate(
     vf = ",".join(filters)
     output = output_path or _auto_output(input_path, f"rotated_{angle}")
 
-    _run_ffmpeg(["-i", input_path, "-vf", vf, "-c:v", "libx264", "-preset", "fast", "-crf", "23", "-c:a", "aac", "-b:a", "128k", *_movflags_args(output), output])
+    _run_ffmpeg(
+        [
+            "-i",
+            input_path,
+            "-vf",
+            vf,
+            "-c:v",
+            "libx264",
+            "-preset",
+            "fast",
+            "-crf",
+            "23",
+            "-c:a",
+            "aac",
+            "-b:a",
+            "128k",
+            *_movflags_args(output),
+            output,
+        ]
+    )
 
     result_info = probe(output)
     return EditResult(
@@ -1500,7 +1972,21 @@ def fade(
 
     vf = ",".join(vf_parts)
 
-    _run_ffmpeg(["-i", input_path, "-vf", vf, "-c:v", "libx264", *_quality_args(crf=crf, preset=preset), "-c:a", "copy", *_movflags_args(output), output])
+    _run_ffmpeg(
+        [
+            "-i",
+            input_path,
+            "-vf",
+            vf,
+            "-c:v",
+            "libx264",
+            *_quality_args(crf=crf, preset=preset),
+            "-c:a",
+            "copy",
+            *_movflags_args(output),
+            output,
+        ]
+    )
 
     result_info = probe(output)
     return EditResult(
@@ -1525,8 +2011,13 @@ def export_video(
     """Export a video with specified quality and format settings."""
     _validate_input(input_path)
     result = convert(
-        input_path, format=format, quality=quality, output_path=output_path,
-        on_progress=on_progress, two_pass=two_pass, target_bitrate=target_bitrate,
+        input_path,
+        format=format,
+        quality=quality,
+        output_path=output_path,
+        on_progress=on_progress,
+        two_pass=two_pass,
+        target_bitrate=target_bitrate,
     )
     result.operation = "export"
     return result
@@ -1535,6 +2026,7 @@ def export_video(
 # ---------------------------------------------------------------------------
 # Timeline-based edit (composite operation)
 # ---------------------------------------------------------------------------
+
 
 def edit_timeline(timeline: Timeline | dict, output_path: str | None = None) -> EditResult:
     """Execute a full timeline-based edit described in JSON."""
@@ -1604,7 +2096,10 @@ def edit_timeline(timeline: Timeline | dict, output_path: str | None = None) -> 
         if text_elements or image_overlays:
             composited = os.path.join(tmpdir, "composited.mp4")
             _apply_composite_overlays(
-                merged, composited, text_elements, image_overlays,
+                merged,
+                composited,
+                text_elements,
+                image_overlays,
             )
             current = composited
 
@@ -1770,19 +2265,69 @@ def _apply_composite_overlays(
             last_label = "vout"
 
         # Final map
-        cmd = [*inputs, "-filter_complex", ";".join(filter_parts), "-map", f"[{last_label}]", "-map", "0:a?", "-c:v", "libx264", "-preset", "fast", "-crf", "23", "-c:a", "copy", *_movflags_args(output_path), output_path]
+        cmd = [
+            *inputs,
+            "-filter_complex",
+            ";".join(filter_parts),
+            "-map",
+            f"[{last_label}]",
+            "-map",
+            "0:a?",
+            "-c:v",
+            "libx264",
+            "-preset",
+            "fast",
+            "-crf",
+            "23",
+            "-c:a",
+            "copy",
+            *_movflags_args(output_path),
+            output_path,
+        ]
         _run_ffmpeg(cmd)
 
     elif image_overlays:
         # Only image overlays, no text
-        cmd = [*inputs, "-filter_complex", ";".join(filter_parts), "-map", f"[{prev_label}]", "-map", "0:a?", "-c:v", "libx264", "-preset", "fast", "-crf", "23", "-c:a", "copy", *_movflags_args(output_path), output_path]
+        cmd = [
+            *inputs,
+            "-filter_complex",
+            ";".join(filter_parts),
+            "-map",
+            f"[{prev_label}]",
+            "-map",
+            "0:a?",
+            "-c:v",
+            "libx264",
+            "-preset",
+            "fast",
+            "-crf",
+            "23",
+            "-c:a",
+            "copy",
+            *_movflags_args(output_path),
+            output_path,
+        ]
         _run_ffmpeg(cmd)
 
     elif text_elements:
         # Only text overlays (no images) — use -vf
         vf = ",".join(vf_parts)
         _run_ffmpeg(
-            [*inputs, "-vf", vf, "-c:v", "libx264", "-preset", "fast", "-crf", "23", "-c:a", "copy", *_movflags_args(output_path), output_path]
+            [
+                *inputs,
+                "-vf",
+                vf,
+                "-c:v",
+                "libx264",
+                "-preset",
+                "fast",
+                "-crf",
+                "23",
+                "-c:a",
+                "copy",
+                *_movflags_args(output_path),
+                output_path,
+            ]
         )
 
 
@@ -1812,13 +2357,19 @@ def extract_audio(
     }
     codec = codec_map[format]
 
-    _run_ffmpeg([
-        "-i", input_path,
-        "-vn",
-        "-c:a", codec,
-        "-b:a", "192k" if format != "wav" else "0",
-        "-y", output,
-    ])
+    _run_ffmpeg(
+        [
+            "-i",
+            input_path,
+            "-vn",
+            "-c:a",
+            codec,
+            "-b:a",
+            "192k" if format != "wav" else "0",
+            "-y",
+            output,
+        ]
+    )
 
     return output
 
@@ -1826,6 +2377,7 @@ def extract_audio(
 # ---------------------------------------------------------------------------
 # Video filters & effects
 # ---------------------------------------------------------------------------
+
 
 def _get_color_preset_filter(preset: ColorPreset) -> str:
     """Return FFmpeg eq filter string for a named color preset."""
@@ -1920,11 +2472,27 @@ def apply_filter(
         "invert": ("negate", "negate", False),
         "vignette": ("vignette", f"vignette=angle={params.get('angle', 'PI/4')}", False),
         "color_preset": ("eq", _get_color_preset_filter(params.get("preset", "warm")), False),
-        "denoise": ("hqdn3d", f"hqdn3d={params.get('luma_spatial', 4)}:{params.get('chroma_spatial', 3)}:{params.get('luma_tmp', 6)}:{params.get('chroma_tmp', 4.5)}", False),
+        "denoise": (
+            "hqdn3d",
+            f"hqdn3d={params.get('luma_spatial', 4)}:{params.get('chroma_spatial', 3)}:{params.get('luma_tmp', 6)}:{params.get('chroma_tmp', 4.5)}",
+            False,
+        ),
         "deinterlace": ("yadif", "yadif=0:-1:0", False),
-        "ken_burns": ("zoompan", f"zoompan=z='min(zoom+{params.get('zoom_speed', 0.0015)},1.5)':d={params.get('duration', 150)}:x='iw/2-(iw/zoom)/2':y='ih/2-(ih/zoom)/2':s={info.width}x{info.height}", False),
-        "reverb": ("aecho", f"aecho={params.get('in_gain', 0.8)}:{params.get('out_gain', 0.9)}:{params.get('delays', 60)}:{params.get('decay', 0.2)}", True),
-        "compressor": ("acompressor", f"acompressor=threshold={params.get('threshold_db', -20)}dB:ratio={params.get('ratio', 4)}:attack={params.get('attack', 5)}:release={params.get('release', 50)}", True),
+        "ken_burns": (
+            "zoompan",
+            f"zoompan=z='min(zoom+{params.get('zoom_speed', 0.0015)},1.5)':d={params.get('duration', 150)}:x='iw/2-(iw/zoom)/2':y='ih/2-(ih/zoom)/2':s={info.width}x{info.height}",
+            False,
+        ),
+        "reverb": (
+            "aecho",
+            f"aecho={params.get('in_gain', 0.8)}:{params.get('out_gain', 0.9)}:{params.get('delays', 60)}:{params.get('decay', 0.2)}",
+            True,
+        ),
+        "compressor": (
+            "acompressor",
+            f"acompressor=threshold={params.get('threshold_db', -20)}dB:ratio={params.get('ratio', 4)}:attack={params.get('attack', 5)}:release={params.get('release', 50)}",
+            True,
+        ),
         "pitch_shift": ("asetrate", _build_pitch_shift_filter(params.get("semitones", 0)), True),
         "noise_reduction": ("afftdn", f"afftdn=nf={params.get('noise_level', -25)}", True),
     }
@@ -1948,9 +2516,38 @@ def apply_filter(
                 error_type="validation_error",
                 code="audio_filter_no_audio",
             )
-        _run_ffmpeg(["-i", input_path, "-af", filter_string, "-c:v", "copy", "-c:a", "aac", "-b:a", "128k", *_movflags_args(output), output])
+        _run_ffmpeg(
+            [
+                "-i",
+                input_path,
+                "-af",
+                filter_string,
+                "-c:v",
+                "copy",
+                "-c:a",
+                "aac",
+                "-b:a",
+                "128k",
+                *_movflags_args(output),
+                output,
+            ]
+        )
     else:
-        _run_ffmpeg(["-i", input_path, "-vf", filter_string, "-c:v", "libx264", *_quality_args(crf=crf, preset=preset), "-c:a", "copy", *_movflags_args(output), output])
+        _run_ffmpeg(
+            [
+                "-i",
+                input_path,
+                "-vf",
+                filter_string,
+                "-c:v",
+                "libx264",
+                *_quality_args(crf=crf, preset=preset),
+                "-c:a",
+                "copy",
+                *_movflags_args(output),
+                output,
+            ]
+        )
 
     info = probe(output)
     return EditResult(
@@ -1966,6 +2563,7 @@ def apply_filter(
 # ---------------------------------------------------------------------------
 # Audio normalization
 # ---------------------------------------------------------------------------
+
 
 def normalize_audio(
     input_path: str,
@@ -1984,7 +2582,9 @@ def normalize_audio(
     """
     _validate_input(input_path)
     if not isinstance(target_lufs, (int, float)) or not (-70 <= target_lufs <= -5):
-        raise MCPVideoError(f"target_lufs must be -70 to -5, got {target_lufs}", error_type="validation_error", code="invalid_parameter")
+        raise MCPVideoError(
+            f"target_lufs must be -70 to -5, got {target_lufs}", error_type="validation_error", code="invalid_parameter"
+        )
     _require_filter("loudnorm", "Audio normalization")
     output = output_path or _auto_output(input_path, "normalized")
 
@@ -1992,7 +2592,22 @@ def normalize_audio(
     # TP (true peak) should be a fixed value near -1.5 dBTP regardless of target LUFS.
     tp = -1.5
 
-    _run_ffmpeg(["-i", input_path, "-af", f"loudnorm=I={target_lufs}:TP={tp}:LRA={lra}", "-c:v", "copy", "-c:a", "aac", "-b:a", "192k", *_movflags_args(output), output])
+    _run_ffmpeg(
+        [
+            "-i",
+            input_path,
+            "-af",
+            f"loudnorm=I={target_lufs}:TP={tp}:LRA={lra}",
+            "-c:v",
+            "copy",
+            "-c:a",
+            "aac",
+            "-b:a",
+            "192k",
+            *_movflags_args(output),
+            output,
+        ]
+    )
 
     info = probe(output)
     return EditResult(
@@ -2008,6 +2623,7 @@ def normalize_audio(
 # ---------------------------------------------------------------------------
 # Compositing & overlays
 # ---------------------------------------------------------------------------
+
 
 def overlay_video(
     background_path: str,
@@ -2086,7 +2702,25 @@ def overlay_video(
 
     filter_complex = f"[1:v]{overlay_chain}[ov];[0:v][ov]overlay={overlay_pos}{enable_expr}"
 
-    _run_ffmpeg(["-i", background_path, "-i", overlay_path, "-filter_complex", filter_complex, "-c:v", "libx264", *_quality_args(crf=crf, preset=preset), "-c:a", "aac", "-b:a", "128k", *_movflags_args(output), output])
+    _run_ffmpeg(
+        [
+            "-i",
+            background_path,
+            "-i",
+            overlay_path,
+            "-filter_complex",
+            filter_complex,
+            "-c:v",
+            "libx264",
+            *_quality_args(crf=crf, preset=preset),
+            "-c:a",
+            "aac",
+            "-b:a",
+            "128k",
+            *_movflags_args(output),
+            output,
+        ]
+    )
 
     info = probe(output)
     return EditResult(
@@ -2144,7 +2778,32 @@ def split_screen(
         else:
             filter_complex = "[0:v][1:v]vstack=inputs=2[v]"
 
-    _run_ffmpeg(["-i", left_path, "-i", right_path, "-filter_complex", filter_complex, "-map", "[v]", "-map", "0:a?", "-c:v", "libx264", "-preset", "fast", "-crf", "23", "-c:a", "aac", "-b:a", "128k", *_movflags_args(output), output])
+    _run_ffmpeg(
+        [
+            "-i",
+            left_path,
+            "-i",
+            right_path,
+            "-filter_complex",
+            filter_complex,
+            "-map",
+            "[v]",
+            "-map",
+            "0:a?",
+            "-c:v",
+            "libx264",
+            "-preset",
+            "fast",
+            "-crf",
+            "23",
+            "-c:a",
+            "aac",
+            "-b:a",
+            "128k",
+            *_movflags_args(output),
+            output,
+        ]
+    )
 
     info = probe(output)
     return EditResult(
@@ -2180,9 +2839,13 @@ def reverse(
         args += ["-an"]
     args += ["-c:v", "libx264", "-preset", "fast", "-crf", "23"]
 
-    _run_ffmpeg(args + _movflags_args(output) + [
-        output,
-    ])
+    _run_ffmpeg(
+        args
+        + _movflags_args(output)
+        + [
+            output,
+        ]
+    )
 
     info = probe(output)
     return EditResult(
@@ -2249,6 +2912,7 @@ def chroma_key(
 # ---------------------------------------------------------------------------
 # Subtitle generation
 # ---------------------------------------------------------------------------
+
 
 def generate_subtitles(
     entries: list[dict],
@@ -2317,7 +2981,24 @@ def generate_subtitles(
         _require_filter("subtitles", "Subtitle burn-in")
         video_out = os.path.join(srt_dir, "subtitled.mp4")
         escaped_srt = _escape_ffmpeg_filter_value(srt_file)
-        _run_ffmpeg(["-i", input_path, "-vf", f"subtitles={escaped_srt}", "-c:v", "libx264", "-preset", "fast", "-crf", "23", "-c:a", "copy", *_movflags_args(video_out), video_out])
+        _run_ffmpeg(
+            [
+                "-i",
+                input_path,
+                "-vf",
+                f"subtitles={escaped_srt}",
+                "-c:v",
+                "libx264",
+                "-preset",
+                "fast",
+                "-crf",
+                "23",
+                "-c:a",
+                "copy",
+                *_movflags_args(video_out),
+                video_out,
+            ]
+        )
         return SubtitleResult(
             srt_path=srt_file,
             video_path=video_out,
@@ -2342,6 +3023,7 @@ def _seconds_to_srt_time(seconds: float) -> str:
 # ---------------------------------------------------------------------------
 # Audio waveform extraction
 # ---------------------------------------------------------------------------
+
 
 def audio_waveform(
     input_path: str,
@@ -2370,7 +3052,9 @@ def audio_waveform(
     filter_str = "astats=metadata=1:reset=0,ametadata=1"
     proc = subprocess.run(
         [_ffmpeg(), "-i", input_path, "-af", filter_str, "-f", "null", "-"],
-        capture_output=True, text=True, timeout=120,
+        capture_output=True,
+        text=True,
+        timeout=120,
     )
     # Parse astats output for RMS level
     peaks: list[dict] = []
@@ -2455,6 +3139,7 @@ def audio_waveform(
 # Scene detection
 # ---------------------------------------------------------------------------
 
+
 def detect_scenes(
     input_path: str,
     threshold: float = 0.3,
@@ -2469,18 +3154,27 @@ def detect_scenes(
     """
     _validate_input(input_path)
     if not isinstance(threshold, (int, float)) or not (0.0 <= threshold <= 1.0):
-        raise MCPVideoError(f"threshold must be 0.0-1.0, got {threshold}", error_type="validation_error", code="invalid_parameter")
+        raise MCPVideoError(
+            f"threshold must be 0.0-1.0, got {threshold}", error_type="validation_error", code="invalid_parameter"
+        )
     info = probe(input_path)
     duration = info.duration
 
     # Use FFmpeg select filter with scene detection
     proc = subprocess.run(
         [
-            _ffmpeg(), "-i", input_path,
-            "-vf", f"select='gt(scene,{threshold})',showinfo",
-            "-f", "null", "-",
+            _ffmpeg(),
+            "-i",
+            input_path,
+            "-vf",
+            f"select='gt(scene,{threshold})',showinfo",
+            "-f",
+            "null",
+            "-",
         ],
-        capture_output=True, text=True, timeout=300,
+        capture_output=True,
+        text=True,
+        timeout=300,
     )
     if proc.returncode != 0:
         raise parse_ffmpeg_error(proc.stderr)
@@ -2502,22 +3196,26 @@ def detect_scenes(
     prev_time = 0.0
     for t in scene_times:
         if t - prev_time >= min_scene_duration:
-            scenes.append({
-                "start": round(prev_time, 2),
-                "end": round(t, 2),
-                "start_frame": round(prev_time * info.fps),
-                "end_frame": round(t * info.fps),
-            })
+            scenes.append(
+                {
+                    "start": round(prev_time, 2),
+                    "end": round(t, 2),
+                    "start_frame": round(prev_time * info.fps),
+                    "end_frame": round(t * info.fps),
+                }
+            )
             prev_time = t
 
     # Add final scene
     if duration - prev_time >= 0.1:
-        scenes.append({
-            "start": round(prev_time, 2),
-            "end": round(duration, 2),
-            "start_frame": round(prev_time * info.fps),
-            "end_frame": round(duration * info.fps),
-        })
+        scenes.append(
+            {
+                "start": round(prev_time, 2),
+                "end": round(duration, 2),
+                "start_frame": round(prev_time * info.fps),
+                "end_frame": round(duration * info.fps),
+            }
+        )
 
     return SceneDetectionResult(
         scenes=scenes,
@@ -2529,6 +3227,7 @@ def detect_scenes(
 # ---------------------------------------------------------------------------
 # Image sequences
 # ---------------------------------------------------------------------------
+
 
 def create_from_images(
     images: list[str],
@@ -2565,19 +3264,31 @@ def create_from_images(
         for i, img in enumerate(images):
             norm_path = os.path.join(tmpdir, f"img_{i:04d}{ext}")
             if img_format == "png":
-                _run_ffmpeg([
-                    "-y", "-i", img,
-                    "-vf", "scale=trunc(iw/2)*2:trunc(ih/2)*2",
-                    "-c:v", "png",
-                    norm_path,
-                ])
+                _run_ffmpeg(
+                    [
+                        "-y",
+                        "-i",
+                        img,
+                        "-vf",
+                        "scale=trunc(iw/2)*2:trunc(ih/2)*2",
+                        "-c:v",
+                        "png",
+                        norm_path,
+                    ]
+                )
             else:
-                _run_ffmpeg([
-                    "-y", "-i", img,
-                    "-vf", "scale=trunc(iw/2)*2:trunc(ih/2)*2",
-                    "-q:v", "2",
-                    norm_path,
-                ])
+                _run_ffmpeg(
+                    [
+                        "-y",
+                        "-i",
+                        img,
+                        "-vf",
+                        "scale=trunc(iw/2)*2:trunc(ih/2)*2",
+                        "-q:v",
+                        "2",
+                        norm_path,
+                    ]
+                )
             normalized.append(norm_path)
 
         # Build concat file
@@ -2591,7 +3302,26 @@ def create_from_images(
             abs_last = os.path.abspath(normalized[-1]).replace("'", "'\\''")
             f.write(f"file '{abs_last}'\n")
 
-        _run_ffmpeg(["-f", "concat", "-safe", "0", "-i", concat_file, "-c:v", "libx264", "-preset", "fast", "-crf", "23", "-pix_fmt", "yuv420p", *_movflags_args(output), output])
+        _run_ffmpeg(
+            [
+                "-f",
+                "concat",
+                "-safe",
+                "0",
+                "-i",
+                concat_file,
+                "-c:v",
+                "libx264",
+                "-preset",
+                "fast",
+                "-crf",
+                "23",
+                "-pix_fmt",
+                "yuv420p",
+                *_movflags_args(output),
+                output,
+            ]
+        )
     finally:
         shutil.rmtree(tmpdir, ignore_errors=True)
 
@@ -2637,20 +3367,23 @@ def export_frames(
     ext = format if format.startswith(".") else f".{format}"
     pattern = os.path.join(out_dir, f"frame_%04d{ext}")
 
-    _run_ffmpeg([
-        "-i", input_path,
-        "-vf", f"fps={fps}",
-        "-q:v", "2",
-        "-y",
-        pattern,
-    ])
+    _run_ffmpeg(
+        [
+            "-i",
+            input_path,
+            "-vf",
+            f"fps={fps}",
+            "-q:v",
+            "2",
+            "-y",
+            pattern,
+        ]
+    )
 
     # Collect generated frame paths
-    frame_paths = sorted([
-        os.path.join(out_dir, f)
-        for f in os.listdir(out_dir)
-        if f.startswith("frame_") and f.endswith(ext)
-    ])
+    frame_paths = sorted(
+        [os.path.join(out_dir, f) for f in os.listdir(out_dir) if f.startswith("frame_") and f.endswith(ext)]
+    )
 
     return ImageSequenceResult(
         frame_paths=frame_paths,
@@ -2662,6 +3395,7 @@ def export_frames(
 # ---------------------------------------------------------------------------
 # Quality metrics
 # ---------------------------------------------------------------------------
+
 
 def compare_quality(
     original_path: str,
@@ -2696,11 +3430,20 @@ def compare_quality(
             filter_str = f"[1:v]scale={target_w}:{target_h}[scaled];[0:v][scaled]{metric_lower}"
             proc = subprocess.run(
                 [
-                    _ffmpeg(), "-i", original_path, "-i", distorted_path,
-                    "-lavfi", filter_str,
-                    "-f", "null", "-",
+                    _ffmpeg(),
+                    "-i",
+                    original_path,
+                    "-i",
+                    distorted_path,
+                    "-lavfi",
+                    filter_str,
+                    "-f",
+                    "null",
+                    "-",
                 ],
-                capture_output=True, text=True, timeout=300,
+                capture_output=True,
+                text=True,
+                timeout=300,
             )
             if proc.returncode != 0:
                 raise ProcessingError(
@@ -2765,6 +3508,7 @@ def compare_quality(
 # ---------------------------------------------------------------------------
 # Metadata editing
 # ---------------------------------------------------------------------------
+
 
 def read_metadata(input_path: str) -> MetadataResult:
     """Read metadata tags from a video/audio file.
@@ -2854,6 +3598,7 @@ def write_metadata(
 # Video stabilization
 # ---------------------------------------------------------------------------
 
+
 def stabilize(
     input_path: str,
     smoothing: float = 15,
@@ -2880,18 +3625,44 @@ def stabilize(
         vectors_file = os.path.join(tmpdir, "vectors.trf")
         result = subprocess.run(
             [
-                _ffmpeg(), "-y",
-                "-i", input_path,
-                "-vf", "vidstabdetect=shakiness=10:accuracy=15:result=" + vectors_file,
-                "-f", "null", "-",
+                _ffmpeg(),
+                "-y",
+                "-i",
+                input_path,
+                "-vf",
+                "vidstabdetect=shakiness=10:accuracy=15:result=" + vectors_file,
+                "-f",
+                "null",
+                "-",
             ],
-            capture_output=True, text=True, timeout=600,
+            capture_output=True,
+            text=True,
+            timeout=600,
         )
         if result.returncode != 0:
             raise parse_ffmpeg_error(result.stderr)
 
         # Pass 2: apply stabilization
-        _run_ffmpeg(["-i", input_path, "-vf", f"vidstabtransform=input={vectors_file}:smoothing={smoothing}:zoom={zooming}:crop=black", "-c:v", "libx264", "-preset", "fast", "-crf", "23", "-c:a", "aac", "-b:a", "128k", *_movflags_args(output), output])
+        _run_ffmpeg(
+            [
+                "-i",
+                input_path,
+                "-vf",
+                f"vidstabtransform=input={vectors_file}:smoothing={smoothing}:zoom={zooming}:crop=black",
+                "-c:v",
+                "libx264",
+                "-preset",
+                "fast",
+                "-crf",
+                "23",
+                "-c:a",
+                "aac",
+                "-b:a",
+                "128k",
+                *_movflags_args(output),
+                output,
+            ]
+        )
     finally:
         shutil.rmtree(tmpdir, ignore_errors=True)
 
@@ -2909,6 +3680,7 @@ def stabilize(
 # ---------------------------------------------------------------------------
 # Advanced masking
 # ---------------------------------------------------------------------------
+
 
 def apply_mask(
     input_path: str,
@@ -2943,11 +3715,33 @@ def apply_mask(
         )
     else:
         filter_complex = (
-            f"[1:v]format=gray,scale={w}:{h},colorchannelmixer=aa=1.0[alpha];"
-            f"[0:v][alpha]alphamerge,format=yuv420p[out]"
+            f"[1:v]format=gray,scale={w}:{h},colorchannelmixer=aa=1.0[alpha];[0:v][alpha]alphamerge,format=yuv420p[out]"
         )
 
-    _run_ffmpeg(["-i", input_path, "-i", mask_path, "-filter_complex", filter_complex, "-map", "[out]", "-map", "0:a?", "-c:v", "libx264", "-preset", "fast", "-crf", "23", "-c:a", "copy", *_movflags_args(output), output])
+    _run_ffmpeg(
+        [
+            "-i",
+            input_path,
+            "-i",
+            mask_path,
+            "-filter_complex",
+            filter_complex,
+            "-map",
+            "[out]",
+            "-map",
+            "0:a?",
+            "-c:v",
+            "libx264",
+            "-preset",
+            "fast",
+            "-crf",
+            "23",
+            "-c:a",
+            "copy",
+            *_movflags_args(output),
+            output,
+        ]
+    )
 
     result_info = probe(output)
     return EditResult(
@@ -2964,6 +3758,7 @@ def apply_mask(
 # Batch processing
 # ---------------------------------------------------------------------------
 
+
 def video_batch(
     inputs: list[str],
     operation: str,
@@ -2979,7 +3774,10 @@ def video_batch(
         output_dir: Directory for output files. Auto-generated if omitted.
     """
     if not inputs:
-        return {"success": False, "error": {"type": "input_error", "code": "empty_inputs", "message": "No input files provided"}}
+        return {
+            "success": False,
+            "error": {"type": "input_error", "code": "empty_inputs", "message": "No input files provided"},
+        }
 
     params = params or {}
     results = []
@@ -3000,26 +3798,69 @@ def video_batch(
                 return None  # let the engine auto-generate
 
             if operation == "trim":
-                result = trim(input_path, start=params.get("start", "0"), duration=params.get("duration"), end=params.get("end"), output_path=_batch_output())
+                result = trim(
+                    input_path,
+                    start=params.get("start", "0"),
+                    duration=params.get("duration"),
+                    end=params.get("end"),
+                    output_path=_batch_output(),
+                )
             elif operation == "resize":
-                result = resize(input_path, width=params.get("width"), height=params.get("height"), aspect_ratio=params.get("aspect_ratio"), quality=params.get("quality", "high"), output_path=_batch_output())
+                result = resize(
+                    input_path,
+                    width=params.get("width"),
+                    height=params.get("height"),
+                    aspect_ratio=params.get("aspect_ratio"),
+                    quality=params.get("quality", "high"),
+                    output_path=_batch_output(),
+                )
             elif operation == "convert":
                 out_ext = f".{params.get('format', 'mp4')}"
-                result = convert(input_path, format=params.get("format", "mp4"), quality=params.get("quality", "high"), output_path=_batch_output(out_ext))
+                result = convert(
+                    input_path,
+                    format=params.get("format", "mp4"),
+                    quality=params.get("quality", "high"),
+                    output_path=_batch_output(out_ext),
+                )
             elif operation == "filter":
-                result = apply_filter(input_path, filter_type=params.get("filter_type", "blur"), params=params.get("filter_params", {}), output_path=_batch_output())
+                result = apply_filter(
+                    input_path,
+                    filter_type=params.get("filter_type", "blur"),
+                    params=params.get("filter_params", {}),
+                    output_path=_batch_output(),
+                )
             elif operation == "blur":
-                result = apply_filter(input_path, filter_type="blur", params=params.get("filter_params", {}), output_path=_batch_output())
+                result = apply_filter(
+                    input_path, filter_type="blur", params=params.get("filter_params", {}), output_path=_batch_output()
+                )
             elif operation == "color_grade":
-                result = apply_filter(input_path, filter_type="color_preset", params={"preset": params.get("preset", "warm")}, output_path=_batch_output())
+                result = apply_filter(
+                    input_path,
+                    filter_type="color_preset",
+                    params={"preset": params.get("preset", "warm")},
+                    output_path=_batch_output(),
+                )
             elif operation == "watermark":
-                result = watermark(input_path, image_path=params.get("image_path", ""), position=params.get("position", "bottom-right"), opacity=params.get("opacity", 0.7), output_path=_batch_output())
+                result = watermark(
+                    input_path,
+                    image_path=params.get("image_path", ""),
+                    position=params.get("position", "bottom-right"),
+                    opacity=params.get("opacity", 0.7),
+                    output_path=_batch_output(),
+                )
             elif operation == "speed":
                 result = speed(input_path, factor=params.get("factor", 1.0), output_path=_batch_output())
             elif operation == "fade":
-                result = fade(input_path, fade_in=params.get("fade_in", 0.5), fade_out=params.get("fade_out", 0.5), output_path=_batch_output())
+                result = fade(
+                    input_path,
+                    fade_in=params.get("fade_in", 0.5),
+                    fade_out=params.get("fade_out", 0.5),
+                    output_path=_batch_output(),
+                )
             elif operation == "normalize_audio":
-                result = normalize_audio(input_path, target_lufs=params.get("target_lufs", -16.0), output_path=_batch_output())
+                result = normalize_audio(
+                    input_path, target_lufs=params.get("target_lufs", -16.0), output_path=_batch_output()
+                )
             else:
                 results.append({"input": input_path, "success": False, "error": f"Unknown operation: {operation}"})
                 failed += 1

--- a/mcp_video/ffmpeg_helpers.py
+++ b/mcp_video/ffmpeg_helpers.py
@@ -57,10 +57,14 @@ def _escape_ffmpeg_filter_value(value: str) -> str:
 def _get_video_duration(video_path: str) -> float:
     """Get video duration using ffprobe."""
     cmd = [
-        "ffprobe", "-v", "error",
-        "-show_entries", "format=duration",
-        "-of", "default=noprint_wrappers=1:nokey=1",
-        video_path
+        "ffprobe",
+        "-v",
+        "error",
+        "-show_entries",
+        "format=duration",
+        "-of",
+        "default=noprint_wrappers=1:nokey=1",
+        video_path,
     ]
     result = _run_ffmpeg(cmd)
     return float(result.stdout.strip())

--- a/mcp_video/image_engine.py
+++ b/mcp_video/image_engine.py
@@ -25,14 +25,14 @@ SUPPORTED_EXTENSIONS = frozenset({".jpg", ".jpeg", ".png", ".bmp", ".gif", ".tif
 # Private helpers
 # ---------------------------------------------------------------------------
 
+
 def _require_image_deps() -> None:
     """Raise a helpful error if optional image deps are not installed."""
     try:
         import PIL.Image  # noqa: F401
     except ImportError:
         raise MCPVideoError(
-            "Image analysis requires optional dependencies. "
-            "Install with: pip install mcp-video[image]",
+            "Image analysis requires optional dependencies. Install with: pip install mcp-video[image]",
             error_type="dependency_error",
             code="missing_optional_dep",
             suggested_action={
@@ -109,6 +109,7 @@ def _closest_color_name(r: int, g: int, b: int) -> str:
 # Public API
 # ---------------------------------------------------------------------------
 
+
 def extract_colors(
     image_path: str,
     n_colors: int = 5,
@@ -152,12 +153,14 @@ def extract_colors(
         r = max(0, min(255, r))
         g = max(0, min(255, g))
         b = max(0, min(255, b))
-        colors.append(DominantColor(
-            hex=_rgb_to_hex(r, g, b),
-            rgb=(r, g, b),
-            name=_closest_color_name(r, g, b),
-            percentage=round(count / total * 100, 1),
-        ))
+        colors.append(
+            DominantColor(
+                hex=_rgb_to_hex(r, g, b),
+                rgb=(r, g, b),
+                name=_closest_color_name(r, g, b),
+                percentage=round(count / total * 100, 1),
+            )
+        )
 
     return ColorExtractionResult(
         image_path=image_path,
@@ -194,9 +197,9 @@ def generate_palette(
     # Harmony rotation rules
     harmony_offsets: dict[str, list[float]] = {
         "complementary": [0.0, 0.5],
-        "analogous": [0.0, 1/12, -1/12, 2/12, -2/12],
-        "triadic": [0.0, 1/3, 2/3],
-        "split_complementary": [0.0, 150/360, 210/360],
+        "analogous": [0.0, 1 / 12, -1 / 12, 2 / 12, -2 / 12],
+        "triadic": [0.0, 1 / 3, 2 / 3],
+        "split_complementary": [0.0, 150 / 360, 210 / 360],
     }
     offsets = harmony_offsets[harmony]
 
@@ -212,11 +215,13 @@ def generate_palette(
         new_h = (h + offset) % 1.0
         nr, ng, nb = _hsl_to_rgb(new_h, s, lightness)
         role = role_names[harmony][i] if i < len(role_names[harmony]) else f"accent{i}"
-        palette.append(PaletteColor(
-            hex=_rgb_to_hex(nr, ng, nb),
-            rgb=(nr, ng, nb),
-            role=role,
-        ))
+        palette.append(
+            PaletteColor(
+                hex=_rgb_to_hex(nr, ng, nb),
+                rgb=(nr, ng, nb),
+                role=role,
+            )
+        )
 
     return PaletteResult(
         image_path=image_path,
@@ -243,8 +248,7 @@ def analyze_product(
             import anthropic
         except ImportError:
             raise MCPVideoError(
-                "AI description requires the anthropic package. "
-                "Install with: pip install mcp-video[image-ai]",
+                "AI description requires the anthropic package. Install with: pip install mcp-video[image-ai]",
                 error_type="dependency_error",
                 code="missing_ai_dep",
                 suggested_action={
@@ -272,24 +276,26 @@ def analyze_product(
         response = client.messages.create(
             model="claude-sonnet-4-20250514",
             max_tokens=300,
-            messages=[{
-                "role": "user",
-                "content": [
-                    {
-                        "type": "image",
-                        "source": {
-                            "type": "base64",
-                            "media_type": mime_type,
-                            "data": img_data,
+            messages=[
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "image",
+                            "source": {
+                                "type": "base64",
+                                "media_type": mime_type,
+                                "data": img_data,
+                            },
                         },
-                    },
-                    {
-                        "type": "text",
-                        "text": "Describe this product image concisely in 2-3 sentences. "
-                                "Focus on the product type, colors, and key visual features.",
-                    },
-                ],
-            }],
+                        {
+                            "type": "text",
+                            "text": "Describe this product image concisely in 2-3 sentences. "
+                            "Focus on the product type, colors, and key visual features.",
+                        },
+                    ],
+                }
+            ],
         )
         description = response.content[0].text
 

--- a/mcp_video/limits.py
+++ b/mcp_video/limits.py
@@ -1,22 +1,22 @@
 """Resource limits and validation constants for mcp-video."""
 
 # Video limits
-MAX_VIDEO_DURATION = 14400       # 4 hours in seconds
-MAX_RESOLUTION = 7680            # 8K width/height
-MAX_FILE_SIZE_MB = 4096          # 4 GB
+MAX_VIDEO_DURATION = 14400  # 4 hours in seconds
+MAX_RESOLUTION = 7680  # 8K width/height
+MAX_FILE_SIZE_MB = 4096  # 4 GB
 
 # Processing limits
 MAX_CONCURRENT_PROCESSES = 4
-DEFAULT_FFMPEG_TIMEOUT = 600     # 10 minutes
+DEFAULT_FFMPEG_TIMEOUT = 600  # 10 minutes
 MAX_BATCH_SIZE = 50
 MAX_SUBTITLE_ENTRIES = 1000
 MAX_STORYBOARD_FRAMES = 50
 MAX_EXPORT_FRAMES_FPS = 60
 
 # Audio limits
-MAX_AUDIO_DURATION = 3600        # 1 hour
-MIN_FREQUENCY = 20               # Human hearing lower bound
-MAX_FREQUENCY = 20000            # Human hearing upper bound
+MAX_AUDIO_DURATION = 3600  # 1 hour
+MIN_FREQUENCY = 20  # Human hearing lower bound
+MAX_FREQUENCY = 20000  # Human hearing upper bound
 MIN_SAMPLE_RATE = 8000
 MAX_SAMPLE_RATE = 96000
 

--- a/mcp_video/models.py
+++ b/mcp_video/models.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel, Field
 
 # --- Video metadata ---
 
+
 class VideoInfo(BaseModel):
     """Metadata about a video file."""
 
@@ -31,6 +32,7 @@ class VideoInfo(BaseModel):
     @property
     def aspect_ratio(self) -> str:
         from math import gcd
+
         g = gcd(self.width, self.height)
         return f"{self.width // g}:{self.height // g}"
 
@@ -42,6 +44,7 @@ class VideoInfo(BaseModel):
 
 
 # --- Operation results ---
+
 
 class EditResult(BaseModel):
     """Result of a video editing operation."""
@@ -97,7 +100,9 @@ class WaveformResult(BaseModel):
     max_level: float
     min_level: float
     silence_regions: list[dict] = Field(description="List of {start, end} silence regions")
-    synthetic: bool = Field(default=False, description="True if data was synthetically generated due to analysis failure")
+    synthetic: bool = Field(
+        default=False, description="True if data was synthetically generated due to analysis failure"
+    )
 
 
 class SceneDetectionResult(BaseModel):
@@ -177,9 +182,15 @@ ASPECT_RATIOS: dict[str, tuple[int, int]] = {
 # --- Text positioning ---
 
 NamedPosition = Literal[
-    "top-left", "top-center", "top-right",
-    "center-left", "center", "center-right",
-    "bottom-left", "bottom-center", "bottom-right",
+    "top-left",
+    "top-center",
+    "top-right",
+    "center-left",
+    "center",
+    "center-right",
+    "bottom-left",
+    "bottom-center",
+    "bottom-right",
 ]
 
 # Position can be a named position string, pixel coordinates, or percentage coordinates
@@ -192,10 +203,23 @@ TransitionType = Literal["fade", "dissolve", "wipe-left", "wipe-right", "wipe-up
 # --- Filter types ---
 
 FilterType = Literal[
-    "blur", "sharpen", "brightness", "contrast", "saturation",
-    "grayscale", "sepia", "invert", "vignette", "color_preset",
-    "denoise", "deinterlace", "ken_burns",
-    "reverb", "compressor", "pitch_shift", "noise_reduction",
+    "blur",
+    "sharpen",
+    "brightness",
+    "contrast",
+    "saturation",
+    "grayscale",
+    "sepia",
+    "invert",
+    "vignette",
+    "color_preset",
+    "denoise",
+    "deinterlace",
+    "ken_burns",
+    "reverb",
+    "compressor",
+    "pitch_shift",
+    "noise_reduction",
 ]
 
 ColorPreset = Literal["warm", "cool", "vintage", "cinematic", "noir"]
@@ -209,6 +233,7 @@ SplitLayout = Literal["side-by-side", "top-bottom"]
 ExportFormat = Literal["mp4", "webm", "gif", "mov"]
 
 # --- Timeline DSL models ---
+
 
 class TimelineClip(BaseModel):
     """A single clip in a timeline track."""
@@ -238,12 +263,14 @@ class TimelineTextElement(BaseModel):
     start: float = 0.0
     duration: float | None = None
     position: Position = "top-center"
-    style: dict[str, Any] = Field(default_factory=lambda: {
-        "font": "Arial",
-        "size": 48,
-        "color": "white",
-        "shadow": True,
-    })
+    style: dict[str, Any] = Field(
+        default_factory=lambda: {
+            "font": "Arial",
+            "size": 48,
+            "color": "white",
+            "shadow": True,
+        }
+    )
 
 
 class TimelineImageOverlay(BaseModel):
@@ -288,6 +315,7 @@ class Timeline(BaseModel):
 
 
 # --- Watermark settings ---
+
 
 class WatermarkSettings(BaseModel):
     """Settings for watermark overlay."""

--- a/mcp_video/quality_guardrails.py
+++ b/mcp_video/quality_guardrails.py
@@ -60,16 +60,19 @@ class VisualQualityGuardrails:
         """Run ffprobe with signalstats filter and parse results."""
         cmd = [
             "ffprobe",
-            "-v", "error",
-            "-f", "lavfi",
-            "-i", f"movie={_escape_lavfi_path(video)},signalstats",
-            "-show_entries", f"frame_tags={filter_name}",
-            "-of", "json",
+            "-v",
+            "error",
+            "-f",
+            "lavfi",
+            "-i",
+            f"movie={_escape_lavfi_path(video)},signalstats",
+            "-show_entries",
+            f"frame_tags={filter_name}",
+            "-of",
+            "json",
         ]
         try:
-            result = subprocess.run(
-                cmd, capture_output=True, text=True, timeout=60
-            )
+            result = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
             if result.returncode != 0:
                 return {}
             data = json.loads(result.stdout)
@@ -95,22 +98,25 @@ class VisualQualityGuardrails:
             logger.warning("ffprobe signalstats returned invalid JSON for %s (filter=%s)", video, filter_name)
             return {}
         except Exception as exc:
-            logger.warning("ffprobe signalstats failed for %s (filter=%s): %s: %s", video, filter_name, type(exc).__name__, exc)
+            logger.warning(
+                "ffprobe signalstats failed for %s (filter=%s): %s: %s", video, filter_name, type(exc).__name__, exc
+            )
             return {}
 
     def _run_ffmpeg_signalstats(self, video: str) -> dict[str, Any]:
         """Run ffmpeg with signalstats filter to get video statistics."""
         cmd = [
             "ffmpeg",
-            "-i", video,
-            "-vf", "signalstats",
-            "-f", "null",
+            "-i",
+            video,
+            "-vf",
+            "signalstats",
+            "-f",
+            "null",
             "-",
         ]
         try:
-            result = subprocess.run(
-                cmd, capture_output=True, text=True, timeout=120
-            )
+            result = subprocess.run(cmd, capture_output=True, text=True, timeout=120)
             # Parse stderr for signalstats output
             stderr = result.stderr
             stats = {}
@@ -142,15 +148,16 @@ class VisualQualityGuardrails:
         """Analyze audio loudness using loudnorm filter."""
         cmd = [
             "ffmpeg",
-            "-i", video,
-            "-af", "loudnorm=print_format=json",
-            "-f", "null",
+            "-i",
+            video,
+            "-af",
+            "loudnorm=print_format=json",
+            "-f",
+            "null",
             "-",
         ]
         try:
-            result = subprocess.run(
-                cmd, capture_output=True, text=True, timeout=120
-            )
+            result = subprocess.run(cmd, capture_output=True, text=True, timeout=120)
             # Parse JSON from the output (it's embedded in stderr)
             stderr = result.stderr
 
@@ -176,16 +183,19 @@ class VisualQualityGuardrails:
         """Get mean RGB values for color balance analysis."""
         cmd = [
             "ffprobe",
-            "-v", "error",
-            "-f", "lavfi",
-            "-i", f"movie={video},signalstats",
-            "-show_entries", "frame_tags=lavfi.signalstats.RAVG,lavfi.signalstats.GAVG,lavfi.signalstats.BAVG",
-            "-of", "json",
+            "-v",
+            "error",
+            "-f",
+            "lavfi",
+            "-i",
+            f"movie={video},signalstats",
+            "-show_entries",
+            "frame_tags=lavfi.signalstats.RAVG,lavfi.signalstats.GAVG,lavfi.signalstats.BAVG",
+            "-of",
+            "json",
         ]
         try:
-            result = subprocess.run(
-                cmd, capture_output=True, text=True, timeout=60
-            )
+            result = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
             if result.returncode != 0:
                 return None
 
@@ -296,7 +306,9 @@ class VisualQualityGuardrails:
         score = float(max(0, 100 - (deviation / optimal_contrast) * 100))
 
         if y_std < self.CONTRAST_MIN:
-            message = f"Video has low contrast (std dev: {y_std:.1f}). Image may appear flat. Consider increasing contrast."
+            message = (
+                f"Video has low contrast (std dev: {y_std:.1f}). Image may appear flat. Consider increasing contrast."
+            )
         elif y_std > self.CONTRAST_MAX:
             message = f"Video has very high contrast (std dev: {y_std:.1f}). May lose detail in shadows/highlights."
         else:
@@ -365,10 +377,14 @@ class VisualQualityGuardrails:
             # Check if video has audio
             cmd = [
                 "ffprobe",
-                "-v", "error",
-                "-select_streams", "a:0",
-                "-show_entries", "stream=codec_type",
-                "-of", "csv=p=0",
+                "-v",
+                "error",
+                "-select_streams",
+                "a:0",
+                "-show_entries",
+                "stream=codec_type",
+                "-of",
+                "csv=p=0",
                 video,
             ]
             try:
@@ -536,9 +552,7 @@ class VisualQualityGuardrails:
                 }
                 for c in checks
             ],
-            "recommendations": [
-                c.message for c in checks if not c.passed
-            ],
+            "recommendations": [c.message for c in checks if not c.passed],
         }
 
 

--- a/mcp_video/remotion_engine.py
+++ b/mcp_video/remotion_engine.py
@@ -40,6 +40,7 @@ from .remotion_models import (
 # Private helpers
 # ---------------------------------------------------------------------------
 
+
 def _require_remotion_deps() -> None:
     """Raise a helpful error if Node.js/npx are not available."""
     if shutil.which("node") is None:
@@ -110,6 +111,7 @@ def _run_remotion(
 # Public API
 # ---------------------------------------------------------------------------
 
+
 def render(
     project_path: str,
     composition_id: str,
@@ -137,7 +139,8 @@ def render(
         str(entry_point),
         composition_id,
         output_path,
-        "--codec", codec,
+        "--codec",
+        codec,
     ]
     if crf is not None:
         args += ["--crf", str(crf)]
@@ -193,6 +196,7 @@ def _parse_compositions_output(stdout: str) -> list[dict[str, Any]]:
     # Fallback: parse text format like:
     # McpVideoExplainer    30      1920x1080      1500 (50.00 sec)
     import re
+
     comps = []
     # Match lines with: Name  fps  WxH  frames (duration)
     pattern = re.compile(
@@ -200,14 +204,16 @@ def _parse_compositions_output(stdout: str) -> list[dict[str, Any]]:
         re.MULTILINE,
     )
     for m in pattern.finditer(stdout):
-        comps.append({
-            "id": m.group(1),
-            "fps": int(m.group(2)),
-            "width": int(m.group(3)),
-            "height": int(m.group(4)),
-            "durationInFrames": int(m.group(5)),
-            "defaultProps": {},
-        })
+        comps.append(
+            {
+                "id": m.group(1),
+                "fps": int(m.group(2)),
+                "width": int(m.group(3)),
+                "height": int(m.group(4)),
+                "durationInFrames": int(m.group(5)),
+                "defaultProps": {},
+            }
+        )
     return comps
 
 
@@ -232,14 +238,16 @@ def compositions(
 
     comp_list = []
     for c in raw:
-        comp_list.append(CompositionInfo(
-            id=c.get("id", c.get("compositionId", "")),
-            width=c.get("width", 1920),
-            height=c.get("height", 1080),
-            fps=c.get("fps", 30),
-            duration_in_frames=c.get("durationInFrames", c.get("duration", 0)),
-            default_props=c.get("defaultProps", {}),
-        ))
+        comp_list.append(
+            CompositionInfo(
+                id=c.get("id", c.get("compositionId", "")),
+                width=c.get("width", 1920),
+                height=c.get("height", 1080),
+                fps=c.get("fps", 30),
+                duration_in_frames=c.get("durationInFrames", c.get("duration", 0)),
+                default_props=c.get("defaultProps", {}),
+            )
+        )
 
     return CompositionsResult(
         compositions=comp_list,
@@ -292,8 +300,10 @@ def still(
         str(entry_point),
         composition_id,
         output_path,
-        "--frame", str(frame),
-        "--image-format", image_format,
+        "--frame",
+        str(frame),
+        "--image-format",
+        image_format,
     ]
 
     result = _run_remotion(args, cwd=project, timeout=120)
@@ -311,7 +321,7 @@ def still(
 # Template scaffolding helpers
 # ---------------------------------------------------------------------------
 
-_CONSTANTS_TSX = '''// Design tokens — edit these values to customize appearance
+_CONSTANTS_TSX = """// Design tokens — edit these values to customize appearance
 export const PRIMARY_COLOR = "{primary_color}";
 export const SECONDARY_COLOR = "{secondary_color}";
 export const BACKGROUND_COLOR = "{background_color}";
@@ -319,9 +329,9 @@ export const HEADING_FONT = "{heading_font}";
 export const BODY_FONT = "{body_font}";
 export const TARGET_FPS = {target_fps};
 export const TARGET_DURATION = {target_duration};
-'''
+"""
 
-_ROOT_TSX = '''import {{ Composition }} from "remotion";
+_ROOT_TSX = """import {{ Composition }} from "remotion";
 import React from "react";
 import {{ {slug}Composition }} from "./compositions/{slug}";
 
@@ -339,9 +349,9 @@ export const RemotionRoot: React.FC = () => {{
     </>
   );
 }};
-'''
+"""
 
-_COMPOSITION_TSX = '''import React from "react";
+_COMPOSITION_TSX = """import React from "react";
 import {{ AbsoluteFill, useCurrentFrame, interpolate }} from "remotion";
 import {{ PRIMARY_COLOR, TARGET_FPS }} from "../constants";
 
@@ -371,9 +381,9 @@ const {slug}Composition: React.FC<Props> = ({{ title, subtitle }}) => {{
 }};
 
 export default {slug}Composition;
-'''
+"""
 
-_PACKAGE_JSON = '''{{
+_PACKAGE_JSON = """{{
   "name": "{name}",
   "version": "1.0.0",
   "private": true,
@@ -395,9 +405,9 @@ _PACKAGE_JSON = '''{{
     "typescript": "^5"
   }}
 }}
-'''
+"""
 
-_TS_CONFIG = '''{{
+_TS_CONFIG = """{{
   "compilerOptions": {{
     "target": "ES2018",
     "module": "commonjs",
@@ -411,9 +421,9 @@ _TS_CONFIG = '''{{
   }},
   "include": ["src/**/*"]
 }}
-'''
+"""
 
-_HELLO_WORLD_TSX = '''import React from "react";
+_HELLO_WORLD_TSX = """import React from "react";
 import {{ AbsoluteFill, useCurrentFrame, interpolate, spring }} from "remotion";
 
 export const HelloWorld: React.FC = () => {{
@@ -439,7 +449,7 @@ export const HelloWorld: React.FC = () => {{
     </AbsoluteFill>
   );
 }};
-'''
+"""
 
 
 def create_project(
@@ -480,7 +490,7 @@ def create_project(
         (src_dir / "HelloWorld.tsx").write_text(_HELLO_WORLD_TSX)
         files.append("src/HelloWorld.tsx")
 
-        root_content = '''import { Composition } from "remotion";
+        root_content = """import { Composition } from "remotion";
 import React from "react";
 import { HelloWorld } from "./HelloWorld";
 
@@ -498,12 +508,12 @@ export const RemotionRoot: React.FC = () => {
     </>
   );
 };
-'''
+"""
         (src_dir / "Root.tsx").write_text(root_content)
         files.append("src/Root.tsx")
     else:
         # Blank template — minimal Root.tsx
-        root_content = '''import { Composition } from "remotion";
+        root_content = """import { Composition } from "remotion";
 import React from "react";
 
 export const RemotionRoot: React.FC = () => {
@@ -513,7 +523,7 @@ export const RemotionRoot: React.FC = () => {
     </>
   );
 };
-'''
+"""
         (src_dir / "Root.tsx").write_text(root_content)
         files.append("src/Root.tsx")
 
@@ -542,6 +552,7 @@ def scaffold_template(
     """Generate a generic composition from a spec."""
     # Sanitize slug — only alphanumeric, dashes, underscores
     import re
+
     if not re.fullmatch(r"[a-zA-Z0-9_-]+", slug):
         raise RemotionProjectError(
             project_path,
@@ -634,7 +645,10 @@ def validate(
     if not p.is_dir():
         issues.append("Project directory does not exist")
         return RemotionValidationResult(
-            valid=False, issues=issues, warnings=warnings, project_path=str(p),
+            valid=False,
+            issues=issues,
+            warnings=warnings,
+            project_path=str(p),
         )
 
     if not (p / "package.json").is_file():
@@ -660,7 +674,10 @@ def validate(
     valid = len(issues) == 0
 
     return RemotionValidationResult(
-        valid=valid, issues=issues, warnings=warnings, project_path=str(p),
+        valid=valid,
+        issues=issues,
+        warnings=warnings,
+        project_path=str(p),
     )
 
 
@@ -685,36 +702,43 @@ def render_and_post(
 
         if op_type == "resize":
             from .engine import resize
+
             result = resize(current_input, output_path=output_path, **params)
             current_input = result.output_path
             operations.append("resize")
         elif op_type == "convert":
             from .engine import convert
+
             result = convert(current_input, output_path=output_path, **params)
             current_input = result.output_path
             operations.append("convert")
         elif op_type == "add_audio":
             from .engine import add_audio
+
             result = add_audio(current_input, output_path=output_path, **params)
             current_input = result.output_path
             operations.append("add_audio")
         elif op_type == "normalize_audio":
             from .engine import normalize_audio
+
             result = normalize_audio(current_input, output_path=output_path, **params)
             current_input = result.output_path
             operations.append("normalize_audio")
         elif op_type == "add_text":
             from .engine import add_text
+
             result = add_text(current_input, output_path=output_path, **params)
             current_input = result.output_path
             operations.append("add_text")
         elif op_type == "fade":
             from .engine import fade
+
             result = fade(current_input, output_path=output_path, **params)
             current_input = result.output_path
             operations.append("fade")
         elif op_type == "watermark":
             from .engine import watermark
+
             result = watermark(current_input, output_path=output_path, **params)
             current_input = result.output_path
             operations.append("watermark")

--- a/mcp_video/remotion_models.py
+++ b/mcp_video/remotion_models.py
@@ -16,6 +16,7 @@ RemotionImageFormat = Literal["png", "jpeg", "webp"]
 
 # --- Result models ---
 
+
 class CompositionInfo(BaseModel):
     """A single composition found in a Remotion project."""
 

--- a/mcp_video/server.py
+++ b/mcp_video/server.py
@@ -98,7 +98,10 @@ def _error_result(err: MCPVideoError | Exception) -> dict[str, Any]:
 
 def _result(result: Any) -> dict[str, Any]:
     if result is None:
-        return {"success": False, "error": {"type": "processing_error", "code": "no_result", "message": "Operation returned no result"}}
+        return {
+            "success": False,
+            "error": {"type": "processing_error", "code": "no_result", "message": "Operation returned no result"},
+        }
     if hasattr(result, "model_dump"):
         data = result.model_dump()
         # Include thumbnail_base64 only if it was generated (keep MCP responses lean)
@@ -114,6 +117,7 @@ def _result(result: Any) -> dict[str, Any]:
 # ---------------------------------------------------------------------------
 # MCP Resources
 # ---------------------------------------------------------------------------
+
 
 @mcp.resource("mcp-video://video/{path}/info")
 def video_info_resource(path: str) -> str:
@@ -135,7 +139,7 @@ def video_preview_resource(path: str) -> str:
         count = 8
         for i in range(count):
             ts = dur * (i + 1) / (count + 1)
-            frames.append(f"Frame {i+1}: {ts:.1f}s")
+            frames.append(f"Frame {i + 1}: {ts:.1f}s")
         return "\n".join(frames)
     except MCPVideoError as e:
         return _error_result(e).__str__()
@@ -166,15 +170,20 @@ def templates_resource() -> str:
     data = {
         "aspect_ratios": {k: f"{v[0]}x{v[1]}" for k, v in ASPECT_RATIOS.items()},
         "quality_presets": {
-            k: f"CRF {v['crf']}, preset={v['preset']}, max_height={v['max_height']}"
-            for k, v in QUALITY_PRESETS.items()
+            k: f"CRF {v['crf']}, preset={v['preset']}, max_height={v['max_height']}" for k, v in QUALITY_PRESETS.items()
         },
         "transition_types": ["fade", "dissolve", "wipe-left", "wipe-right", "wipe-up", "wipe-down"],
         "export_formats": ["mp4", "webm", "gif", "mov"],
         "text_positions": [
-            "top-left", "top-center", "top-right",
-            "center-left", "center", "center-right",
-            "bottom-left", "bottom-center", "bottom-right",
+            "top-left",
+            "top-center",
+            "top-right",
+            "center-left",
+            "center",
+            "center-right",
+            "bottom-left",
+            "bottom-center",
+            "bottom-right",
         ],
     }
     return json.dumps(data, indent=2)
@@ -183,6 +192,7 @@ def templates_resource() -> str:
 # ---------------------------------------------------------------------------
 # MCP Tools
 # ---------------------------------------------------------------------------
+
 
 @mcp.tool()
 def video_info(input_path: str) -> dict[str, Any]:
@@ -226,10 +236,20 @@ def video_trim(
 
 
 VALID_XFADE_TRANSITIONS = {
-    "fade", "dissolve", "wipeleft", "wiperight",
-    "slideleft", "slideright", "slideup", "slidedown",
-    "circlecrop", "radial",
-    "smoothleft", "smoothright", "smoothup", "smoothdown",
+    "fade",
+    "dissolve",
+    "wipeleft",
+    "wiperight",
+    "slideleft",
+    "slideright",
+    "slideup",
+    "slidedown",
+    "circlecrop",
+    "radial",
+    "smoothleft",
+    "smoothright",
+    "smoothup",
+    "smoothdown",
 }
 
 
@@ -251,21 +271,33 @@ def video_merge(
         transition_duration: Duration of each transition in seconds.
     """
     if transition is not None and transition not in VALID_XFADE_TRANSITIONS:
-        return _error_result(MCPVideoError(
-            f"Invalid transition '{transition}'. Must be one of: {', '.join(sorted(VALID_XFADE_TRANSITIONS))}",
-            error_type="validation_error",
-            code="invalid_parameter",
-        ))
+        return _error_result(
+            MCPVideoError(
+                f"Invalid transition '{transition}'. Must be one of: {', '.join(sorted(VALID_XFADE_TRANSITIONS))}",
+                error_type="validation_error",
+                code="invalid_parameter",
+            )
+        )
     if transitions is not None:
         invalid = [t for t in transitions if t not in VALID_XFADE_TRANSITIONS]
         if invalid:
-            return _error_result(MCPVideoError(
-                f"Invalid transition(s): {', '.join(invalid)}. Must be one of: {', '.join(sorted(VALID_XFADE_TRANSITIONS))}",
-                error_type="validation_error",
-                code="invalid_parameter",
-            ))
+            return _error_result(
+                MCPVideoError(
+                    f"Invalid transition(s): {', '.join(invalid)}. Must be one of: {', '.join(sorted(VALID_XFADE_TRANSITIONS))}",
+                    error_type="validation_error",
+                    code="invalid_parameter",
+                )
+            )
     try:
-        return _result(merge(clips, output_path=output_path, transition=transition, transitions=transitions, transition_duration=transition_duration))
+        return _result(
+            merge(
+                clips,
+                output_path=output_path,
+                transition=transition,
+                transitions=transitions,
+                transition_duration=transition_duration,
+            )
+        )
     except MCPVideoError as e:
         return _error_result(e)
     except Exception as e:
@@ -304,22 +336,38 @@ def video_add_text(
         preset: Override FFmpeg encoding preset (ultrafast, fast, medium, slow, veryslow).
     """
     if crf is not None and not (0 <= crf <= 51):
-        return _error_result(MCPVideoError(f"crf must be 0-51, got {crf}", error_type="validation_error", code="invalid_parameter"))
+        return _error_result(
+            MCPVideoError(f"crf must be 0-51, got {crf}", error_type="validation_error", code="invalid_parameter")
+        )
     if preset is not None and preset not in VALID_PRESETS:
-        return _error_result(MCPVideoError(f"Invalid preset: {preset}", error_type="validation_error", code="invalid_parameter"))
+        return _error_result(
+            MCPVideoError(f"Invalid preset: {preset}", error_type="validation_error", code="invalid_parameter")
+        )
     try:
         if size < 8 or size > 500:
-            return _error_result(MCPVideoError(
-                f"Font size must be between 8 and 500, got {size}",
-                error_type="validation_error",
-                code="invalid_parameter",
-            ))
-        return _result(add_text(
-            input_path, text=text, position=position, font=font,
-            size=size, color=color, shadow=shadow,
-            start_time=start_time, duration=duration,
-            output_path=output_path, crf=crf, preset=preset,
-        ))
+            return _error_result(
+                MCPVideoError(
+                    f"Font size must be between 8 and 500, got {size}",
+                    error_type="validation_error",
+                    code="invalid_parameter",
+                )
+            )
+        return _result(
+            add_text(
+                input_path,
+                text=text,
+                position=position,
+                font=font,
+                size=size,
+                color=color,
+                shadow=shadow,
+                start_time=start_time,
+                duration=duration,
+                output_path=output_path,
+                crf=crf,
+                preset=preset,
+            )
+        )
     except MCPVideoError as e:
         return _error_result(e)
     except Exception as e:
@@ -351,33 +399,45 @@ def video_add_audio(
     """
     try:
         if not 0 <= volume <= 2.0:
-            return _error_result(MCPVideoError(
-                f"volume must be between 0.0 and 2.0, got {volume}",
-                error_type="validation_error",
-                code="invalid_parameter",
-            ))
+            return _error_result(
+                MCPVideoError(
+                    f"volume must be between 0.0 and 2.0, got {volume}",
+                    error_type="validation_error",
+                    code="invalid_parameter",
+                )
+            )
         if fade_in is not None and fade_in < 0:
-            return _error_result(MCPVideoError(
-                f"fade_in must be non-negative, got {fade_in}",
-                error_type="validation_error",
-                code="invalid_parameter",
-            ))
+            return _error_result(
+                MCPVideoError(
+                    f"fade_in must be non-negative, got {fade_in}",
+                    error_type="validation_error",
+                    code="invalid_parameter",
+                )
+            )
         if fade_out is not None and fade_out < 0:
-            return _error_result(MCPVideoError(
-                f"fade_out must be non-negative, got {fade_out}",
-                error_type="validation_error",
-                code="invalid_parameter",
-            ))
-        return _result(add_audio(
-            video_path, audio_path=audio_path, volume=volume,
-            fade_in=fade_in, fade_out=fade_out, mix=mix,
-            start_time=start_time, output_path=output_path,
-        ))
+            return _error_result(
+                MCPVideoError(
+                    f"fade_out must be non-negative, got {fade_out}",
+                    error_type="validation_error",
+                    code="invalid_parameter",
+                )
+            )
+        return _result(
+            add_audio(
+                video_path,
+                audio_path=audio_path,
+                volume=volume,
+                fade_in=fade_in,
+                fade_out=fade_out,
+                mix=mix,
+                start_time=start_time,
+                output_path=output_path,
+            )
+        )
     except MCPVideoError as e:
         return _error_result(e)
     except Exception as e:
         return _error_result(e)
-
 
 
 @mcp.tool()
@@ -400,35 +460,48 @@ def video_resize(
         output_path: Where to save the output. Auto-generated if omitted.
     """
     if width is not None and width > MAX_RESOLUTION:
-        return _error_result(MCPVideoError(
-            f"Width {width} exceeds maximum resolution of {MAX_RESOLUTION}",
-            error_type="validation_error",
-            code="resolution_too_high",
-        ))
+        return _error_result(
+            MCPVideoError(
+                f"Width {width} exceeds maximum resolution of {MAX_RESOLUTION}",
+                error_type="validation_error",
+                code="resolution_too_high",
+            )
+        )
     if width is not None and width <= 0:
-        return _error_result(MCPVideoError(
-            f"Width must be positive, got {width}",
-            error_type="validation_error",
-            code="invalid_parameter",
-        ))
+        return _error_result(
+            MCPVideoError(
+                f"Width must be positive, got {width}",
+                error_type="validation_error",
+                code="invalid_parameter",
+            )
+        )
     if height is not None and height > MAX_RESOLUTION:
-        return _error_result(MCPVideoError(
-            f"Height {height} exceeds maximum resolution of {MAX_RESOLUTION}",
-            error_type="validation_error",
-            code="resolution_too_high",
-        ))
+        return _error_result(
+            MCPVideoError(
+                f"Height {height} exceeds maximum resolution of {MAX_RESOLUTION}",
+                error_type="validation_error",
+                code="resolution_too_high",
+            )
+        )
     if height is not None and height <= 0:
-        return _error_result(MCPVideoError(
-            f"Height must be positive, got {height}",
-            error_type="validation_error",
-            code="invalid_parameter",
-        ))
+        return _error_result(
+            MCPVideoError(
+                f"Height must be positive, got {height}",
+                error_type="validation_error",
+                code="invalid_parameter",
+            )
+        )
     try:
-        return _result(resize(
-            input_path, width=width, height=height,
-            aspect_ratio=aspect_ratio, quality=quality,
-            output_path=output_path,
-        ))
+        return _result(
+            resize(
+                input_path,
+                width=width,
+                height=height,
+                aspect_ratio=aspect_ratio,
+                quality=quality,
+                output_path=output_path,
+            )
+        )
     except MCPVideoError as e:
         return _error_result(e)
     except Exception as e:
@@ -451,12 +524,22 @@ def video_convert(
         output_path: Where to save the output. Auto-generated if omitted.
     """
     if format not in VALID_FORMATS:
-        return _error_result(MCPVideoError(f"Invalid format: {format}. Must be one of {sorted(VALID_FORMATS)}", error_type="validation_error", code="invalid_parameter"))
+        return _error_result(
+            MCPVideoError(
+                f"Invalid format: {format}. Must be one of {sorted(VALID_FORMATS)}",
+                error_type="validation_error",
+                code="invalid_parameter",
+            )
+        )
     try:
-        return _result(convert(
-            input_path, format=format, quality=quality,
-            output_path=output_path,
-        ))
+        return _result(
+            convert(
+                input_path,
+                format=format,
+                quality=quality,
+                output_path=output_path,
+            )
+        )
     except MCPVideoError as e:
         return _error_result(e)
     except Exception as e:
@@ -477,11 +560,13 @@ def video_speed(
         output_path: Where to save the output. Auto-generated if omitted.
     """
     if not (MIN_SPEED_FACTOR <= factor <= MAX_SPEED_FACTOR):
-        return _error_result(MCPVideoError(
-            f"Speed factor {factor} out of range [{MIN_SPEED_FACTOR}, {MAX_SPEED_FACTOR}]",
-            error_type="validation_error",
-            code="speed_out_of_range",
-        ))
+        return _error_result(
+            MCPVideoError(
+                f"Speed factor {factor} out of range [{MIN_SPEED_FACTOR}, {MAX_SPEED_FACTOR}]",
+                error_type="validation_error",
+                code="speed_out_of_range",
+            )
+        )
     try:
         return _result(speed(input_path, factor=factor, output_path=output_path))
     except MCPVideoError as e:
@@ -527,17 +612,21 @@ def video_preview(
     try:
         MAX_SCALE_FACTOR = 16
         if scale_factor < 2:
-            return _error_result(MCPVideoError(
-                f"scale_factor must be at least 2, got {scale_factor}",
-                error_type="validation_error",
-                code="invalid_parameter",
-            ))
+            return _error_result(
+                MCPVideoError(
+                    f"scale_factor must be at least 2, got {scale_factor}",
+                    error_type="validation_error",
+                    code="invalid_parameter",
+                )
+            )
         if scale_factor > MAX_SCALE_FACTOR:
-            return _error_result(MCPVideoError(
-                f"scale_factor must be at most {MAX_SCALE_FACTOR}, got {scale_factor}",
-                error_type="validation_error",
-                code="invalid_parameter",
-            ))
+            return _error_result(
+                MCPVideoError(
+                    f"scale_factor must be at most {MAX_SCALE_FACTOR}, got {scale_factor}",
+                    error_type="validation_error",
+                    code="invalid_parameter",
+                )
+            )
         return _result(preview(input_path, output_path=output_path, scale_factor=scale_factor))
     except MCPVideoError as e:
         return _error_result(e)
@@ -561,11 +650,13 @@ def video_storyboard(
     try:
         MAX_FRAME_COUNT = 100
         if frame_count is not None and (frame_count < 1 or frame_count > MAX_FRAME_COUNT):
-            return _error_result(MCPVideoError(
-                f"frame_count must be between 1 and {MAX_FRAME_COUNT}, got {frame_count}",
-                error_type="validation_error",
-                code="invalid_parameter",
-            ))
+            return _error_result(
+                MCPVideoError(
+                    f"frame_count must be between 1 and {MAX_FRAME_COUNT}, got {frame_count}",
+                    error_type="validation_error",
+                    code="invalid_parameter",
+                )
+            )
         return _result(storyboard(input_path, output_dir=output_dir, frame_count=frame_count))
     except MCPVideoError as e:
         return _error_result(e)
@@ -618,27 +709,42 @@ def video_watermark(
         preset: Override FFmpeg encoding preset (ultrafast, fast, medium, slow, veryslow).
     """
     if not 0 <= opacity <= 1:
-        return _error_result(MCPVideoError(
-            f"opacity must be between 0 and 1, got {opacity}",
-            error_type="validation_error",
-            code="invalid_parameter",
-        ))
+        return _error_result(
+            MCPVideoError(
+                f"opacity must be between 0 and 1, got {opacity}",
+                error_type="validation_error",
+                code="invalid_parameter",
+            )
+        )
     if margin < 0:
-        return _error_result(MCPVideoError(
-            f"margin must be non-negative, got {margin}",
-            error_type="validation_error",
-            code="invalid_parameter",
-        ))
+        return _error_result(
+            MCPVideoError(
+                f"margin must be non-negative, got {margin}",
+                error_type="validation_error",
+                code="invalid_parameter",
+            )
+        )
     if crf is not None and not (0 <= crf <= 51):
-        return _error_result(MCPVideoError(f"crf must be 0-51, got {crf}", error_type="validation_error", code="invalid_parameter"))
+        return _error_result(
+            MCPVideoError(f"crf must be 0-51, got {crf}", error_type="validation_error", code="invalid_parameter")
+        )
     if preset is not None and preset not in VALID_PRESETS:
-        return _error_result(MCPVideoError(f"Invalid preset: {preset}", error_type="validation_error", code="invalid_parameter"))
+        return _error_result(
+            MCPVideoError(f"Invalid preset: {preset}", error_type="validation_error", code="invalid_parameter")
+        )
     try:
-        return _result(watermark(
-            input_path, image_path=image_path, position=position,
-            opacity=opacity, margin=margin, output_path=output_path,
-            crf=crf, preset=preset,
-        ))
+        return _result(
+            watermark(
+                input_path,
+                image_path=image_path,
+                position=position,
+                opacity=opacity,
+                margin=margin,
+                output_path=output_path,
+                crf=crf,
+                preset=preset,
+            )
+        )
     except MCPVideoError as e:
         return _error_result(e)
     except Exception as e:
@@ -661,12 +767,22 @@ def video_export(
         format: Output format (mp4, webm, gif, mov).
     """
     if format not in VALID_FORMATS:
-        return _error_result(MCPVideoError(f"Invalid format: {format}. Must be one of {sorted(VALID_FORMATS)}", error_type="validation_error", code="invalid_parameter"))
+        return _error_result(
+            MCPVideoError(
+                f"Invalid format: {format}. Must be one of {sorted(VALID_FORMATS)}",
+                error_type="validation_error",
+                code="invalid_parameter",
+            )
+        )
     try:
-        return _result(export_video(
-            input_path, output_path=output_path,
-            quality=quality, format=format,
-        ))
+        return _result(
+            export_video(
+                input_path,
+                output_path=output_path,
+                quality=quality,
+                format=format,
+            )
+        )
     except MCPVideoError as e:
         return _error_result(e)
     except Exception as e:
@@ -718,7 +834,15 @@ def video_rotate(
         output_path: Where to save the output. Auto-generated if omitted.
     """
     try:
-        return _result(rotate(input_path, angle=angle, flip_horizontal=flip_horizontal, flip_vertical=flip_vertical, output_path=output_path))
+        return _result(
+            rotate(
+                input_path,
+                angle=angle,
+                flip_horizontal=flip_horizontal,
+                flip_vertical=flip_vertical,
+                output_path=output_path,
+            )
+        )
     except MCPVideoError as e:
         return _error_result(e)
     except Exception as e:
@@ -745,26 +869,40 @@ def video_fade(
         preset: Override FFmpeg encoding preset (ultrafast, fast, medium, slow, veryslow).
     """
     if crf is not None and not (0 <= crf <= 51):
-        return _error_result(MCPVideoError(f"crf must be 0-51, got {crf}", error_type="validation_error", code="invalid_parameter"))
+        return _error_result(
+            MCPVideoError(f"crf must be 0-51, got {crf}", error_type="validation_error", code="invalid_parameter")
+        )
     if preset is not None and preset not in VALID_PRESETS:
-        return _error_result(MCPVideoError(f"Invalid preset: {preset}", error_type="validation_error", code="invalid_parameter"))
+        return _error_result(
+            MCPVideoError(f"Invalid preset: {preset}", error_type="validation_error", code="invalid_parameter")
+        )
     try:
         if fade_in < 0:
-            return _error_result(MCPVideoError(
-                f"fade_in must be non-negative, got {fade_in}",
-                error_type="validation_error",
-                code="invalid_parameter",
-            ))
+            return _error_result(
+                MCPVideoError(
+                    f"fade_in must be non-negative, got {fade_in}",
+                    error_type="validation_error",
+                    code="invalid_parameter",
+                )
+            )
         if fade_out < 0:
-            return _error_result(MCPVideoError(
-                f"fade_out must be non-negative, got {fade_out}",
-                error_type="validation_error",
-                code="invalid_parameter",
-            ))
-        return _result(fade(
-            input_path, fade_in=fade_in, fade_out=fade_out,
-            output_path=output_path, crf=crf, preset=preset,
-        ))
+            return _error_result(
+                MCPVideoError(
+                    f"fade_out must be non-negative, got {fade_out}",
+                    error_type="validation_error",
+                    code="invalid_parameter",
+                )
+            )
+        return _result(
+            fade(
+                input_path,
+                fade_in=fade_in,
+                fade_out=fade_out,
+                output_path=output_path,
+                crf=crf,
+                preset=preset,
+            )
+        )
     except MCPVideoError as e:
         return _error_result(e)
     except Exception as e:
@@ -810,15 +948,23 @@ def video_extract_audio(
         format: Audio format (mp3, aac, wav, ogg, flac).
     """
     if format not in VALID_AUDIO_FORMATS:
-        return _error_result(MCPVideoError(f"Invalid audio format: {format}. Must be one of {sorted(VALID_AUDIO_FORMATS)}", error_type="validation_error", code="invalid_parameter"))
+        return _error_result(
+            MCPVideoError(
+                f"Invalid audio format: {format}. Must be one of {sorted(VALID_AUDIO_FORMATS)}",
+                error_type="validation_error",
+                code="invalid_parameter",
+            )
+        )
     try:
         result = extract_audio(input_path, output_path=output_path, format=format)
         if not os.path.isfile(result):
-            return _error_result(MCPVideoError(
-                f"Audio extraction completed but output file not found: {result}",
-                error_type="processing_error",
-                code="missing_output",
-            ))
+            return _error_result(
+                MCPVideoError(
+                    f"Audio extraction completed but output file not found: {result}",
+                    error_type="processing_error",
+                    code="missing_output",
+                )
+            )
         size_mb = os.path.getsize(result) / (1024 * 1024)
         return {
             "success": True,
@@ -830,11 +976,13 @@ def video_extract_audio(
     except MCPVideoError as e:
         return _error_result(e)
     except OSError as e:
-        return _error_result(MCPVideoError(
-            f"File error during audio extraction: {e}",
-            error_type="processing_error",
-            code="file_error",
-        ))
+        return _error_result(
+            MCPVideoError(
+                f"File error during audio extraction: {e}",
+                error_type="processing_error",
+                code="file_error",
+            )
+        )
     except Exception as e:
         return _error_result(e)
 
@@ -859,14 +1007,24 @@ def video_filter(
         preset: Override FFmpeg encoding preset (ultrafast, fast, medium, slow, veryslow).
     """
     if crf is not None and not (0 <= crf <= 51):
-        return _error_result(MCPVideoError(f"crf must be 0-51, got {crf}", error_type="validation_error", code="invalid_parameter"))
+        return _error_result(
+            MCPVideoError(f"crf must be 0-51, got {crf}", error_type="validation_error", code="invalid_parameter")
+        )
     if preset is not None and preset not in VALID_PRESETS:
-        return _error_result(MCPVideoError(f"Invalid preset: {preset}", error_type="validation_error", code="invalid_parameter"))
+        return _error_result(
+            MCPVideoError(f"Invalid preset: {preset}", error_type="validation_error", code="invalid_parameter")
+        )
     try:
-        return _result(apply_filter(
-            input_path, filter_type=filter_type, params=params,
-            output_path=output_path, crf=crf, preset=preset,
-        ))
+        return _result(
+            apply_filter(
+                input_path,
+                filter_type=filter_type,
+                params=params,
+                output_path=output_path,
+                crf=crf,
+                preset=preset,
+            )
+        )
     except MCPVideoError as e:
         return _error_result(e)
     except Exception as e:
@@ -911,23 +1069,29 @@ def video_chroma_key(
     """
     # Validate color doesn't contain FFmpeg filter injection characters
     if any(c in color for c in (":", "]", "[", ";", "\x00")):
-        return _error_result(MCPVideoError(
-            f"Invalid color value containing forbidden characters: {color}",
-            error_type="validation_error",
-            code="invalid_parameter",
-        ))
+        return _error_result(
+            MCPVideoError(
+                f"Invalid color value containing forbidden characters: {color}",
+                error_type="validation_error",
+                code="invalid_parameter",
+            )
+        )
     if not 0 <= similarity <= 1:
-        return _error_result(MCPVideoError(
-            f"similarity must be between 0 and 1, got {similarity}",
-            error_type="validation_error",
-            code="invalid_parameter",
-        ))
+        return _error_result(
+            MCPVideoError(
+                f"similarity must be between 0 and 1, got {similarity}",
+                error_type="validation_error",
+                code="invalid_parameter",
+            )
+        )
     if not 0 <= blend <= 1:
-        return _error_result(MCPVideoError(
-            f"blend must be between 0 and 1, got {blend}",
-            error_type="validation_error",
-            code="invalid_parameter",
-        ))
+        return _error_result(
+            MCPVideoError(
+                f"blend must be between 0 and 1, got {blend}",
+                error_type="validation_error",
+                code="invalid_parameter",
+            )
+        )
     try:
         return _result(chroma_key(input_path, color=color, similarity=similarity, blend=blend, output_path=output_path))
     except MCPVideoError as e:
@@ -952,11 +1116,14 @@ def video_blur(
         output_path: Where to save the output. Auto-generated if omitted.
     """
     try:
-        return _result(apply_filter(
-            input_path, filter_type="blur",
-            params={"radius": radius, "strength": strength},
-            output_path=output_path,
-        ))
+        return _result(
+            apply_filter(
+                input_path,
+                filter_type="blur",
+                params={"radius": radius, "strength": strength},
+                output_path=output_path,
+            )
+        )
     except MCPVideoError as e:
         return _error_result(e)
     except Exception as e:
@@ -977,11 +1144,14 @@ def video_color_grade(
         output_path: Where to save the output. Auto-generated if omitted.
     """
     try:
-        return _result(apply_filter(
-            input_path, filter_type="color_preset",
-            params={"preset": preset},
-            output_path=output_path,
-        ))
+        return _result(
+            apply_filter(
+                input_path,
+                filter_type="color_preset",
+                params={"preset": preset},
+                output_path=output_path,
+            )
+        )
     except MCPVideoError as e:
         return _error_result(e)
     except Exception as e:
@@ -1005,11 +1175,13 @@ def video_normalize_audio(
     """
     try:
         if not -70 <= target_lufs <= -5:
-            return _error_result(MCPVideoError(
-                f"target_lufs must be between -70 and -5, got {target_lufs}",
-                error_type="validation_error",
-                code="invalid_parameter",
-            ))
+            return _error_result(
+                MCPVideoError(
+                    f"target_lufs must be between -70 and -5, got {target_lufs}",
+                    error_type="validation_error",
+                    code="invalid_parameter",
+                )
+            )
         return _result(normalize_audio(input_path, target_lufs=target_lufs, output_path=output_path))
     except MCPVideoError as e:
         return _error_result(e)
@@ -1047,34 +1219,53 @@ def video_overlay(
         preset: Override FFmpeg encoding preset (ultrafast, fast, medium, slow, veryslow).
     """
     if width is not None and width <= 0:
-        return _error_result(MCPVideoError(
-            f"width must be positive, got {width}",
-            error_type="validation_error",
-            code="invalid_parameter",
-        ))
-    if height is not None and height <= 0:
-        return _error_result(MCPVideoError(
-            f"height must be positive, got {height}",
-            error_type="validation_error",
-            code="invalid_parameter",
-        ))
-    if crf is not None and not (0 <= crf <= 51):
-        return _error_result(MCPVideoError(f"crf must be 0-51, got {crf}", error_type="validation_error", code="invalid_parameter"))
-    if preset is not None and preset not in VALID_PRESETS:
-        return _error_result(MCPVideoError(f"Invalid preset: {preset}", error_type="validation_error", code="invalid_parameter"))
-    try:
-        if not 0 <= opacity <= 1:
-            return _error_result(MCPVideoError(
-                f"opacity must be between 0 and 1, got {opacity}",
+        return _error_result(
+            MCPVideoError(
+                f"width must be positive, got {width}",
                 error_type="validation_error",
                 code="invalid_parameter",
-            ))
-        return _result(overlay_video(
-            background_path, overlay_path=overlay_path, position=position,
-            width=width, height=height, opacity=opacity,
-            start_time=start_time, duration=duration,
-            output_path=output_path, crf=crf, preset=preset,
-        ))
+            )
+        )
+    if height is not None and height <= 0:
+        return _error_result(
+            MCPVideoError(
+                f"height must be positive, got {height}",
+                error_type="validation_error",
+                code="invalid_parameter",
+            )
+        )
+    if crf is not None and not (0 <= crf <= 51):
+        return _error_result(
+            MCPVideoError(f"crf must be 0-51, got {crf}", error_type="validation_error", code="invalid_parameter")
+        )
+    if preset is not None and preset not in VALID_PRESETS:
+        return _error_result(
+            MCPVideoError(f"Invalid preset: {preset}", error_type="validation_error", code="invalid_parameter")
+        )
+    try:
+        if not 0 <= opacity <= 1:
+            return _error_result(
+                MCPVideoError(
+                    f"opacity must be between 0 and 1, got {opacity}",
+                    error_type="validation_error",
+                    code="invalid_parameter",
+                )
+            )
+        return _result(
+            overlay_video(
+                background_path,
+                overlay_path=overlay_path,
+                position=position,
+                width=width,
+                height=height,
+                opacity=opacity,
+                start_time=start_time,
+                duration=duration,
+                output_path=output_path,
+                crf=crf,
+                preset=preset,
+            )
+        )
     except MCPVideoError as e:
         return _error_result(e)
     except Exception as e:
@@ -1097,11 +1288,13 @@ def video_split_screen(
         output_path: Where to save the output. Auto-generated if omitted.
     """
     if layout not in VALID_LAYOUTS:
-        return _error_result(MCPVideoError(
-            f"Invalid layout: must be one of {sorted(VALID_LAYOUTS)}, got '{layout}'",
-            error_type="validation_error",
-            code="invalid_parameter",
-        ))
+        return _error_result(
+            MCPVideoError(
+                f"Invalid layout: must be one of {sorted(VALID_LAYOUTS)}, got '{layout}'",
+                error_type="validation_error",
+                code="invalid_parameter",
+            )
+        )
     try:
         return _result(split_screen(left_path, right_path=right_path, layout=layout, output_path=output_path))
     except MCPVideoError as e:
@@ -1125,17 +1318,21 @@ def video_detect_scenes(
     """
     try:
         if not 0 <= threshold <= 1:
-            return _error_result(MCPVideoError(
-                f"threshold must be between 0 and 1, got {threshold}",
-                error_type="validation_error",
-                code="invalid_parameter",
-            ))
+            return _error_result(
+                MCPVideoError(
+                    f"threshold must be between 0 and 1, got {threshold}",
+                    error_type="validation_error",
+                    code="invalid_parameter",
+                )
+            )
         if min_scene_duration <= 0:
-            return _error_result(MCPVideoError(
-                f"min_scene_duration must be positive, got {min_scene_duration}",
-                error_type="validation_error",
-                code="invalid_parameter",
-            ))
+            return _error_result(
+                MCPVideoError(
+                    f"min_scene_duration must be positive, got {min_scene_duration}",
+                    error_type="validation_error",
+                    code="invalid_parameter",
+                )
+            )
         return _result(detect_scenes(input_path, threshold=threshold, min_scene_duration=min_scene_duration))
     except MCPVideoError as e:
         return _error_result(e)
@@ -1158,11 +1355,13 @@ def video_create_from_images(
     """
     try:
         if fps <= 0 or fps > MAX_EXPORT_FRAMES_FPS:
-            return _error_result(MCPVideoError(
-                f"fps must be between 1 and {MAX_EXPORT_FRAMES_FPS}, got {fps}",
-                error_type="validation_error",
-                code="invalid_parameter",
-            ))
+            return _error_result(
+                MCPVideoError(
+                    f"fps must be between 1 and {MAX_EXPORT_FRAMES_FPS}, got {fps}",
+                    error_type="validation_error",
+                    code="invalid_parameter",
+                )
+            )
         return _result(create_from_images(images, output_path=output_path, fps=fps))
     except MCPVideoError as e:
         return _error_result(e)
@@ -1186,17 +1385,21 @@ def video_export_frames(
         format: Output image format (jpg or png, default jpg).
     """
     if fps <= 0:
-        return _error_result(MCPVideoError(
-            f"fps must be positive, got {fps}",
-            error_type="validation_error",
-            code="invalid_parameter",
-        ))
+        return _error_result(
+            MCPVideoError(
+                f"fps must be positive, got {fps}",
+                error_type="validation_error",
+                code="invalid_parameter",
+            )
+        )
     if fps > MAX_EXPORT_FRAMES_FPS:
-        return _error_result(MCPVideoError(
-            f"FPS {fps} exceeds maximum of {MAX_EXPORT_FRAMES_FPS}",
-            error_type="validation_error",
-            code="fps_too_high",
-        ))
+        return _error_result(
+            MCPVideoError(
+                f"FPS {fps} exceeds maximum of {MAX_EXPORT_FRAMES_FPS}",
+                error_type="validation_error",
+                code="fps_too_high",
+            )
+        )
     try:
         return _result(export_frames(input_path, output_dir=output_dir, fps=fps, format=format))
     except MCPVideoError as e:
@@ -1219,11 +1422,13 @@ def video_generate_subtitles(
         burn: If True, burn subtitles into the video (default False).
     """
     if not isinstance(entries, list) or len(entries) == 0:
-        return _error_result(MCPVideoError(
-            "entries must be a non-empty list",
-            error_type="validation_error",
-            code="invalid_parameter",
-        ))
+        return _error_result(
+            MCPVideoError(
+                "entries must be a non-empty list",
+                error_type="validation_error",
+                code="invalid_parameter",
+            )
+        )
     try:
         return _result(generate_subtitles(entries, input_path, burn=burn))
     except MCPVideoError as e:
@@ -1308,17 +1513,21 @@ def video_stabilize(
     """
     try:
         if smoothing < 0:
-            return _error_result(MCPVideoError(
-                f"smoothing must be non-negative, got {smoothing}",
-                error_type="validation_error",
-                code="invalid_parameter",
-            ))
+            return _error_result(
+                MCPVideoError(
+                    f"smoothing must be non-negative, got {smoothing}",
+                    error_type="validation_error",
+                    code="invalid_parameter",
+                )
+            )
         if zooming < 0:
-            return _error_result(MCPVideoError(
-                f"zooming must be non-negative, got {zooming}",
-                error_type="validation_error",
-                code="invalid_parameter",
-            ))
+            return _error_result(
+                MCPVideoError(
+                    f"zooming must be non-negative, got {zooming}",
+                    error_type="validation_error",
+                    code="invalid_parameter",
+                )
+            )
         return _result(stabilize(input_path, smoothing=smoothing, zooming=zooming, output_path=output_path))
     except MCPVideoError as e:
         return _error_result(e)
@@ -1343,11 +1552,13 @@ def video_apply_mask(
     """
     try:
         if feather < 0:
-            return _error_result(MCPVideoError(
-                f"feather must be non-negative, got {feather}",
-                error_type="validation_error",
-                code="invalid_parameter",
-            ))
+            return _error_result(
+                MCPVideoError(
+                    f"feather must be non-negative, got {feather}",
+                    error_type="validation_error",
+                    code="invalid_parameter",
+                )
+            )
         return _result(apply_mask(input_path, mask_path=mask_path, feather=feather, output_path=output_path))
     except MCPVideoError as e:
         return _error_result(e)
@@ -1368,11 +1579,13 @@ def video_audio_waveform(
     """
     try:
         if bins < 1 or bins > 1000:
-            return _error_result(MCPVideoError(
-                f"bins must be between 1 and 1000, got {bins}",
-                error_type="validation_error",
-                code="invalid_parameter",
-            ))
+            return _error_result(
+                MCPVideoError(
+                    f"bins must be between 1 and 1000, got {bins}",
+                    error_type="validation_error",
+                    code="invalid_parameter",
+                )
+            )
         return _result(audio_waveform(input_path, bins=bins))
     except MCPVideoError as e:
         return _error_result(e)
@@ -1399,21 +1612,33 @@ def video_batch(
         output_dir: Directory for output files. Auto-generated if omitted.
     """
     VALID_BATCH_OPERATIONS = {
-        "trim", "resize", "convert", "filter", "blur", "color_grade",
-        "watermark", "speed", "fade", "normalize_audio",
+        "trim",
+        "resize",
+        "convert",
+        "filter",
+        "blur",
+        "color_grade",
+        "watermark",
+        "speed",
+        "fade",
+        "normalize_audio",
     }
     if operation not in VALID_BATCH_OPERATIONS:
-        return _error_result(MCPVideoError(
-            f"Unknown operation '{operation}'. Valid operations: {sorted(VALID_BATCH_OPERATIONS)}",
-            error_type="validation_error",
-            code="invalid_operation",
-        ))
+        return _error_result(
+            MCPVideoError(
+                f"Unknown operation '{operation}'. Valid operations: {sorted(VALID_BATCH_OPERATIONS)}",
+                error_type="validation_error",
+                code="invalid_operation",
+            )
+        )
     if len(inputs) > MAX_BATCH_SIZE:
-        return _error_result(MCPVideoError(
-            f"Batch size {len(inputs)} exceeds maximum of {MAX_BATCH_SIZE}",
-            error_type="validation_error",
-            code="batch_too_large",
-        ))
+        return _error_result(
+            MCPVideoError(
+                f"Batch size {len(inputs)} exceeds maximum of {MAX_BATCH_SIZE}",
+                error_type="validation_error",
+                code="batch_too_large",
+            )
+        )
     try:
         return _result(_video_batch(inputs, operation, params, output_dir))
     except MCPVideoError as e:
@@ -1447,6 +1672,7 @@ def video_extract_frame(
 # Image Analysis Tools
 # ---------------------------------------------------------------------------
 
+
 @mcp.tool()
 def image_extract_colors(
     image_path: str,
@@ -1463,6 +1689,7 @@ def image_extract_colors(
     """
     try:
         from .image_engine import extract_colors
+
         return _result(extract_colors(image_path, n_colors=n_colors))
     except MCPVideoError as e:
         return _error_result(e)
@@ -1488,6 +1715,7 @@ def image_generate_palette(
     """
     try:
         from .image_engine import generate_palette
+
         return _result(generate_palette(image_path, harmony=harmony, n_colors=n_colors))
     except MCPVideoError as e:
         return _error_result(e)
@@ -1513,6 +1741,7 @@ def image_analyze_product(
     """
     try:
         from .image_engine import analyze_product
+
         return _result(analyze_product(image_path, use_ai=use_ai, n_colors=n_colors))
     except MCPVideoError as e:
         return _error_result(e)
@@ -1523,6 +1752,7 @@ def image_analyze_product(
 # ---------------------------------------------------------------------------
 # Remotion Integration Tools
 # ---------------------------------------------------------------------------
+
 
 @mcp.tool()
 def remotion_render(
@@ -1556,20 +1786,70 @@ def remotion_render(
         scale: Render scale factor.
     """
     if codec not in VALID_CODECS:
-        return _error_result(MCPVideoError(f"Invalid codec: must be one of {sorted(VALID_CODECS)}, got '{codec}'", error_type="validation_error", code="invalid_parameter"))
+        return _error_result(
+            MCPVideoError(
+                f"Invalid codec: must be one of {sorted(VALID_CODECS)}, got '{codec}'",
+                error_type="validation_error",
+                code="invalid_parameter",
+            )
+        )
     if width is not None and (width < 1 or width > MAX_RESOLUTION):
-        return _error_result(MCPVideoError(f"Invalid width: must be 1-{MAX_RESOLUTION}, got {width}", error_type="validation_error", code="invalid_parameter"))
+        return _error_result(
+            MCPVideoError(
+                f"Invalid width: must be 1-{MAX_RESOLUTION}, got {width}",
+                error_type="validation_error",
+                code="invalid_parameter",
+            )
+        )
     if height is not None and (height < 1 or height > MAX_RESOLUTION):
-        return _error_result(MCPVideoError(f"Invalid height: must be 1-{MAX_RESOLUTION}, got {height}", error_type="validation_error", code="invalid_parameter"))
+        return _error_result(
+            MCPVideoError(
+                f"Invalid height: must be 1-{MAX_RESOLUTION}, got {height}",
+                error_type="validation_error",
+                code="invalid_parameter",
+            )
+        )
     if concurrency is not None and (concurrency < 1 or concurrency > MAX_CONCURRENCY):
-        return _error_result(MCPVideoError(f"Invalid concurrency: must be 1-{MAX_CONCURRENCY}, got {concurrency}", error_type="validation_error", code="invalid_parameter"))
+        return _error_result(
+            MCPVideoError(
+                f"Invalid concurrency: must be 1-{MAX_CONCURRENCY}, got {concurrency}",
+                error_type="validation_error",
+                code="invalid_parameter",
+            )
+        )
     if scale is not None and scale <= 0:
-        return _error_result(MCPVideoError(f"Invalid scale: must be > 0, got {scale}", error_type="validation_error", code="invalid_parameter"))
+        return _error_result(
+            MCPVideoError(
+                f"Invalid scale: must be > 0, got {scale}", error_type="validation_error", code="invalid_parameter"
+            )
+        )
     if crf is not None and (crf < MIN_CRF or crf > MAX_CRF):
-        return _error_result(MCPVideoError(f"Invalid crf: must be {MIN_CRF}-{MAX_CRF}, got {crf}", error_type="validation_error", code="invalid_parameter"))
+        return _error_result(
+            MCPVideoError(
+                f"Invalid crf: must be {MIN_CRF}-{MAX_CRF}, got {crf}",
+                error_type="validation_error",
+                code="invalid_parameter",
+            )
+        )
     try:
         from .remotion_engine import render
-        return _result(render(project_path, composition_id, output_path=output_path, codec=codec, crf=crf, width=width, height=height, fps=fps, concurrency=concurrency, frames=frames, props=props, scale=scale))
+
+        return _result(
+            render(
+                project_path,
+                composition_id,
+                output_path=output_path,
+                codec=codec,
+                crf=crf,
+                width=width,
+                height=height,
+                fps=fps,
+                concurrency=concurrency,
+                frames=frames,
+                props=props,
+                scale=scale,
+            )
+        )
     except MCPVideoError as e:
         return _error_result(e)
     except Exception as e:
@@ -1587,6 +1867,7 @@ def remotion_compositions(
     """
     try:
         from .remotion_engine import compositions
+
         return _result(compositions(project_path))
     except MCPVideoError as e:
         return _error_result(e)
@@ -1606,9 +1887,16 @@ def remotion_studio(
         port: Port for the studio server (default 3000).
     """
     if port < MIN_PORT or port > MAX_PORT:
-        return _error_result(MCPVideoError(f"Invalid port: must be {MIN_PORT}-{MAX_PORT}, got {port}", error_type="validation_error", code="invalid_parameter"))
+        return _error_result(
+            MCPVideoError(
+                f"Invalid port: must be {MIN_PORT}-{MAX_PORT}, got {port}",
+                error_type="validation_error",
+                code="invalid_parameter",
+            )
+        )
     try:
         from .remotion_engine import studio
+
         return _result(studio(project_path, port=port))
     except MCPVideoError as e:
         return _error_result(e)
@@ -1635,7 +1923,10 @@ def remotion_still(
     """
     try:
         from .remotion_engine import still
-        return _result(still(project_path, composition_id, output_path=output_path, frame=frame, image_format=image_format))
+
+        return _result(
+            still(project_path, composition_id, output_path=output_path, frame=frame, image_format=image_format)
+        )
     except MCPVideoError as e:
         return _error_result(e)
     except Exception as e:
@@ -1656,11 +1947,22 @@ def remotion_create_project(
         template: Project template (blank, hello-world). Default blank.
     """
     if not re.match(r"^[a-zA-Z0-9_-]+$", name):
-        return _error_result(MCPVideoError("Invalid name: must match ^[a-zA-Z0-9_-]+$", error_type="validation_error", code="invalid_parameter"))
+        return _error_result(
+            MCPVideoError(
+                "Invalid name: must match ^[a-zA-Z0-9_-]+$", error_type="validation_error", code="invalid_parameter"
+            )
+        )
     if template not in VALID_REMOTION_TEMPLATES:
-        return _error_result(MCPVideoError(f"Invalid template: must be one of {sorted(VALID_REMOTION_TEMPLATES)}, got '{template}'", error_type="validation_error", code="invalid_parameter"))
+        return _error_result(
+            MCPVideoError(
+                f"Invalid template: must be one of {sorted(VALID_REMOTION_TEMPLATES)}, got '{template}'",
+                error_type="validation_error",
+                code="invalid_parameter",
+            )
+        )
     try:
         from .remotion_engine import create_project
+
         return _result(create_project(name, output_dir=output_dir, template=template))
     except MCPVideoError as e:
         return _error_result(e)
@@ -1682,9 +1984,14 @@ def remotion_scaffold_template(
         slug: Slug for the composition (used for filenames and component naming).
     """
     if not re.match(r"^[a-zA-Z0-9_-]+$", slug):
-        return _error_result(MCPVideoError("Invalid slug: must match ^[a-zA-Z0-9_-]+$", error_type="validation_error", code="invalid_parameter"))
+        return _error_result(
+            MCPVideoError(
+                "Invalid slug: must match ^[a-zA-Z0-9_-]+$", error_type="validation_error", code="invalid_parameter"
+            )
+        )
     try:
         from .remotion_engine import scaffold_template
+
         return _result(scaffold_template(project_path, spec, slug))
     except MCPVideoError as e:
         return _error_result(e)
@@ -1705,6 +2012,7 @@ def remotion_validate(
     """
     try:
         from .remotion_engine import validate
+
         return _result(validate(project_path, composition_id=composition_id))
     except MCPVideoError as e:
         return _error_result(e)
@@ -1729,9 +2037,16 @@ def remotion_to_mcpvideo(
         output_path: Where to save the final output. Auto-generated if omitted.
     """
     if not isinstance(post_process, list) or len(post_process) < 1:
-        return _error_result(MCPVideoError("Invalid post_process: must be a non-empty list", error_type="validation_error", code="invalid_parameter"))
+        return _error_result(
+            MCPVideoError(
+                "Invalid post_process: must be a non-empty list",
+                error_type="validation_error",
+                code="invalid_parameter",
+            )
+        )
     try:
         from .remotion_engine import render_and_post
+
         return _result(render_and_post(project_path, composition_id, post_process, output_path=output_path))
     except MCPVideoError as e:
         return _error_result(e)
@@ -1742,6 +2057,7 @@ def remotion_to_mcpvideo(
 # ---------------------------------------------------------------------------
 # Audio Synthesis Tools (P1 Features)
 # ---------------------------------------------------------------------------
+
 
 @mcp.tool()
 def audio_synthesize(
@@ -1774,23 +2090,48 @@ def audio_synthesize(
         Dict with success status and output_path.
     """
     if waveform not in VALID_WAVEFORMS:
-        return _error_result(MCPVideoError(f"Invalid waveform: must be one of {sorted(VALID_WAVEFORMS)}, got '{waveform}'", error_type="validation_error", code="invalid_parameter"))
+        return _error_result(
+            MCPVideoError(
+                f"Invalid waveform: must be one of {sorted(VALID_WAVEFORMS)}, got '{waveform}'",
+                error_type="validation_error",
+                code="invalid_parameter",
+            )
+        )
     if frequency < MIN_FREQUENCY or frequency > MAX_FREQUENCY:
-        return _error_result(MCPVideoError(f"Invalid frequency: must be {MIN_FREQUENCY}-{MAX_FREQUENCY}, got {frequency}", error_type="validation_error", code="invalid_parameter"))
+        return _error_result(
+            MCPVideoError(
+                f"Invalid frequency: must be {MIN_FREQUENCY}-{MAX_FREQUENCY}, got {frequency}",
+                error_type="validation_error",
+                code="invalid_parameter",
+            )
+        )
     if duration <= 0:
-        return _error_result(MCPVideoError(f"Invalid duration: must be > 0, got {duration}", error_type="validation_error", code="invalid_parameter"))
+        return _error_result(
+            MCPVideoError(
+                f"Invalid duration: must be > 0, got {duration}",
+                error_type="validation_error",
+                code="invalid_parameter",
+            )
+        )
     if volume < 0 or volume > 1:
-        return _error_result(MCPVideoError(f"Invalid volume: must be 0-1, got {volume}", error_type="validation_error", code="invalid_parameter"))
+        return _error_result(
+            MCPVideoError(
+                f"Invalid volume: must be 0-1, got {volume}", error_type="validation_error", code="invalid_parameter"
+            )
+        )
     try:
         from .audio_engine import audio_synthesize as _synth
-        return _result(_synth(
-            output=output_path,
-            waveform=waveform,
-            frequency=frequency,
-            duration=duration,
-            volume=volume,
-            effects=effects,
-        ))
+
+        return _result(
+            _synth(
+                output=output_path,
+                waveform=waveform,
+                frequency=frequency,
+                duration=duration,
+                volume=volume,
+                effects=effects,
+            )
+        )
     except MCPVideoError as e:
         return _error_result(e)
     except Exception as e:
@@ -1826,22 +2167,49 @@ def audio_preset(
         Dict with success status and output_path.
     """
     if preset not in VALID_AUDIO_PRESETS:
-        return _error_result(MCPVideoError(f"Invalid preset: must be one of {sorted(VALID_AUDIO_PRESETS)}, got '{preset}'", error_type="validation_error", code="invalid_parameter"))
+        return _error_result(
+            MCPVideoError(
+                f"Invalid preset: must be one of {sorted(VALID_AUDIO_PRESETS)}, got '{preset}'",
+                error_type="validation_error",
+                code="invalid_parameter",
+            )
+        )
     if pitch not in {"low", "mid", "high"}:
-        return _error_result(MCPVideoError(f"Invalid pitch: must be one of ['high', 'low', 'mid'], got '{pitch}'", error_type="validation_error", code="invalid_parameter"))
+        return _error_result(
+            MCPVideoError(
+                f"Invalid pitch: must be one of ['high', 'low', 'mid'], got '{pitch}'",
+                error_type="validation_error",
+                code="invalid_parameter",
+            )
+        )
     if intensity < 0 or intensity > 1:
-        return _error_result(MCPVideoError(f"Invalid intensity: must be 0-1, got {intensity}", error_type="validation_error", code="invalid_parameter"))
+        return _error_result(
+            MCPVideoError(
+                f"Invalid intensity: must be 0-1, got {intensity}",
+                error_type="validation_error",
+                code="invalid_parameter",
+            )
+        )
     if duration is not None and duration <= 0:
-        return _error_result(MCPVideoError(f"Invalid duration: must be > 0, got {duration}", error_type="validation_error", code="invalid_parameter"))
+        return _error_result(
+            MCPVideoError(
+                f"Invalid duration: must be > 0, got {duration}",
+                error_type="validation_error",
+                code="invalid_parameter",
+            )
+        )
     try:
         from .audio_engine import audio_preset as _preset
-        return _result(_preset(
-            preset=preset,
-            output=output_path,
-            pitch=pitch,
-            duration=duration,
-            intensity=intensity,
-        ))
+
+        return _result(
+            _preset(
+                preset=preset,
+                output=output_path,
+                pitch=pitch,
+                duration=duration,
+                intensity=intensity,
+            )
+        )
     except MCPVideoError as e:
         return _error_result(e)
     except Exception as e:
@@ -1872,21 +2240,48 @@ def audio_sequence(
         Dict with success status and output_path.
     """
     if not isinstance(sequence, list) or len(sequence) < 1:
-        return _error_result(MCPVideoError("Invalid sequence: must be a non-empty list", error_type="validation_error", code="invalid_parameter"))
+        return _error_result(
+            MCPVideoError(
+                "Invalid sequence: must be a non-empty list", error_type="validation_error", code="invalid_parameter"
+            )
+        )
     for i, event in enumerate(sequence):
         if not isinstance(event, dict):
-            return _error_result(MCPVideoError(f"Invalid sequence[{i}]: must be a dict", error_type="validation_error", code="invalid_parameter"))
+            return _error_result(
+                MCPVideoError(
+                    f"Invalid sequence[{i}]: must be a dict", error_type="validation_error", code="invalid_parameter"
+                )
+            )
         evt_type = event.get("type")
         if evt_type not in VALID_AUDIO_SEQUENCE_TYPES:
-            return _error_result(MCPVideoError(f"Invalid sequence[{i}].type: must be one of {sorted(VALID_AUDIO_SEQUENCE_TYPES)}, got '{evt_type}'", error_type="validation_error", code="invalid_parameter"))
+            return _error_result(
+                MCPVideoError(
+                    f"Invalid sequence[{i}].type: must be one of {sorted(VALID_AUDIO_SEQUENCE_TYPES)}, got '{evt_type}'",
+                    error_type="validation_error",
+                    code="invalid_parameter",
+                )
+            )
         evt_at = event.get("at")
         if not isinstance(evt_at, (int, float)):
-            return _error_result(MCPVideoError(f"Invalid sequence[{i}].at: must be numeric, got {type(evt_at).__name__}", error_type="validation_error", code="invalid_parameter"))
+            return _error_result(
+                MCPVideoError(
+                    f"Invalid sequence[{i}].at: must be numeric, got {type(evt_at).__name__}",
+                    error_type="validation_error",
+                    code="invalid_parameter",
+                )
+            )
         evt_dur = event.get("duration")
         if evt_dur is not None and evt_dur <= 0:
-            return _error_result(MCPVideoError(f"Invalid sequence[{i}].duration: must be > 0, got {evt_dur}", error_type="validation_error", code="invalid_parameter"))
+            return _error_result(
+                MCPVideoError(
+                    f"Invalid sequence[{i}].duration: must be > 0, got {evt_dur}",
+                    error_type="validation_error",
+                    code="invalid_parameter",
+                )
+            )
     try:
         from .audio_engine import audio_sequence as _sequence
+
         return _result(_sequence(sequence=sequence, output=output_path))
     except MCPVideoError as e:
         return _error_result(e)
@@ -1917,19 +2312,46 @@ def audio_compose(
         Dict with success status and output_path.
     """
     if duration <= 0:
-        return _error_result(MCPVideoError(f"Invalid duration: must be > 0, got {duration}", error_type="validation_error", code="invalid_parameter"))
+        return _error_result(
+            MCPVideoError(
+                f"Invalid duration: must be > 0, got {duration}",
+                error_type="validation_error",
+                code="invalid_parameter",
+            )
+        )
     if not isinstance(tracks, list) or len(tracks) < 1:
-        return _error_result(MCPVideoError("Invalid tracks: must be a non-empty list", error_type="validation_error", code="invalid_parameter"))
+        return _error_result(
+            MCPVideoError(
+                "Invalid tracks: must be a non-empty list", error_type="validation_error", code="invalid_parameter"
+            )
+        )
     for i, track in enumerate(tracks):
         if not isinstance(track, dict):
-            return _error_result(MCPVideoError(f"Invalid tracks[{i}]: must be a dict", error_type="validation_error", code="invalid_parameter"))
+            return _error_result(
+                MCPVideoError(
+                    f"Invalid tracks[{i}]: must be a dict", error_type="validation_error", code="invalid_parameter"
+                )
+            )
         if not isinstance(track.get("file"), str):
-            return _error_result(MCPVideoError(f"Invalid tracks[{i}].file: must be a string", error_type="validation_error", code="invalid_parameter"))
+            return _error_result(
+                MCPVideoError(
+                    f"Invalid tracks[{i}].file: must be a string",
+                    error_type="validation_error",
+                    code="invalid_parameter",
+                )
+            )
         vol = track.get("volume", 1.0)
         if vol < 0 or vol > 1:
-            return _error_result(MCPVideoError(f"Invalid tracks[{i}].volume: must be 0-1, got {vol}", error_type="validation_error", code="invalid_parameter"))
+            return _error_result(
+                MCPVideoError(
+                    f"Invalid tracks[{i}].volume: must be 0-1, got {vol}",
+                    error_type="validation_error",
+                    code="invalid_parameter",
+                )
+            )
     try:
         from .audio_engine import audio_compose as _compose
+
         return _result(_compose(tracks=tracks, duration=duration, output=output_path))
     except MCPVideoError as e:
         return _error_result(e)
@@ -1958,15 +2380,30 @@ def audio_effects(
         Dict with success status and output_path.
     """
     if not isinstance(effects, list) or len(effects) < 1:
-        return _error_result(MCPVideoError("Invalid effects: must be a non-empty list", error_type="validation_error", code="invalid_parameter"))
+        return _error_result(
+            MCPVideoError(
+                "Invalid effects: must be a non-empty list", error_type="validation_error", code="invalid_parameter"
+            )
+        )
     for i, effect in enumerate(effects):
         if not isinstance(effect, dict):
-            return _error_result(MCPVideoError(f"Invalid effects[{i}]: must be a dict", error_type="validation_error", code="invalid_parameter"))
+            return _error_result(
+                MCPVideoError(
+                    f"Invalid effects[{i}]: must be a dict", error_type="validation_error", code="invalid_parameter"
+                )
+            )
         eff_type = effect.get("type")
         if eff_type not in VALID_AUDIO_EFFECT_TYPES:
-            return _error_result(MCPVideoError(f"Invalid effects[{i}].type: must be one of {sorted(VALID_AUDIO_EFFECT_TYPES)}, got '{eff_type}'", error_type="validation_error", code="invalid_parameter"))
+            return _error_result(
+                MCPVideoError(
+                    f"Invalid effects[{i}].type: must be one of {sorted(VALID_AUDIO_EFFECT_TYPES)}, got '{eff_type}'",
+                    error_type="validation_error",
+                    code="invalid_parameter",
+                )
+            )
     try:
         from .audio_engine import audio_effects as _effects
+
         return _result(_effects(input_path=input_path, output=output_path, effects=effects))
     except MCPVideoError as e:
         return _error_result(e)
@@ -1998,6 +2435,7 @@ def video_add_generated_audio(
         if not isinstance(audio_config, dict) or not audio_config:
             return _error_result(ValueError("audio_config must be a non-empty dict"))
         from .audio_engine import add_generated_audio as _add_gen_audio
+
         return _result(_add_gen_audio(input_path, audio_config, output_path))
     except MCPVideoError as e:
         return _error_result(e)
@@ -2008,6 +2446,7 @@ def video_add_generated_audio(
 # ---------------------------------------------------------------------------
 # Visual Effects Tools (P1 Features)
 # ---------------------------------------------------------------------------
+
 
 @mcp.tool()
 def effect_vignette(
@@ -2039,6 +2478,7 @@ def effect_vignette(
         if not (0.0 <= smoothness <= 1.0):
             return _error_result(ValueError(f"smoothness must be between 0.0 and 1.0, got {smoothness}"))
         from .effects_engine import effect_vignette as _vignette
+
         return _result(_vignette(input_path, output_path, intensity, radius, smoothness))
     except MCPVideoError as e:
         return _error_result(e)
@@ -2070,6 +2510,7 @@ def effect_chromatic_aberration(
         if intensity < 0:
             return _error_result(ValueError(f"intensity must be non-negative, got {intensity}"))
         from .effects_engine import effect_chromatic_aberration as _chroma
+
         return _result(_chroma(input_path, output_path, intensity, angle))
     except MCPVideoError as e:
         return _error_result(e)
@@ -2107,6 +2548,7 @@ def effect_scanlines(
         if not (0.0 <= flicker <= 1.0):
             return _error_result(ValueError(f"flicker must be between 0.0 and 1.0, got {flicker}"))
         from .effects_engine import effect_scanlines as _scanlines
+
         return _result(_scanlines(input_path, output_path, line_height, opacity, flicker))
     except MCPVideoError as e:
         return _error_result(e)
@@ -2142,6 +2584,7 @@ def effect_noise(
         if mode not in ("film", "digital", "color"):
             return _error_result(ValueError(f"mode must be film, digital, or color, got {mode}"))
         from .effects_engine import effect_noise as _noise
+
         return _result(_noise(input_path, output_path, intensity, mode, animated))
     except MCPVideoError as e:
         return _error_result(e)
@@ -2179,6 +2622,7 @@ def effect_glow(
         if not (0.0 <= threshold <= 1.0):
             return _error_result(ValueError(f"threshold must be between 0.0 and 1.0, got {threshold}"))
         from .effects_engine import effect_glow as _glow
+
         return _result(_glow(input_path, output_path, intensity, radius, threshold))
     except MCPVideoError as e:
         return _error_result(e)
@@ -2216,6 +2660,7 @@ def video_layout_grid(
         if padding < 0:
             return _error_result(ValueError(f"padding must be non-negative, got {padding}"))
         from .effects_engine import layout_grid as _grid
+
         return _result(_grid(clips, layout, output_path, gap, padding, background))
     except MCPVideoError as e:
         return _error_result(e)
@@ -2261,7 +2706,21 @@ def video_layout_pip(
         if border_width < 0:
             return _error_result(ValueError(f"border_width must be non-negative, got {border_width}"))
         from .effects_engine import layout_pip as _pip
-        return _result(_pip(main_path, pip_path, output_path, position=position, size=size, margin=margin, rounded_corners=rounded_corners, border=border, border_color=border_color, border_width=border_width))
+
+        return _result(
+            _pip(
+                main_path,
+                pip_path,
+                output_path,
+                position=position,
+                size=size,
+                margin=margin,
+                rounded_corners=rounded_corners,
+                border=border,
+                border_color=border_color,
+                border_width=border_width,
+            )
+        )
     except MCPVideoError as e:
         return _error_result(e)
     except Exception as e:
@@ -2308,6 +2767,7 @@ def video_text_animated(
         if start < 0:
             return _error_result(ValueError(f"start must be non-negative, got {start}"))
         from .effects_engine import text_animated as _text
+
         return _result(_text(input_path, text, output_path, animation, font, size, color, position, start, duration))
     except MCPVideoError as e:
         return _error_result(e)
@@ -2336,13 +2796,16 @@ def video_text_subtitles(
         Dict with success status and output_path.
     """
     if not os.path.isfile(subtitles_path):
-        return _error_result(MCPVideoError(
-            f"Subtitles file not found: {subtitles_path}",
-            error_type="validation_error",
-            code="file_not_found",
-        ))
+        return _error_result(
+            MCPVideoError(
+                f"Subtitles file not found: {subtitles_path}",
+                error_type="validation_error",
+                code="file_not_found",
+            )
+        )
     try:
         from .effects_engine import text_subtitles as _subs
+
         return _result(_subs(input_path, subtitles_path, output_path, style))
     except MCPVideoError as e:
         return _error_result(e)
@@ -2380,6 +2843,7 @@ def video_mograph_count(
         if duration <= 0:
             return _error_result(ValueError(f"duration must be positive, got {duration}"))
         from .effects_engine import mograph_count as _count
+
         return _result(_count(start, end, duration, output_path, style=style, fps=fps))
     except MCPVideoError as e:
         return _error_result(e)
@@ -2412,17 +2876,20 @@ def video_mograph_progress(
         Dict with success status and output_path.
     """
     if style not in VALID_MOGRAPH_STYLES:
-        return _error_result(MCPVideoError(
-            f"Invalid style: must be one of {sorted(VALID_MOGRAPH_STYLES)}, got '{style}'",
-            error_type="validation_error",
-            code="invalid_parameter",
-        ))
+        return _error_result(
+            MCPVideoError(
+                f"Invalid style: must be one of {sorted(VALID_MOGRAPH_STYLES)}, got '{style}'",
+                error_type="validation_error",
+                code="invalid_parameter",
+            )
+        )
     try:
         if not (1 <= fps <= 120):
             return _error_result(ValueError(f"fps must be between 1 and 120, got {fps}"))
         if duration <= 0:
             return _error_result(ValueError(f"duration must be positive, got {duration}"))
         from .effects_engine import mograph_progress as _progress
+
         return _result(_progress(duration, output_path, style=style, color=color, track_color=track_color, fps=fps))
     except MCPVideoError as e:
         return _error_result(e)
@@ -2447,6 +2914,7 @@ def video_info_detailed(
     """
     try:
         from .effects_engine import video_info_detailed as _info
+
         return _result(_info(input_path))
     except MCPVideoError as e:
         return _error_result(e)
@@ -2471,13 +2939,16 @@ def video_auto_chapters(
         List of (timestamp, description) chapter tuples.
     """
     if not 0.0 <= threshold <= 1.0:
-        return _error_result(MCPVideoError(
-            f"threshold must be between 0.0 and 1.0, got {threshold}",
-            error_type="validation_error",
-            code="invalid_parameter",
-        ))
+        return _error_result(
+            MCPVideoError(
+                f"threshold must be between 0.0 and 1.0, got {threshold}",
+                error_type="validation_error",
+                code="invalid_parameter",
+            )
+        )
     try:
         from .effects_engine import auto_chapters as _chapters
+
         return _result(_chapters(input_path, threshold))
     except MCPVideoError as e:
         return _error_result(e)
@@ -2488,6 +2959,7 @@ def video_auto_chapters(
 # ---------------------------------------------------------------------------
 # Transition Tools (Advanced Effects)
 # ---------------------------------------------------------------------------
+
 
 @mcp.tool()
 def transition_glitch(
@@ -2507,19 +2979,24 @@ def transition_glitch(
         intensity: Glitch intensity 0-1 (default 0.3).
     """
     if duration <= 0:
-        return _error_result(MCPVideoError(
-            f"duration must be positive, got {duration}",
-            error_type="validation_error",
-            code="invalid_parameter",
-        ))
+        return _error_result(
+            MCPVideoError(
+                f"duration must be positive, got {duration}",
+                error_type="validation_error",
+                code="invalid_parameter",
+            )
+        )
     if not 0.0 <= intensity <= 1.0:
-        return _error_result(MCPVideoError(
-            f"intensity must be between 0.0 and 1.0, got {intensity}",
-            error_type="validation_error",
-            code="invalid_parameter",
-        ))
+        return _error_result(
+            MCPVideoError(
+                f"intensity must be between 0.0 and 1.0, got {intensity}",
+                error_type="validation_error",
+                code="invalid_parameter",
+            )
+        )
     try:
         from .transitions_engine import transition_glitch
+
         return _result(transition_glitch(clip1_path, clip2_path, output_path, duration, intensity))
     except MCPVideoError as e:
         return _error_result(e)
@@ -2537,19 +3014,24 @@ def transition_pixelate(
 ) -> dict[str, Any]:
     """Apply pixelate transition between two video clips."""
     if duration <= 0:
-        return _error_result(MCPVideoError(
-            f"duration must be positive, got {duration}",
-            error_type="validation_error",
-            code="invalid_parameter",
-        ))
+        return _error_result(
+            MCPVideoError(
+                f"duration must be positive, got {duration}",
+                error_type="validation_error",
+                code="invalid_parameter",
+            )
+        )
     if pixel_size < 2:
-        return _error_result(MCPVideoError(
-            f"pixel_size must be at least 2, got {pixel_size}",
-            error_type="validation_error",
-            code="invalid_parameter",
-        ))
+        return _error_result(
+            MCPVideoError(
+                f"pixel_size must be at least 2, got {pixel_size}",
+                error_type="validation_error",
+                code="invalid_parameter",
+            )
+        )
     try:
         from .transitions_engine import transition_pixelate
+
         return _result(transition_pixelate(clip1_path, clip2_path, output_path, duration, pixel_size))
     except MCPVideoError as e:
         return _error_result(e)
@@ -2567,19 +3049,24 @@ def transition_morph(
 ) -> dict[str, Any]:
     """Apply morph transition between two video clips."""
     if duration <= 0:
-        return _error_result(MCPVideoError(
-            f"duration must be positive, got {duration}",
-            error_type="validation_error",
-            code="invalid_parameter",
-        ))
+        return _error_result(
+            MCPVideoError(
+                f"duration must be positive, got {duration}",
+                error_type="validation_error",
+                code="invalid_parameter",
+            )
+        )
     if mesh_size < 2:
-        return _error_result(MCPVideoError(
-            f"mesh_size must be at least 2, got {mesh_size}",
-            error_type="validation_error",
-            code="invalid_parameter",
-        ))
+        return _error_result(
+            MCPVideoError(
+                f"mesh_size must be at least 2, got {mesh_size}",
+                error_type="validation_error",
+                code="invalid_parameter",
+            )
+        )
     try:
         from .transitions_engine import transition_morph
+
         return _result(transition_morph(clip1_path, clip2_path, output_path, duration, mesh_size))
     except MCPVideoError as e:
         return _error_result(e)
@@ -2591,6 +3078,7 @@ def transition_morph(
 # AI Feature Tools
 # ---------------------------------------------------------------------------
 
+
 @mcp.tool()
 def video_ai_remove_silence(
     input_path: str,
@@ -2601,25 +3089,32 @@ def video_ai_remove_silence(
 ) -> dict[str, Any]:
     """Remove silent sections from video."""
     if not -70 <= silence_threshold <= 0:
-        return _error_result(MCPVideoError(
-            f"silence_threshold must be between -70 and 0, got {silence_threshold}",
-            error_type="validation_error",
-            code="invalid_parameter",
-        ))
+        return _error_result(
+            MCPVideoError(
+                f"silence_threshold must be between -70 and 0, got {silence_threshold}",
+                error_type="validation_error",
+                code="invalid_parameter",
+            )
+        )
     if min_silence_duration <= 0:
-        return _error_result(MCPVideoError(
-            f"min_silence_duration must be positive, got {min_silence_duration}",
-            error_type="validation_error",
-            code="invalid_parameter",
-        ))
+        return _error_result(
+            MCPVideoError(
+                f"min_silence_duration must be positive, got {min_silence_duration}",
+                error_type="validation_error",
+                code="invalid_parameter",
+            )
+        )
     if keep_margin < 0:
-        return _error_result(MCPVideoError(
-            f"keep_margin must be non-negative, got {keep_margin}",
-            error_type="validation_error",
-            code="invalid_parameter",
-        ))
+        return _error_result(
+            MCPVideoError(
+                f"keep_margin must be non-negative, got {keep_margin}",
+                error_type="validation_error",
+                code="invalid_parameter",
+            )
+        )
     try:
         from .ai_engine import ai_remove_silence
+
         return _result(ai_remove_silence(input_path, output_path, silence_threshold, min_silence_duration, keep_margin))
     except MCPVideoError as e:
         return _error_result(e)
@@ -2636,13 +3131,16 @@ def video_ai_transcribe(
 ) -> dict[str, Any]:
     """Transcribe speech to text using Whisper."""
     if model not in VALID_WHISPER_MODELS:
-        return _error_result(MCPVideoError(
-            f"Invalid model: must be one of {sorted(VALID_WHISPER_MODELS)}, got '{model}'",
-            error_type="validation_error",
-            code="invalid_parameter",
-        ))
+        return _error_result(
+            MCPVideoError(
+                f"Invalid model: must be one of {sorted(VALID_WHISPER_MODELS)}, got '{model}'",
+                error_type="validation_error",
+                code="invalid_parameter",
+            )
+        )
     try:
         from .ai_engine import ai_transcribe
+
         return _result(ai_transcribe(input_path, output_srt, model, language))
     except MCPVideoError as e:
         return _error_result(e)
@@ -2658,13 +3156,16 @@ def video_ai_scene_detect(
 ) -> dict[str, Any]:
     """Detect scene changes in video."""
     if not 0.0 <= threshold <= 1.0:
-        return _error_result(MCPVideoError(
-            f"threshold must be between 0.0 and 1.0, got {threshold}",
-            error_type="validation_error",
-            code="invalid_parameter",
-        ))
+        return _error_result(
+            MCPVideoError(
+                f"threshold must be between 0.0 and 1.0, got {threshold}",
+                error_type="validation_error",
+                code="invalid_parameter",
+            )
+        )
     try:
         from .ai_engine import ai_scene_detect
+
         return _result(ai_scene_detect(input_path, threshold, use_ai))
     except MCPVideoError as e:
         return _error_result(e)
@@ -2681,19 +3182,24 @@ def video_ai_stem_separation(
 ) -> dict[str, Any]:
     """Separate audio into stems using Demucs."""
     if model not in VALID_DEMUCS_MODELS:
-        return _error_result(MCPVideoError(
-            f"Invalid model: must be one of {sorted(VALID_DEMUCS_MODELS)}, got '{model}'",
-            error_type="validation_error",
-            code="invalid_parameter",
-        ))
+        return _error_result(
+            MCPVideoError(
+                f"Invalid model: must be one of {sorted(VALID_DEMUCS_MODELS)}, got '{model}'",
+                error_type="validation_error",
+                code="invalid_parameter",
+            )
+        )
     if stems is not None and not isinstance(stems, list):
-        return _error_result(MCPVideoError(
-            f"stems must be a list, got {type(stems).__name__}",
-            error_type="validation_error",
-            code="invalid_parameter",
-        ))
+        return _error_result(
+            MCPVideoError(
+                f"stems must be a list, got {type(stems).__name__}",
+                error_type="validation_error",
+                code="invalid_parameter",
+            )
+        )
     try:
         from .ai_engine import ai_stem_separation
+
         return _result(ai_stem_separation(input_path, output_dir, stems, model))
     except MCPVideoError as e:
         return _error_result(e)
@@ -2710,19 +3216,24 @@ def video_ai_upscale(
 ) -> dict[str, Any]:
     """Upscale video using AI super-resolution."""
     if scale not in {2, 4}:
-        return _error_result(MCPVideoError(
-            f"scale must be 2 or 4, got {scale}",
-            error_type="validation_error",
-            code="invalid_parameter",
-        ))
+        return _error_result(
+            MCPVideoError(
+                f"scale must be 2 or 4, got {scale}",
+                error_type="validation_error",
+                code="invalid_parameter",
+            )
+        )
     if model not in VALID_UPSCALE_MODELS:
-        return _error_result(MCPVideoError(
-            f"Invalid model: must be one of {sorted(VALID_UPSCALE_MODELS)}, got '{model}'",
-            error_type="validation_error",
-            code="invalid_parameter",
-        ))
+        return _error_result(
+            MCPVideoError(
+                f"Invalid model: must be one of {sorted(VALID_UPSCALE_MODELS)}, got '{model}'",
+                error_type="validation_error",
+                code="invalid_parameter",
+            )
+        )
     try:
         from .ai_engine import ai_upscale
+
         return _result(ai_upscale(input_path, output_path, scale, model))
     except MCPVideoError as e:
         return _error_result(e)
@@ -2739,13 +3250,16 @@ def video_ai_color_grade(
 ) -> dict[str, Any]:
     """Auto color grade video."""
     if style not in VALID_COLOR_GRADE_STYLES:
-        return _error_result(MCPVideoError(
-            f"Invalid style: must be one of {sorted(VALID_COLOR_GRADE_STYLES)}, got '{style}'",
-            error_type="validation_error",
-            code="invalid_parameter",
-        ))
+        return _error_result(
+            MCPVideoError(
+                f"Invalid style: must be one of {sorted(VALID_COLOR_GRADE_STYLES)}, got '{style}'",
+                error_type="validation_error",
+                code="invalid_parameter",
+            )
+        )
     try:
         from .ai_engine import ai_color_grade
+
         return _result(ai_color_grade(input_path, output_path, reference_path, style))
     except MCPVideoError as e:
         return _error_result(e)
@@ -2762,19 +3276,24 @@ def video_audio_spatial(
 ) -> dict[str, Any]:
     """Apply 3D spatial audio positioning."""
     if method not in VALID_SPATIAL_METHODS:
-        return _error_result(MCPVideoError(
-            f"Invalid method: must be one of {sorted(VALID_SPATIAL_METHODS)}, got '{method}'",
-            error_type="validation_error",
-            code="invalid_parameter",
-        ))
+        return _error_result(
+            MCPVideoError(
+                f"Invalid method: must be one of {sorted(VALID_SPATIAL_METHODS)}, got '{method}'",
+                error_type="validation_error",
+                code="invalid_parameter",
+            )
+        )
     if not isinstance(positions, list) or len(positions) == 0:
-        return _error_result(MCPVideoError(
-            "positions must be a non-empty list",
-            error_type="validation_error",
-            code="invalid_parameter",
-        ))
+        return _error_result(
+            MCPVideoError(
+                "positions must be a non-empty list",
+                error_type="validation_error",
+                code="invalid_parameter",
+            )
+        )
     try:
         from .ai_engine import audio_spatial
+
         return _result(audio_spatial(input_path, output_path, positions, method))
     except MCPVideoError as e:
         return _error_result(e)
@@ -2798,6 +3317,7 @@ def video_quality_check(
     """
     try:
         from .quality_guardrails import quality_check
+
         return _result(quality_check(input_path, fail_on_warning))
     except MCPVideoError as e:
         return _error_result(e)
@@ -2823,6 +3343,7 @@ def video_design_quality_check(
     """
     try:
         from .design_quality import design_quality_check
+
         return _result(design_quality_check(input_path, auto_fix=auto_fix, strict=strict))
     except MCPVideoError as e:
         return _error_result(e)
@@ -2846,6 +3367,7 @@ def video_fix_design_issues(
     """
     try:
         from .design_quality import fix_design_issues
+
         return _result(fix_design_issues(input_path, output_path))
     except MCPVideoError as e:
         return _error_result(e)

--- a/mcp_video/templates.py
+++ b/mcp_video/templates.py
@@ -34,25 +34,29 @@ def tiktok_template(
     }
 
     if caption:
-        timeline["tracks"].append({
-            "type": "text",
-            "elements": [
-                {
-                    "text": caption,
-                    "start": 0,
-                    "position": "bottom-center",
-                    "style": {"size": 36, "color": "white", "shadow": True},
-                }
-            ],
-        })
+        timeline["tracks"].append(
+            {
+                "type": "text",
+                "elements": [
+                    {
+                        "text": caption,
+                        "start": 0,
+                        "position": "bottom-center",
+                        "style": {"size": 36, "color": "white", "shadow": True},
+                    }
+                ],
+            }
+        )
 
     if music_path:
-        timeline["tracks"].append({
-            "type": "audio",
-            "clips": [
-                {"source": music_path, "start": 0, "volume": 0.5, "fade_in": 1.0, "fade_out": 2.0},
-            ],
-        })
+        timeline["tracks"].append(
+            {
+                "type": "audio",
+                "clips": [
+                    {"source": music_path, "start": 0, "volume": 0.5, "fade_in": 1.0, "fade_out": 2.0},
+                ],
+            }
+        )
 
     return timeline
 
@@ -120,26 +124,30 @@ def youtube_video_template(
     }
 
     if title:
-        timeline["tracks"].append({
-            "type": "text",
-            "elements": [
-                {
-                    "text": title,
-                    "start": 0,
-                    "duration": 3,
-                    "position": "top-center",
-                    "style": {"size": 48, "color": "white", "shadow": True},
-                }
-            ],
-        })
+        timeline["tracks"].append(
+            {
+                "type": "text",
+                "elements": [
+                    {
+                        "text": title,
+                        "start": 0,
+                        "duration": 3,
+                        "position": "top-center",
+                        "style": {"size": 48, "color": "white", "shadow": True},
+                    }
+                ],
+            }
+        )
 
     if music_path:
-        timeline["tracks"].append({
-            "type": "audio",
-            "clips": [
-                {"source": music_path, "start": 0, "volume": 0.3, "fade_in": 2.0, "fade_out": 3.0},
-            ],
-        })
+        timeline["tracks"].append(
+            {
+                "type": "audio",
+                "clips": [
+                    {"source": music_path, "start": 0, "volume": 0.3, "fade_in": 2.0, "fade_out": 3.0},
+                ],
+            }
+        )
 
     return timeline
 
@@ -165,17 +173,19 @@ def instagram_post_template(
     }
 
     if caption:
-        timeline["tracks"].append({
-            "type": "text",
-            "elements": [
-                {
-                    "text": caption,
-                    "start": 0,
-                    "position": "bottom-center",
-                    "style": {"size": 32, "color": "white", "shadow": True},
-                }
-            ],
-        })
+        timeline["tracks"].append(
+            {
+                "type": "text",
+                "elements": [
+                    {
+                        "text": caption,
+                        "start": 0,
+                        "position": "bottom-center",
+                        "style": {"size": 32, "color": "white", "shadow": True},
+                    }
+                ],
+            }
+        )
 
     return timeline
 

--- a/mcp_video/transitions_engine.py
+++ b/mcp_video/transitions_engine.py
@@ -53,15 +53,23 @@ def transition_glitch(
     )
 
     cmd = [
-        "ffmpeg", "-y",
-        "-i", clip1,
-        "-i", clip2,
-        "-filter_complex", filter_complex,
-        "-map", "[glitched]",
-        "-c:v", "libx264",
-        "-pix_fmt", "yuv420p",
-        "-movflags", "+faststart",
-        output
+        "ffmpeg",
+        "-y",
+        "-i",
+        clip1,
+        "-i",
+        clip2,
+        "-filter_complex",
+        filter_complex,
+        "-map",
+        "[glitched]",
+        "-c:v",
+        "libx264",
+        "-pix_fmt",
+        "yuv420p",
+        "-movflags",
+        "+faststart",
+        output,
     ]
 
     _run_ffmpeg(cmd)
@@ -133,15 +141,23 @@ def transition_pixelate(
     )
 
     cmd = [
-        "ffmpeg", "-y",
-        "-i", clip1,
-        "-i", clip2,
-        "-filter_complex", filter_complex,
-        "-map", "[output]",
-        "-c:v", "libx264",
-        "-pix_fmt", "yuv420p",
-        "-movflags", "+faststart",
-        output
+        "ffmpeg",
+        "-y",
+        "-i",
+        clip1,
+        "-i",
+        clip2,
+        "-filter_complex",
+        filter_complex,
+        "-map",
+        "[output]",
+        "-c:v",
+        "libx264",
+        "-pix_fmt",
+        "yuv420p",
+        "-movflags",
+        "+faststart",
+        output,
     ]
 
     _run_ffmpeg(cmd)
@@ -189,20 +205,26 @@ def transition_morph(
 
     # Use xfade with pixelize transition for morph-like effect
     # pixelize creates a blocky dissolve that simulates mesh morphing
-    filter_complex = (
-        f"[0:v][1:v]xfade=transition=pixelize:duration={duration}:offset={offset}[output]"
-    )
+    filter_complex = f"[0:v][1:v]xfade=transition=pixelize:duration={duration}:offset={offset}[output]"
 
     cmd = [
-        "ffmpeg", "-y",
-        "-i", clip1,
-        "-i", clip2,
-        "-filter_complex", filter_complex,
-        "-map", "[output]",
-        "-c:v", "libx264",
-        "-pix_fmt", "yuv420p",
-        "-movflags", "+faststart",
-        output
+        "ffmpeg",
+        "-y",
+        "-i",
+        clip1,
+        "-i",
+        clip2,
+        "-filter_complex",
+        filter_complex,
+        "-map",
+        "[output]",
+        "-c:v",
+        "libx264",
+        "-pix_fmt",
+        "yuv420p",
+        "-movflags",
+        "+faststart",
+        output,
     ]
 
     _run_ffmpeg(cmd)

--- a/mcp_video/validation.py
+++ b/mcp_video/validation.py
@@ -10,8 +10,13 @@ from .limits import *  # noqa: F403 — re-export all limit constants
 # Validation helpers — all raise MCPVideoError with validation metadata
 # ---------------------------------------------------------------------------
 
+
 def _validate_ffmpeg_param(
-    value, name, min_val=None, max_val=None, allowed_types=(int, float),
+    value,
+    name,
+    min_val=None,
+    max_val=None,
+    allowed_types=(int, float),
 ):
     """Validate a numeric FFmpeg parameter. Returns float(value)."""
     if not isinstance(value, allowed_types):
@@ -118,9 +123,20 @@ VALID_AUDIO_FORMATS = {"mp3", "aac", "wav", "ogg", "flac"}
 VALID_PRESETS = {"ultrafast", "fast", "medium", "slow", "veryslow"}
 VALID_CODECS = {"h264", "h265", "vp8", "vp9", "prores", "gif"}
 VALID_XFADE_TRANSITIONS = {
-    "fade", "dissolve", "wipeleft", "wiperight", "slideleft", "slideright",
-    "slideup", "slidedown", "circlecrop", "radial",
-    "smoothleft", "smoothright", "smoothup", "smoothdown",
+    "fade",
+    "dissolve",
+    "wipeleft",
+    "wiperight",
+    "slideleft",
+    "slideright",
+    "slideup",
+    "slidedown",
+    "circlecrop",
+    "radial",
+    "smoothleft",
+    "smoothright",
+    "smoothup",
+    "smoothdown",
 }
 VALID_WAVEFORMS = {"sine", "square", "sawtooth", "triangle", "noise"}
 VALID_AUDIO_EFFECT_TYPES = {"lowpass", "reverb", "normalize", "fade"}
@@ -135,10 +151,21 @@ VALID_COLOR_GRADE_STYLES = {"auto", "warm", "cool", "vintage", "cinematic", "noi
 VALID_AUDIO_SEQUENCE_TYPES = {"tone", "preset", "whoosh"}
 VALID_TEXT_ANIMATIONS = {"fade", "slide-up"}
 VALID_AUDIO_PRESETS = {
-    "ui-blip", "ui-click", "ui-tap", "ui-whoosh-up", "ui-whoosh-down",
-    "drone-low", "drone-mid", "drone-tech",
-    "chime-success", "chime-error", "chime-notification",
-    "data-flow", "typing", "scan", "processing",
+    "ui-blip",
+    "ui-click",
+    "ui-tap",
+    "ui-whoosh-up",
+    "ui-whoosh-down",
+    "drone-low",
+    "drone-mid",
+    "drone-tech",
+    "chime-success",
+    "chime-error",
+    "chime-notification",
+    "data-flow",
+    "typing",
+    "scan",
+    "processing",
 }
 
 
@@ -154,15 +181,37 @@ def get_valid_audio_presets():
         # The presets dict is local to audio_preset(), so we use the
         # known set documented in its docstring.
         return {
-            "ui-blip", "ui-click", "ui-tap", "ui-whoosh-up", "ui-whoosh-down",
-            "drone-low", "drone-mid", "drone-tech",
-            "chime-success", "chime-error", "chime-notification",
-            "typing", "scan", "processing", "data-flow",
+            "ui-blip",
+            "ui-click",
+            "ui-tap",
+            "ui-whoosh-up",
+            "ui-whoosh-down",
+            "drone-low",
+            "drone-mid",
+            "drone-tech",
+            "chime-success",
+            "chime-error",
+            "chime-notification",
+            "typing",
+            "scan",
+            "processing",
+            "data-flow",
         }
     except ImportError:
         return {
-            "ui-blip", "ui-click", "ui-tap", "ui-whoosh-up", "ui-whoosh-down",
-            "drone-low", "drone-mid", "drone-tech",
-            "chime-success", "chime-error", "chime-notification",
-            "typing", "scan", "processing", "data-flow",
+            "ui-blip",
+            "ui-click",
+            "ui-tap",
+            "ui-whoosh-up",
+            "ui-whoosh-down",
+            "drone-low",
+            "drone-mid",
+            "drone-tech",
+            "chime-success",
+            "chime-error",
+            "chime-notification",
+            "typing",
+            "scan",
+            "processing",
+            "data-flow",
         }

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -29,7 +29,11 @@ def run_cli_json(*args: str, expect_fail: bool = False) -> subprocess.CompletedP
 class TestCLIVersion:
     def test_version_flag(self):
         result = run_cli("--version")
-        assert "1.1.5" in result.stdout
+        # Dynamic version check — reads from package metadata so it
+        # never goes stale after a version bump.
+        from importlib.metadata import version as pkg_version
+
+        assert pkg_version("mcp-video") in result.stdout
 
 
 class TestCLIInfo:


### PR DESCRIPTION
## Summary
- **Fix stale version test**: `test_version_flag` now reads version dynamically from `importlib.metadata` instead of hardcoding `"1.1.5"`, which broke when version was bumped to `1.2.0`
- **Add Python matrix testing**: Tests now run on Python 3.11, 3.12, and 3.13 (matching the classifiers in `pyproject.toml`)
- **Split lint into dedicated job**: Runs `ruff check` + `ruff format --check` in a fast separate job so lint failures are isolated from test failures
- **Improve publish workflow**: Split into `build` + `publish` jobs with artifact passing, adds `pypi` environment requirement for deployment protection
- **Add pip caching**: Uses `actions/setup-python` built-in cache to speed up dependency installation

## Before (CI failures on master)
- Lint and tests in a single job — hard to tell which failed at a glance
- Single Python 3.12 — no coverage for 3.11 or 3.13
- `test_version_flag` asserting `"1.1.5"` against actual `"1.2.0"` output — 1 test failure
- Publish job runs build + publish in one step, no artifact retention

## After
- 3 parallel jobs: lint, test (3x matrix), docker
- Lint catches both style errors and formatting issues
- Version test is future-proof via `importlib.metadata`
- Publish uses build artifact + environment protection

## Test plan
- [x] `test_version_flag` passes locally with dynamic version check
- [ ] CI green on this PR (lint + test matrix + docker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)