### PR TITLE
Group GitHub Actions updates and enforce readiness audit in CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,4 +31,7 @@ updates:
       day: "monday"
       time: "09:00"
     open-pull-requests-limit: 5
-
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,17 @@ on:
     branches: [master]
 
 jobs:
+  repository-readiness:
+    name: Repository readiness
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Run repository readiness audit
+        run: ./scripts/repo-readiness-audit.py
+
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/scripts/repo-readiness-audit.py
+++ b/scripts/repo-readiness-audit.py
@@ -62,17 +62,37 @@ def git_stdout(*args: str) -> str:
 
 
 def dependabot_groups_by_ecosystem() -> dict[tuple[str, str], set[str]]:
-    """Return Dependabot group names keyed by package ecosystem and directory."""
-    try:
-        import yaml
-    except ImportError:
-        return {}
+    """Return Dependabot group names keyed by package ecosystem and directory.
 
-    data = yaml.safe_load(read(".github/dependabot.yml")) or {}
+    This intentionally uses a tiny parser for the limited Dependabot shape used
+    in this repo so the readiness audit has no extra CI dependencies.
+    """
     grouped: dict[tuple[str, str], set[str]] = {}
-    for update in data.get("updates", []):
-        key = (str(update.get("package-ecosystem", "")), str(update.get("directory", "")))
-        grouped[key] = set((update.get("groups") or {}).keys())
+    current_key: tuple[str, str] | None = None
+    in_groups = False
+    ecosystem = ""
+    directory = ""
+    for raw_line in read(".github/dependabot.yml").splitlines():
+        line = raw_line.strip()
+        if line.startswith("- package-ecosystem:"):
+            ecosystem = line.split(":", 1)[1].strip().strip('"')
+            directory = ""
+            current_key = None
+            in_groups = False
+            continue
+        if line.startswith("directory:"):
+            directory = line.split(":", 1)[1].strip().strip('"')
+            current_key = (ecosystem, directory)
+            grouped.setdefault(current_key, set())
+            continue
+        if line == "groups:" and current_key is not None:
+            in_groups = True
+            continue
+        if in_groups and raw_line.startswith("      ") and line.endswith(":"):
+            grouped.setdefault(current_key, set()).add(line[:-1])
+            continue
+        if line and not raw_line.startswith("      ") and not line.startswith("-"):
+            in_groups = False
     return grouped
 
 

--- a/scripts/repo-readiness-audit.py
+++ b/scripts/repo-readiness-audit.py
@@ -198,6 +198,17 @@ def main() -> int:
         warnings=warnings,
     )
 
+    print("\n== Dependabot checks ==")
+    dependabot = read(".github/dependabot.yml")
+    for group_name in ["python-runtime", "explainer-video", "github-actions"]:
+        check(
+            f"{group_name}:" in dependabot,
+            f"Dependabot groups {group_name}",
+            f"Dependabot should group {group_name} updates",
+            failures=failures,
+            warnings=warnings,
+        )
+
     print("\n== Release/tag visibility checks ==")
     tags = git_stdout("tag", "--list")
     check(

--- a/scripts/repo-readiness-audit.py
+++ b/scripts/repo-readiness-audit.py
@@ -61,6 +61,21 @@ def git_stdout(*args: str) -> str:
     return result.stdout.strip()
 
 
+def dependabot_groups_by_ecosystem() -> dict[tuple[str, str], set[str]]:
+    """Return Dependabot group names keyed by package ecosystem and directory."""
+    try:
+        import yaml
+    except ImportError:
+        return {}
+
+    data = yaml.safe_load(read(".github/dependabot.yml")) or {}
+    grouped: dict[tuple[str, str], set[str]] = {}
+    for update in data.get("updates", []):
+        key = (str(update.get("package-ecosystem", "")), str(update.get("directory", "")))
+        grouped[key] = set((update.get("groups") or {}).keys())
+    return grouped
+
+
 def main() -> int:
     failures: list[str] = []
     warnings: list[str] = []
@@ -199,12 +214,16 @@ def main() -> int:
     )
 
     print("\n== Dependabot checks ==")
-    dependabot = read(".github/dependabot.yml")
-    for group_name in ["python-runtime", "explainer-video", "github-actions"]:
+    dependabot_groups = dependabot_groups_by_ecosystem()
+    for ecosystem, directory, group_name in [
+        ("uv", "/", "python-runtime"),
+        ("npm", "/explainer-video", "explainer-video"),
+        ("github-actions", "/", "github-actions"),
+    ]:
         check(
-            f"{group_name}:" in dependabot,
-            f"Dependabot groups {group_name}",
-            f"Dependabot should group {group_name} updates",
+            group_name in dependabot_groups.get((ecosystem, directory), set()),
+            f"Dependabot groups {ecosystem} updates in {directory} as {group_name}",
+            f"Dependabot should group {ecosystem} updates in {directory} as {group_name}",
             failures=failures,
             warnings=warnings,
         )

--- a/tests/test_red_team.py
+++ b/tests/test_red_team.py
@@ -114,9 +114,8 @@ class TestUnicodeFilenames:
 class TestInvalidInputs:
     """Test various invalid parameter combinations."""
 
-    @pytest.mark.xfail(reason="FFmpeg on some platforms accepts negative start")
     def test_trim_negative_start(self, sample_video):
-        """Negative start time should raise an error on most platforms."""
+        """Negative start time should raise an error."""
         with pytest.raises((ValueError, ProcessingError, MCPVideoError)):
             trim(sample_video, start=-1, duration=1)
 
@@ -267,9 +266,8 @@ class TestBoundaryValues:
         assert os.path.exists(path)
         assert os.path.getsize(path) > 0
 
-    @pytest.mark.xfail(reason="FFmpeg on some platforms doesn't reject out-of-range timestamps")
     def test_thumbnail_beyond_duration(self, sample_video):
-        """Thumbnail beyond video duration should handle gracefully."""
+        """Thumbnail beyond video duration should raise an error."""
         info = probe(sample_video)
         beyond_duration = info.duration + 1000
 

--- a/tests/test_red_team.py
+++ b/tests/test_red_team.py
@@ -114,8 +114,9 @@ class TestUnicodeFilenames:
 class TestInvalidInputs:
     """Test various invalid parameter combinations."""
 
+    @pytest.mark.xfail(reason="FFmpeg on some platforms accepts negative start")
     def test_trim_negative_start(self, sample_video):
-        """Negative start time should raise an error."""
+        """Negative start time should raise an error on most platforms."""
         with pytest.raises((ValueError, ProcessingError, MCPVideoError)):
             trim(sample_video, start=-1, duration=1)
 
@@ -266,8 +267,9 @@ class TestBoundaryValues:
         assert os.path.exists(path)
         assert os.path.getsize(path) > 0
 
+    @pytest.mark.xfail(reason="FFmpeg on some platforms doesn't reject out-of-range timestamps")
     def test_thumbnail_beyond_duration(self, sample_video):
-        """Thumbnail beyond video duration should raise an error."""
+        """Thumbnail beyond video duration should handle gracefully."""
         info = probe(sample_video)
         beyond_duration = info.duration + 1000
 


### PR DESCRIPTION
## Summary
- Groups Dependabot GitHub Actions updates so future weekly runs open one actions PR instead of one PR per action.
- Adds a `Repository readiness` CI job that runs `./scripts/repo-readiness-audit.py` on every PR/push.
- Extends the readiness audit to assert Dependabot grouping exists for Python runtime, explainer video, and GitHub Actions ecosystems.

## Why
This is the next remediation slice after the adoption pass triggered the initial Dependabot burst. It reduces future PR noise and makes the trust/discovery/governance rails self-enforcing.

## Validation
- `./scripts/repo-readiness-audit.py`
- `python3 -m ruff check scripts/repo-readiness-audit.py`
- `python3 -m ruff format --check scripts/repo-readiness-audit.py`
- Manual check for the `github-actions` Dependabot group and CI readiness step

## Not Tested
- GitHub Actions execution of the new `Repository readiness` job.