### PR TITLE
Cut v1.2.1 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/version-1.2.0-blue.svg" alt="Version">
+  <img src="https://img.shields.io/badge/version-1.2.1-blue.svg" alt="Version">
   <img src="https://img.shields.io/badge/tests-extensive-brightgreen.svg" alt="Tests">
   <a href="https://github.com/pastorsimon1798/mcp-video/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/pastorsimon1798/mcp-video/.github/workflows/ci.yml?branch=master&label=CI" alt="CI"></a>
   <img src="https://img.shields.io/badge/tools-82%20MCP%20tools-orange.svg" alt="Tools">

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-video"
-version = "1.2.0"
+version = "1.2.1"
 description = "Video editing MCP server for AI agents. 82 tools, 3 interfaces, rich CLI. Local, fast, free."
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary
- bump package version from 1.2.0 to 1.2.1
- update the public README version badge
- prepare the current merged fixes for GitHub Release -> PyPI publish

## Verification
- local version string updated in `pyproject.toml`
- README badge updated to `1.2.1`

## Notes
- This PR is only the release cut.
- Publishing to PyPI will happen via the existing `Publish to PyPI` workflow when the GitHub Release for `v1.2.1` is published.
