### PR TITLE
Ignore local .omc workspace state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ venv/
 .playwright-mcp/
 .stitch/
 out/
+
+.omc/


### PR DESCRIPTION
## Summary
- ignore local `.omc/` workspace state in git
- keep local tool/cache state out of the project surface by default

## Verification
- `git status --short` only showed `.gitignore` before commit
- `.omc/` disappeared from status once the ignore rule was added
