### PR TITLE
Use shared SRT timestamp formatter in AI transcripts

### DIFF
--- a/mcp_video/ai_engine.py
+++ b/mcp_video/ai_engine.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from typing import Any
 
 from .errors import InputFileError, MCPVideoError, ProcessingError
+from .ffmpeg_helpers import _seconds_to_srt_time
 
 
 def ai_transcribe(
@@ -150,15 +151,6 @@ def _format_srt(segments: list[dict[str, Any]]) -> str:
         index += 1
 
     return "\n".join(srt_lines)
-
-
-def _seconds_to_srt_time(seconds: float) -> str:
-    """Convert seconds to SRT time format HH:MM:SS,mmm"""
-    hours = int(seconds // 3600)
-    minutes = int((seconds % 3600) // 60)
-    secs = int(seconds % 60)
-    millis = int((seconds % 1) * 1000)
-    return f"{hours:02d}:{minutes:02d}:{secs:02d},{millis:03d}"
 
 
 def _format_txt(segments: list[dict[str, Any]]) -> str:


### PR DESCRIPTION
## Summary
- Removes the duplicate `_seconds_to_srt_time()` implementation from `ai_engine.py`.
- Imports the shared formatter from `ffmpeg_helpers.py` instead.
- Keeps transcript/SRT behavior unchanged.

## Why
This is a small helper-drift cleanup from the remediation audit. The duplicated formatter matched the shared helper exactly, so keeping both just increases maintenance surface.

## Validation
- `python3 -m pytest tests/test_ai_features.py::TestSRTFormatting -q --tb=short`
- `python3 -m ruff check mcp_video/ai_engine.py tests/test_ai_features.py`
- `python3 -m ruff format --check mcp_video/ai_engine.py`

## Not Tested
- Full AI feature suite.