### PR TITLE
Add doctor command for integration diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,13 @@ Or run without installing:
 uvx mcp-video
 ```
 
+Check your local integration surface:
+
+```bash
+mcp-video doctor
+mcp-video doctor --json
+```
+
 ---
 
 ## Quick Start
@@ -487,6 +494,9 @@ ProductAnalysisResult(success=True, colors=[...], description="...")
 
 ```
 mcp-video [command] [options]
+
+Diagnostics:
+  doctor              Check FFmpeg, Remotion, image, and AI dependencies
 
 Core Editing:
   info                 Get video metadata

--- a/mcp_video/__main__.py
+++ b/mcp_video/__main__.py
@@ -8,6 +8,7 @@ import sys
 from typing import Any
 
 from rich.console import Console
+from rich.markup import escape
 from rich.panel import Panel
 from rich.progress import Progress, SpinnerColumn, TextColumn, TimeElapsedColumn
 from rich.table import Table
@@ -106,6 +107,24 @@ def _format_extract_audio_text(result: Any) -> None:
     console.print(Panel(f"[bold green]Audio extracted:[/bold green] {result}", border_style="green", title="Done"))
 
 
+def _format_doctor_text(report: dict[str, Any]) -> None:
+    """Display diagnostics as a compact table."""
+    summary = report["summary"]
+    status = "OK" if summary["required_ok"] else "Missing required dependencies"
+    console.print(f"[bold]mcp-video doctor[/bold] — {status}")
+    table = Table(title="Environment Checks")
+    table.add_column("Name", style="cyan")
+    table.add_column("Category")
+    table.add_column("Required")
+    table.add_column("Status")
+    table.add_column("Version / Hint")
+    for check in report["checks"]:
+        state = "[green]OK[/green]" if check["ok"] else "[yellow]Missing[/yellow]"
+        detail = check.get("version") or check.get("install_hint") or "-"
+        table.add_row(check["name"], check["category"], "yes" if check["required"] else "no", state, escape(detail))
+    console.print(table)
+
+
 def _format_error(e: Exception) -> None:
     """Display error in a styled panel."""
     from .errors import MCPVideoError
@@ -186,6 +205,10 @@ def main() -> None:
         help="Show version and exit",
     )
     subparsers = parser.add_subparsers(dest="command", help="CLI commands")
+
+    # doctor
+    doctor_p = subparsers.add_parser("doctor", help="Diagnose core and optional integration dependencies")
+    doctor_p.add_argument("--json", action="store_true", help="Output diagnostics as JSON")
 
     # info
     info_p = subparsers.add_parser("info", help="Get video metadata")
@@ -1119,7 +1142,16 @@ def main() -> None:
 
     # CLI commands
     try:
-        if args.command == "info":
+        if args.command == "doctor":
+            from .doctor import run_diagnostics
+
+            report = run_diagnostics()
+            if use_json or args.json:
+                output_json(report)
+            else:
+                _format_doctor_text(report)
+
+        elif args.command == "info":
             from .engine import probe
 
             info = probe(args.input)

--- a/mcp_video/doctor.py
+++ b/mcp_video/doctor.py
@@ -1,0 +1,163 @@
+"""Environment diagnostics for mcp-video integrations."""
+
+from __future__ import annotations
+
+import importlib.metadata
+import importlib.util
+import platform
+import shutil
+import subprocess
+import sys
+from collections.abc import Callable
+from typing import Any
+
+from .limits import DOCTOR_COMMAND_TIMEOUT
+
+WhichFn = Callable[[str], str | None]
+VersionRunner = Callable[[list[str]], str | None]
+FindSpecFn = Callable[[str], Any]
+
+COMMAND_CHECKS = (
+    {
+        "name": "ffmpeg",
+        "category": "core",
+        "required": True,
+        "command": ["ffmpeg", "-version"],
+        "install_hint": "Install FFmpeg: brew install ffmpeg, apt install ffmpeg, or download from https://ffmpeg.org/download.html",
+    },
+    {
+        "name": "ffprobe",
+        "category": "core",
+        "required": True,
+        "command": ["ffprobe", "-version"],
+        "install_hint": "Install FFmpeg, which includes ffprobe.",
+    },
+    {
+        "name": "node",
+        "category": "remotion",
+        "required": False,
+        "command": ["node", "--version"],
+        "install_hint": "Install Node.js 18+ for Remotion features.",
+    },
+    {
+        "name": "npm",
+        "category": "remotion",
+        "required": False,
+        "command": ["npm", "--version"],
+        "install_hint": "Install npm for Remotion project setup.",
+    },
+    {
+        "name": "npx",
+        "category": "remotion",
+        "required": False,
+        "command": ["npx", "--version"],
+        "install_hint": "Install npx/npm for Remotion CLI execution.",
+    },
+)
+
+PACKAGE_CHECKS = (
+    ("mcp", "mcp", "core", True, "Install the base package: pip install mcp-video"),
+    ("pydantic", "pydantic", "core", True, "Install the base package: pip install mcp-video"),
+    ("rich", "rich", "core", True, "Install the base package: pip install mcp-video"),
+    ("pillow", "PIL", "image", False, 'Install image extras: pip install "mcp-video[image]"'),
+    ("scikit-learn", "sklearn", "image", False, 'Install image extras: pip install "mcp-video[image]"'),
+    ("webcolors", "webcolors", "image", False, 'Install image extras: pip install "mcp-video[image]"'),
+    ("anthropic", "anthropic", "image-ai", False, 'Install image AI extras: pip install "mcp-video[image-ai]"'),
+    ("openai-whisper", "whisper", "ai", False, 'Install AI extras: pip install "mcp-video[ai]"'),
+    ("demucs", "demucs", "ai", False, 'Install AI extras: pip install "mcp-video[ai]"'),
+    ("realesrgan", "realesrgan", "ai", False, 'Install AI extras: pip install "mcp-video[ai]"'),
+    ("basicsr", "basicsr", "ai", False, 'Install AI extras: pip install "mcp-video[ai]"'),
+    ("opencv-contrib-python", "cv2", "ai", False, 'Install AI extras: pip install "mcp-video[ai]"'),
+    ("torch", "torch", "ai", False, 'Install AI extras: pip install "mcp-video[ai]"'),
+    ("torchaudio", "torchaudio", "ai", False, 'Install AI extras: pip install "mcp-video[ai]"'),
+    ("imagehash", "imagehash", "ai", False, 'Install AI extras: pip install "mcp-video[ai]"'),
+)
+
+
+def _command_version(command: list[str]) -> str | None:
+    try:
+        result = subprocess.run(command, capture_output=True, text=True, timeout=DOCTOR_COMMAND_TIMEOUT)
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    first_line = (result.stdout or result.stderr).splitlines()[0:1]
+    return first_line[0].strip() if first_line else None
+
+
+def _package_version(distribution_name: str) -> str | None:
+    try:
+        return importlib.metadata.version(distribution_name)
+    except importlib.metadata.PackageNotFoundError:
+        return None
+
+
+def _check_command(definition: dict[str, Any], which: WhichFn, version_runner: VersionRunner) -> dict[str, Any]:
+    path = which(definition["name"])
+    version = version_runner(definition["command"]) if path else None
+    ok = path is not None
+    return {
+        "name": definition["name"],
+        "category": definition["category"],
+        "required": definition["required"],
+        "ok": ok,
+        "path": path,
+        "version": version,
+        "install_hint": None if ok else definition["install_hint"],
+    }
+
+
+def _check_package(
+    distribution_name: str,
+    import_name: str,
+    category: str,
+    required: bool,
+    install_hint: str,
+    find_spec: FindSpecFn,
+) -> dict[str, Any]:
+    ok = find_spec(import_name) is not None
+    return {
+        "name": distribution_name,
+        "category": category,
+        "required": required,
+        "ok": ok,
+        "path": None,
+        "version": _package_version(distribution_name) if ok else None,
+        "install_hint": None if ok else install_hint,
+    }
+
+
+def _summary(checks: list[dict[str, Any]]) -> dict[str, Any]:
+    required = [check for check in checks if check["required"]]
+    optional = [check for check in checks if not check["required"]]
+    missing_required = [check["name"] for check in required if not check["ok"]]
+    missing_optional = [check["name"] for check in optional if not check["ok"]]
+    return {
+        "required_ok": not missing_required,
+        "missing_required": missing_required,
+        "missing_optional": missing_optional,
+        "total_checks": len(checks),
+        "passed": sum(1 for check in checks if check["ok"]),
+        "optional_available": sum(1 for check in optional if check["ok"]),
+    }
+
+
+def run_diagnostics(
+    *,
+    which: WhichFn = shutil.which,
+    version_runner: VersionRunner = _command_version,
+    find_spec: FindSpecFn = importlib.util.find_spec,
+) -> dict[str, Any]:
+    """Return a structured report for core and optional integration dependencies."""
+    checks = [_check_command(definition, which, version_runner) for definition in COMMAND_CHECKS]
+    checks.extend(_check_package(*definition, find_spec=find_spec) for definition in PACKAGE_CHECKS)
+    return {
+        "success": True,
+        "platform": {
+            "python": sys.version.split()[0],
+            "executable": sys.executable,
+            "system": platform.platform(),
+        },
+        "summary": _summary(checks),
+        "checks": checks,
+    }

--- a/mcp_video/doctor.py
+++ b/mcp_video/doctor.py
@@ -16,6 +16,7 @@ from .limits import DOCTOR_COMMAND_TIMEOUT
 WhichFn = Callable[[str], str | None]
 VersionRunner = Callable[[list[str]], str | None]
 FindSpecFn = Callable[[str], Any]
+PackageVersionFn = Callable[[str], str | None]
 
 COMMAND_CHECKS = (
     {
@@ -95,7 +96,7 @@ def _package_version(distribution_name: str) -> str | None:
 def _check_command(definition: dict[str, Any], which: WhichFn, version_runner: VersionRunner) -> dict[str, Any]:
     path = which(definition["name"])
     version = version_runner(definition["command"]) if path else None
-    ok = path is not None
+    ok = path is not None and version is not None
     return {
         "name": definition["name"],
         "category": definition["category"],
@@ -114,15 +115,18 @@ def _check_package(
     required: bool,
     install_hint: str,
     find_spec: FindSpecFn,
+    package_version: PackageVersionFn,
 ) -> dict[str, Any]:
-    ok = find_spec(import_name) is not None
+    found = find_spec(import_name) is not None
+    version = package_version(distribution_name) if found else None
+    ok = found and version is not None
     return {
         "name": distribution_name,
         "category": category,
         "required": required,
         "ok": ok,
         "path": None,
-        "version": _package_version(distribution_name) if ok else None,
+        "version": version if ok else None,
         "install_hint": None if ok else install_hint,
     }
 
@@ -147,10 +151,14 @@ def run_diagnostics(
     which: WhichFn = shutil.which,
     version_runner: VersionRunner = _command_version,
     find_spec: FindSpecFn = importlib.util.find_spec,
+    package_version: PackageVersionFn = _package_version,
 ) -> dict[str, Any]:
     """Return a structured report for core and optional integration dependencies."""
     checks = [_check_command(definition, which, version_runner) for definition in COMMAND_CHECKS]
-    checks.extend(_check_package(*definition, find_spec=find_spec) for definition in PACKAGE_CHECKS)
+    checks.extend(
+        _check_package(*definition, find_spec=find_spec, package_version=package_version)
+        for definition in PACKAGE_CHECKS
+    )
     return {
         "success": True,
         "platform": {

--- a/mcp_video/limits.py
+++ b/mcp_video/limits.py
@@ -8,6 +8,7 @@ MAX_FILE_SIZE_MB = 4096  # 4 GB
 # Processing limits
 MAX_CONCURRENT_PROCESSES = 4
 DEFAULT_FFMPEG_TIMEOUT = 600  # 10 minutes
+DOCTOR_COMMAND_TIMEOUT = 10  # Short version/probe commands should not hang
 MAX_BATCH_SIZE = 50
 MAX_EXPORT_FRAMES_FPS = 60
 

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -20,7 +20,12 @@ def test_run_diagnostics_marks_required_tools_ok_when_present():
     def fake_find_spec(name: str) -> ModuleSpec | None:
         return ModuleSpec(name, loader=None) if name in present_packages else None
 
-    report = run_diagnostics(which=fake_which, version_runner=fake_version, find_spec=fake_find_spec)
+    report = run_diagnostics(
+        which=fake_which,
+        version_runner=fake_version,
+        find_spec=fake_find_spec,
+        package_version=lambda name: "1.0.0" if name in present_packages else None,
+    )
 
     checks = {check["name"]: check for check in report["checks"]}
     assert report["success"] is True
@@ -44,6 +49,26 @@ def test_run_diagnostics_marks_required_tools_missing():
     assert "Install FFmpeg" in checks["ffmpeg"]["install_hint"]
 
 
+def test_run_diagnostics_marks_command_probe_failures_missing():
+    from mcp_video.doctor import run_diagnostics
+
+    present_packages = {"mcp", "pydantic", "rich"}
+
+    def fake_find_spec(name: str) -> ModuleSpec | None:
+        return ModuleSpec(name, loader=None) if name in present_packages else None
+
+    report = run_diagnostics(
+        which=lambda name: f"/usr/bin/{name}",
+        version_runner=lambda command: None,
+        find_spec=fake_find_spec,
+    )
+
+    checks = {check["name"]: check for check in report["checks"]}
+    assert report["summary"]["required_ok"] is False
+    assert checks["ffmpeg"]["ok"] is False
+    assert checks["ffmpeg"]["path"] == "/usr/bin/ffmpeg"
+
+
 def test_run_diagnostics_checks_optional_packages_without_importing_them():
     from mcp_video.doctor import run_diagnostics
 
@@ -52,13 +77,42 @@ def test_run_diagnostics_checks_optional_packages_without_importing_them():
     def fake_find_spec(name: str) -> ModuleSpec | None:
         return ModuleSpec(name, loader=None) if name in present else None
 
-    report = run_diagnostics(which=lambda name: None, version_runner=lambda command: None, find_spec=fake_find_spec)
+    report = run_diagnostics(
+        which=lambda name: None,
+        version_runner=lambda command: None,
+        find_spec=fake_find_spec,
+        package_version=lambda name: "1.0.0" if name in {"pillow", "scikit-learn", "webcolors"} else None,
+    )
 
     checks = {check["name"]: check for check in report["checks"]}
     assert checks["pillow"]["ok"] is True
     assert checks["scikit-learn"]["ok"] is True
     assert checks["openai-whisper"]["ok"] is False
     assert checks["openai-whisper"]["required"] is False
+
+
+def test_run_diagnostics_requires_matching_distribution_for_package_checks():
+    from mcp_video.doctor import run_diagnostics
+
+    present = {"mcp", "pydantic", "rich", "cv2"}
+
+    def fake_find_spec(name: str) -> ModuleSpec | None:
+        return ModuleSpec(name, loader=None) if name in present else None
+
+    def fake_package_version(name: str) -> str | None:
+        return "1.0.0" if name in {"mcp", "pydantic", "rich"} else None
+
+    report = run_diagnostics(
+        which=lambda name: f"/usr/bin/{name}" if name in {"ffmpeg", "ffprobe"} else None,
+        version_runner=lambda command: f"{command[0]} version test",
+        find_spec=fake_find_spec,
+        package_version=fake_package_version,
+    )
+
+    checks = {check["name"]: check for check in report["checks"]}
+    assert report["summary"]["required_ok"] is True
+    assert checks["opencv-contrib-python"]["ok"] is False
+    assert checks["opencv-contrib-python"]["version"] is None
 
 
 def test_cli_doctor_json_outputs_structured_report():

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1,0 +1,91 @@
+"""Tests for environment diagnostics."""
+
+import json
+import subprocess
+import sys
+from importlib.machinery import ModuleSpec
+
+
+def test_run_diagnostics_marks_required_tools_ok_when_present():
+    from mcp_video.doctor import run_diagnostics
+
+    def fake_which(name: str) -> str | None:
+        return f"/usr/bin/{name}" if name in {"ffmpeg", "ffprobe"} else None
+
+    def fake_version(command: list[str]) -> str | None:
+        return f"{command[0]} version test"
+
+    present_packages = {"mcp", "pydantic", "rich"}
+
+    def fake_find_spec(name: str) -> ModuleSpec | None:
+        return ModuleSpec(name, loader=None) if name in present_packages else None
+
+    report = run_diagnostics(which=fake_which, version_runner=fake_version, find_spec=fake_find_spec)
+
+    checks = {check["name"]: check for check in report["checks"]}
+    assert report["success"] is True
+    assert report["summary"]["required_ok"] is True
+    assert checks["ffmpeg"]["ok"] is True
+    assert checks["ffprobe"]["ok"] is True
+    assert checks["node"]["required"] is False
+    assert checks["node"]["ok"] is False
+
+
+def test_run_diagnostics_marks_required_tools_missing():
+    from mcp_video.doctor import run_diagnostics
+
+    report = run_diagnostics(which=lambda name: None, version_runner=lambda command: None, find_spec=lambda name: None)
+
+    checks = {check["name"]: check for check in report["checks"]}
+    assert report["success"] is True
+    assert report["summary"]["required_ok"] is False
+    assert checks["ffmpeg"]["ok"] is False
+    assert checks["ffmpeg"]["required"] is True
+    assert "Install FFmpeg" in checks["ffmpeg"]["install_hint"]
+
+
+def test_run_diagnostics_checks_optional_packages_without_importing_them():
+    from mcp_video.doctor import run_diagnostics
+
+    present = {"PIL", "sklearn", "webcolors"}
+
+    def fake_find_spec(name: str) -> ModuleSpec | None:
+        return ModuleSpec(name, loader=None) if name in present else None
+
+    report = run_diagnostics(which=lambda name: None, version_runner=lambda command: None, find_spec=fake_find_spec)
+
+    checks = {check["name"]: check for check in report["checks"]}
+    assert checks["pillow"]["ok"] is True
+    assert checks["scikit-learn"]["ok"] is True
+    assert checks["openai-whisper"]["ok"] is False
+    assert checks["openai-whisper"]["required"] is False
+
+
+def test_cli_doctor_json_outputs_structured_report():
+    result = subprocess.run(
+        [sys.executable, "-m", "mcp_video", "doctor", "--json"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert result.returncode == 0
+    data = json.loads(result.stdout)
+    assert data["success"] is True
+    assert "summary" in data
+    assert isinstance(data["checks"], list)
+    assert any(check["name"] == "ffmpeg" for check in data["checks"])
+
+
+def test_cli_doctor_text_outputs_summary():
+    result = subprocess.run(
+        [sys.executable, "-m", "mcp_video", "doctor"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert result.returncode == 0
+    assert "mcp-video doctor" in result.stdout
+    assert "ffmpeg" in result.stdout
+    assert "mcp-video[ai]" in result.stdout


### PR DESCRIPTION
## Summary
- Adds `mcp_video.doctor.run_diagnostics()` for structured checks across core tools, Remotion tooling, image extras, and AI extras.
- Adds `mcp-video doctor` and `mcp-video doctor --json` for human-readable and agent-readable diagnostics.
- Adds a short doctor command timeout so version/probe commands cannot inherit the long FFmpeg processing timeout.
- Documents the doctor command in README.

## Why
This is the first implementation slice from the approved adversarial remediation plan. It targets integration hell directly: FFmpeg, ffprobe, Node/npm/npx, image packages, and heavyweight optional AI packages now have one obvious diagnostic entry point.

## Validation
- `python3 -m pytest tests/test_doctor.py tests/test_cli.py -q --tb=short`
- `python3 -m pytest tests/ -q -m "not slow" --tb=short`
- `python3 -m ruff check mcp_video/ tests/test_doctor.py`
- `python3 -m ruff format --check mcp_video/ tests/test_doctor.py`
- `python3 -m mcp_video doctor --json`
- `python3 -m mcp_video doctor`
- `python3 -c "import mcp_video; import mcp_video.doctor; print('import-ok')"`
- `python3 -m build`
- `python3 .github/scripts/check-built-artifacts.py dist`

## Not Tested
- Slow real-media suite.
- Absent-FFmpeg behavior on a machine without FFmpeg installed.