### PR TITLE
Restore visual effect fallbacks after ProcessingError

### DIFF
--- a/mcp_video/effects_engine.py
+++ b/mcp_video/effects_engine.py
@@ -129,17 +129,14 @@ def effect_chromatic_aberration(
         output,
     ]
 
-    # Run first attempt, capture error for fallback check
-    result = _run_ffmpeg(cmd)
-
-    # Fallback if chromashift not available
-    if result.returncode != 0 and "chromashift" in result.stderr:
-        filters = f"colorbalance=rs={intensity / 100}:bs=-{intensity / 100}"
-        cmd[4] = filters
+    try:
         _run_ffmpeg(cmd)
-    elif result.returncode != 0:
-        cmd_str = " ".join(cmd)
-        raise ProcessingError(cmd_str, result.returncode, result.stderr)
+    except ProcessingError as e:
+        if "chromashift" not in e.full_stderr:
+            raise
+        filters = f"colorbalance=rs={intensity / 100}:bs=-{intensity / 100}"
+        cmd[5] = filters
+        _run_ffmpeg(cmd)
 
     return output
 
@@ -301,22 +298,19 @@ def effect_glow(
         output,
     ]
 
-    # Run first attempt, capture error for fallback check
-    result = _run_ffmpeg(cmd)
-
-    # Fallback if gblur not available
-    if result.returncode != 0 and "gblur" in result.stderr:
+    try:
+        _run_ffmpeg(cmd)
+    except ProcessingError as e:
+        if "gblur" not in e.full_stderr:
+            raise
         filters = (
             f"split[original][highlights];"
             f"[highlights]geq=lum='if(lt(lum(X,Y),{threshold_8bit}),0,lum(X,Y))',"
             f"boxblur={radius}:{radius}[glow];"
             f"[original][glow]blend=all_mode='addition':all_opacity={intensity}"
         )
-        cmd[4] = filters
+        cmd[5] = filters
         _run_ffmpeg(cmd)
-    elif result.returncode != 0:
-        cmd_str = " ".join(cmd)
-        raise ProcessingError(cmd_str, result.returncode, result.stderr)
 
     return output
 

--- a/tests/test_effects_engine.py
+++ b/tests/test_effects_engine.py
@@ -1,0 +1,74 @@
+"""Tests for visual effects engine behavior."""
+
+from pathlib import Path
+
+from mcp_video.errors import ProcessingError
+
+
+def test_chromatic_aberration_falls_back_when_chromashift_missing(tmp_path, monkeypatch):
+    from mcp_video import effects_engine
+
+    input_path = tmp_path / "input.mp4"
+    output_path = tmp_path / "output.mp4"
+    input_path.write_bytes(b"placeholder")
+    calls = []
+
+    def fake_run_ffmpeg(cmd):
+        calls.append(cmd.copy())
+        if len(calls) == 1:
+            raise ProcessingError(" ".join(cmd), 1, "No such filter: 'chromashift'")
+        Path(cmd[-1]).write_bytes(b"output")
+
+    monkeypatch.setattr(effects_engine, "_run_ffmpeg", fake_run_ffmpeg)
+
+    result = effects_engine.effect_chromatic_aberration(str(input_path), str(output_path), intensity=3.0)
+
+    assert result == str(output_path)
+    assert len(calls) == 2
+    assert calls[0][5].startswith("chromashift=")
+    assert calls[1][5].startswith("colorbalance=")
+
+
+def test_glow_falls_back_when_gblur_missing(tmp_path, monkeypatch):
+    from mcp_video import effects_engine
+
+    input_path = tmp_path / "input.mp4"
+    output_path = tmp_path / "output.mp4"
+    input_path.write_bytes(b"placeholder")
+    calls = []
+
+    def fake_run_ffmpeg(cmd):
+        calls.append(cmd.copy())
+        if len(calls) == 1:
+            raise ProcessingError(" ".join(cmd), 1, "No such filter: 'gblur'")
+        Path(cmd[-1]).write_bytes(b"output")
+
+    monkeypatch.setattr(effects_engine, "_run_ffmpeg", fake_run_ffmpeg)
+
+    result = effects_engine.effect_glow(str(input_path), str(output_path), radius=15)
+
+    assert result == str(output_path)
+    assert len(calls) == 2
+    assert "gblur=sigma=15" in calls[0][5]
+    assert "boxblur=15:15" in calls[1][5]
+
+
+def test_chromatic_aberration_reraises_unrelated_processing_error(tmp_path, monkeypatch):
+    from mcp_video import effects_engine
+
+    input_path = tmp_path / "input.mp4"
+    output_path = tmp_path / "output.mp4"
+    input_path.write_bytes(b"placeholder")
+    error = ProcessingError("ffmpeg", 1, "encoder failed")
+
+    def fake_run_ffmpeg(cmd):
+        raise error
+
+    monkeypatch.setattr(effects_engine, "_run_ffmpeg", fake_run_ffmpeg)
+
+    try:
+        effects_engine.effect_chromatic_aberration(str(input_path), str(output_path))
+    except ProcessingError as exc:
+        assert exc is error
+    else:
+        raise AssertionError("Expected ProcessingError")


### PR DESCRIPTION
## Summary
- Fixes unreachable fallback logic in `effect_chromatic_aberration()` and `effect_glow()`.
- Catches `ProcessingError` from `_run_ffmpeg()` for missing `chromashift` / `gblur` filters and retries with fallback filters.
- Re-raises unrelated processing failures unchanged.
- Adds unit coverage for both fallback paths and unrelated-error propagation.

## Why
`ffmpeg_helpers._run_ffmpeg()` raises on nonzero exit, so the old branches that inspected `result.returncode` and `result.stderr` could never run. This is one of the highest-leverage helper-drift fixes from the remediation audit.

## Validation
- `python3 -m pytest tests/test_effects_engine.py -q --tb=short`
- `python3 -m pytest tests/test_effects_engine.py tests/test_server.py::TestVideoFilterTool tests/test_cli.py::TestCLIColorGrade -q --tb=short`
- `python3 -m ruff check mcp_video/effects_engine.py tests/test_effects_engine.py`
- `python3 -m ruff format --check mcp_video/effects_engine.py tests/test_effects_engine.py`

## Not Tested
- Slow real-media effect sweep.