### PR TITLE
Extract CLI formatting helpers

### DIFF
--- a/mcp_video/__main__.py
+++ b/mcp_video/__main__.py
@@ -7,180 +7,22 @@ import json
 import sys
 from typing import Any
 
-from rich.console import Console
-from rich.markup import escape
 from rich.panel import Panel
-from rich.progress import Progress, SpinnerColumn, TextColumn, TimeElapsedColumn
 from rich.table import Table
 
-console = Console()
-err_console = Console(stderr=True)
-
-
-def _format_info_text(info: Any) -> None:
-    """Display video info as a rich table."""
-    table = Table(title="Video Info", show_header=False, border_style="blue")
-    table.add_column("Property", style="bold cyan", no_wrap=True)
-    table.add_column("Value")
-    table.add_row("Path", str(getattr(info, "path", "N/A")))
-    table.add_row("Duration", f"{getattr(info, 'duration', 0):.2f}s")
-    table.add_row("Resolution", getattr(info, "resolution", "N/A"))
-    table.add_row("Aspect Ratio", getattr(info, "aspect_ratio", "N/A"))
-    table.add_row("FPS", str(getattr(info, "fps", "N/A")))
-    table.add_row("Video Codec", getattr(info, "codec", "N/A"))
-    table.add_row("Audio Codec", getattr(info, "audio_codec", "N/A"))
-    table.add_row("Size", f"{getattr(info, 'size_mb', 0):.2f} MB")
-    table.add_row("Format", getattr(info, "format", "N/A"))
-    console.print(table)
-
-
-def _format_edit_text(result: Any) -> None:
-    """Display edit result as a success panel."""
-    data = result.model_dump() if hasattr(result, "model_dump") else result
-    lines = [
-        f"[bold green]Operation:[/bold green] {data.get('operation', 'N/A')}",
-        f"[bold green]Output:[/bold green] {data.get('output_path', 'N/A')}",
-    ]
-    if data.get("duration") is not None:
-        lines.append(f"[bold green]Duration:[/bold green] {data['duration']:.2f}s")
-    if data.get("resolution"):
-        lines.append(f"[bold green]Resolution:[/bold green] {data['resolution']}")
-    if data.get("size_mb") is not None:
-        lines.append(f"[bold green]Size:[/bold green] {data['size_mb']:.2f} MB")
-    if data.get("format"):
-        lines.append(f"[bold green]Format:[/bold green] {data['format']}")
-    console.print(Panel("\n".join(lines), border_style="green", title="Done"))
-
-
-def _format_thumbnail_text(result: Any) -> None:
-    """Display thumbnail/extract-frame result."""
-    data = result.model_dump() if hasattr(result, "model_dump") else result
-    frame_path = data.get("frame_path", "N/A")
-    timestamp = data.get("timestamp", 0.0)
-    console.print(
-        Panel(
-            f"[bold green]Frame extracted:[/bold green] {frame_path}\n[bold green]Timestamp:[/bold green] {timestamp:.2f}s",
-            border_style="green",
-            title="Done",
-        )
-    )
-
-
-def _format_storyboard_text(result: Any) -> None:
-    """Display storyboard result."""
-    data = result.model_dump() if hasattr(result, "model_dump") else result
-    frames = data.get("frames", [])
-    grid = data.get("grid")
-    lines = [
-        f"[bold green]Frames:[/bold green] {data.get('count', len(frames))}",
-    ]
-    if frames:
-        lines.append(f"[bold green]Output dir:[/bold green] {frames[0].rsplit('/', 1)[0] if '/' in frames[0] else '.'}")
-    if grid:
-        lines.append(f"[bold green]Grid:[/bold green] {grid}")
-    console.print(Panel("\n".join(lines), border_style="green", title="Storyboard"))
-
-
-def _format_batch_text(result: dict) -> None:
-    """Display batch result as a table."""
-    if result.get("success") is False:
-        error_msg = result.get("error", {})
-        msg = error_msg.get("message", str(error_msg)) if isinstance(error_msg, dict) else str(error_msg)
-        console.print(f"[bold red]Batch failed: {msg}[/bold red]")
-        return
-    table = Table(title="Batch Results")
-    table.add_column("File", style="cyan")
-    table.add_column("Status")
-    table.add_column("Output")
-    for r in result.get("results", []):
-        status = "[green]OK[/green]" if r.get("success") else f"[red]{r.get('error', 'Failed')}[/red]"
-        table.add_row(r.get("input", "N/A"), status, r.get("output_path", "-"))
-    console.print(table)
-    summary = f"[bold]{result['succeeded']}/{result['total']} succeeded[/bold]"
-    if result.get("failed"):
-        summary += f", [red]{result['failed']} failed[/red]"
-    console.print(summary)
-
-
-def _format_extract_audio_text(result: Any) -> None:
-    """Display extract-audio result."""
-    console.print(Panel(f"[bold green]Audio extracted:[/bold green] {result}", border_style="green", title="Done"))
-
-
-def _format_doctor_text(report: dict[str, Any]) -> None:
-    """Display diagnostics as a compact table."""
-    summary = report["summary"]
-    status = "OK" if summary["required_ok"] else "Missing required dependencies"
-    console.print(f"[bold]mcp-video doctor[/bold] — {status}")
-    table = Table(title="Environment Checks")
-    table.add_column("Name", style="cyan")
-    table.add_column("Category")
-    table.add_column("Required")
-    table.add_column("Status")
-    table.add_column("Version / Hint")
-    for check in report["checks"]:
-        state = "[green]OK[/green]" if check["ok"] else "[yellow]Missing[/yellow]"
-        detail = check.get("version") or check.get("install_hint") or "-"
-        table.add_row(check["name"], check["category"], "yes" if check["required"] else "no", state, escape(detail))
-    console.print(table)
-
-
-def _format_error(e: Exception) -> None:
-    """Display error in a styled panel."""
-    from .errors import MCPVideoError
-
-    if isinstance(e, MCPVideoError):
-        try:
-            data = e.to_dict()
-        except Exception:
-            data = {}
-        msg = data.get("message", str(e))
-        code = data.get("code", "")
-        action = data.get("suggested_action", {})
-        lines = [f"[bold red]{msg}[/bold red]"]
-        if code:
-            lines.append(f"[dim]Code: {code}[/dim]")
-        if isinstance(action, dict) and action.get("description"):
-            lines.append(f"\n[yellow]Suggested fix:[/yellow] {action['description']}")
-        err_console.print(Panel("\n".join(lines), border_style="red", title="Error"))
-    else:
-        err_console.print(Panel(f"[bold red]{e}[/bold red]", border_style="red", title="Error"))
-
-
-def _parse_json_arg(value: str, arg_name: str = "argument", json_mode: bool = False) -> Any:
-    """Parse a JSON string argument, showing a friendly error on failure."""
-    try:
-        return json.loads(value)
-    except json.JSONDecodeError as e:
-        if json_mode:
-            print(
-                json.dumps(
-                    {
-                        "success": False,
-                        "error": {
-                            "type": "input_error",
-                            "code": "invalid_json",
-                            "message": f"Invalid JSON in --{arg_name}: {e}",
-                        },
-                    }
-                )
-            )
-        else:
-            console.print(f"[bold red]Invalid JSON in --{arg_name}: {e}[/bold red]")
-        raise SystemExit(1) from None
-
-
-def _with_spinner(label: str, fn, *args, **kwargs):
-    """Run an engine function with a rich spinner."""
-    with Progress(
-        SpinnerColumn(),
-        TextColumn(f"[progress.description]{label}"),
-        TimeElapsedColumn(),
-        console=console,
-        transient=True,
-    ) as progress:
-        progress.add_task(description=label, total=None)
-        return fn(*args, **kwargs)
+from .cli.common import _parse_json_arg, _with_spinner
+from .cli.formatting import (
+    _format_batch_text,
+    _format_doctor_text,
+    _format_edit_text,
+    _format_error,
+    _format_extract_audio_text,
+    _format_info_text,
+    _format_storyboard_text,
+    _format_thumbnail_text,
+    console,
+    err_console,
+)
 
 
 def main() -> None:

--- a/mcp_video/cli/__init__.py
+++ b/mcp_video/cli/__init__.py
@@ -1,0 +1,1 @@
+"""CLI helpers for mcp-video."""

--- a/mcp_video/cli/common.py
+++ b/mcp_video/cli/common.py
@@ -1,0 +1,46 @@
+"""Common execution helpers for the mcp-video CLI."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from rich.progress import Progress, SpinnerColumn, TextColumn, TimeElapsedColumn
+
+from .formatting import console
+
+
+def _parse_json_arg(value: str, arg_name: str = "argument", json_mode: bool = False) -> Any:
+    """Parse a JSON string argument, showing a friendly error on failure."""
+    try:
+        return json.loads(value)
+    except json.JSONDecodeError as e:
+        if json_mode:
+            print(
+                json.dumps(
+                    {
+                        "success": False,
+                        "error": {
+                            "type": "input_error",
+                            "code": "invalid_json",
+                            "message": f"Invalid JSON in --{arg_name}: {e}",
+                        },
+                    }
+                )
+            )
+        else:
+            console.print(f"[bold red]Invalid JSON in --{arg_name}: {e}[/bold red]")
+        raise SystemExit(1) from None
+
+
+def _with_spinner(label: str, fn, *args, **kwargs):
+    """Run an engine function with a rich spinner."""
+    with Progress(
+        SpinnerColumn(),
+        TextColumn(f"[progress.description]{label}"),
+        TimeElapsedColumn(),
+        console=console,
+        transient=True,
+    ) as progress:
+        progress.add_task(description=label, total=None)
+        return fn(*args, **kwargs)

--- a/mcp_video/cli/formatting.py
+++ b/mcp_video/cli/formatting.py
@@ -1,0 +1,143 @@
+"""Rich output formatting helpers for the mcp-video CLI."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from rich.console import Console
+from rich.markup import escape
+from rich.panel import Panel
+from rich.table import Table
+
+console = Console()
+err_console = Console(stderr=True)
+
+
+def _format_info_text(info: Any) -> None:
+    """Display video info as a rich table."""
+    table = Table(title="Video Info", show_header=False, border_style="blue")
+    table.add_column("Property", style="bold cyan", no_wrap=True)
+    table.add_column("Value")
+    table.add_row("Path", str(getattr(info, "path", "N/A")))
+    table.add_row("Duration", f"{getattr(info, 'duration', 0):.2f}s")
+    table.add_row("Resolution", getattr(info, "resolution", "N/A"))
+    table.add_row("Aspect Ratio", getattr(info, "aspect_ratio", "N/A"))
+    table.add_row("FPS", str(getattr(info, "fps", "N/A")))
+    table.add_row("Video Codec", getattr(info, "codec", "N/A"))
+    table.add_row("Audio Codec", getattr(info, "audio_codec", "N/A"))
+    table.add_row("Size", f"{getattr(info, 'size_mb', 0):.2f} MB")
+    table.add_row("Format", getattr(info, "format", "N/A"))
+    console.print(table)
+
+
+def _format_edit_text(result: Any) -> None:
+    """Display edit result as a success panel."""
+    data = result.model_dump() if hasattr(result, "model_dump") else result
+    lines = [
+        f"[bold green]Operation:[/bold green] {data.get('operation', 'N/A')}",
+        f"[bold green]Output:[/bold green] {data.get('output_path', 'N/A')}",
+    ]
+    if data.get("duration") is not None:
+        lines.append(f"[bold green]Duration:[/bold green] {data['duration']:.2f}s")
+    if data.get("resolution"):
+        lines.append(f"[bold green]Resolution:[/bold green] {data['resolution']}")
+    if data.get("size_mb") is not None:
+        lines.append(f"[bold green]Size:[/bold green] {data['size_mb']:.2f} MB")
+    if data.get("format"):
+        lines.append(f"[bold green]Format:[/bold green] {data['format']}")
+    console.print(Panel("\n".join(lines), border_style="green", title="Done"))
+
+
+def _format_thumbnail_text(result: Any) -> None:
+    """Display thumbnail/extract-frame result."""
+    data = result.model_dump() if hasattr(result, "model_dump") else result
+    frame_path = data.get("frame_path", "N/A")
+    timestamp = data.get("timestamp", 0.0)
+    console.print(
+        Panel(
+            f"[bold green]Frame extracted:[/bold green] {frame_path}\n[bold green]Timestamp:[/bold green] {timestamp:.2f}s",
+            border_style="green",
+            title="Done",
+        )
+    )
+
+
+def _format_storyboard_text(result: Any) -> None:
+    """Display storyboard result."""
+    data = result.model_dump() if hasattr(result, "model_dump") else result
+    frames = data.get("frames", [])
+    grid = data.get("grid")
+    lines = [
+        f"[bold green]Frames:[/bold green] {data.get('count', len(frames))}",
+    ]
+    if frames:
+        lines.append(f"[bold green]Output dir:[/bold green] {frames[0].rsplit('/', 1)[0] if '/' in frames[0] else '.'}")
+    if grid:
+        lines.append(f"[bold green]Grid:[/bold green] {grid}")
+    console.print(Panel("\n".join(lines), border_style="green", title="Storyboard"))
+
+
+def _format_batch_text(result: dict) -> None:
+    """Display batch result as a table."""
+    if result.get("success") is False:
+        error_msg = result.get("error", {})
+        msg = error_msg.get("message", str(error_msg)) if isinstance(error_msg, dict) else str(error_msg)
+        console.print(f"[bold red]Batch failed: {msg}[/bold red]")
+        return
+    table = Table(title="Batch Results")
+    table.add_column("File", style="cyan")
+    table.add_column("Status")
+    table.add_column("Output")
+    for r in result.get("results", []):
+        status = "[green]OK[/green]" if r.get("success") else f"[red]{r.get('error', 'Failed')}[/red]"
+        table.add_row(r.get("input", "N/A"), status, r.get("output_path", "-"))
+    console.print(table)
+    summary = f"[bold]{result['succeeded']}/{result['total']} succeeded[/bold]"
+    if result.get("failed"):
+        summary += f", [red]{result['failed']} failed[/red]"
+    console.print(summary)
+
+
+def _format_extract_audio_text(result: Any) -> None:
+    """Display extract-audio result."""
+    console.print(Panel(f"[bold green]Audio extracted:[/bold green] {result}", border_style="green", title="Done"))
+
+
+def _format_doctor_text(report: dict[str, Any]) -> None:
+    """Display diagnostics as a compact table."""
+    summary = report["summary"]
+    status = "OK" if summary["required_ok"] else "Missing required dependencies"
+    console.print(f"[bold]mcp-video doctor[/bold] — {status}")
+    table = Table(title="Environment Checks")
+    table.add_column("Name", style="cyan")
+    table.add_column("Category")
+    table.add_column("Required")
+    table.add_column("Status")
+    table.add_column("Version / Hint")
+    for check in report["checks"]:
+        state = "[green]OK[/green]" if check["ok"] else "[yellow]Missing[/yellow]"
+        detail = check.get("version") or check.get("install_hint") or "-"
+        table.add_row(check["name"], check["category"], "yes" if check["required"] else "no", state, escape(detail))
+    console.print(table)
+
+
+def _format_error(e: Exception) -> None:
+    """Display error in a styled panel."""
+    from ..errors import MCPVideoError
+
+    if isinstance(e, MCPVideoError):
+        try:
+            data = e.to_dict()
+        except Exception:
+            data = {}
+        msg = data.get("message", str(e))
+        code = data.get("code", "")
+        action = data.get("suggested_action", {})
+        lines = [f"[bold red]{msg}[/bold red]"]
+        if code:
+            lines.append(f"[dim]Code: {code}[/dim]")
+        if isinstance(action, dict) and action.get("description"):
+            lines.append(f"\n[yellow]Suggested fix:[/yellow] {action['description']}")
+        err_console.print(Panel("\n".join(lines), border_style="red", title="Error"))
+    else:
+        err_console.print(Panel(f"[bold red]{e}[/bold red]", border_style="red", title="Error"))


### PR DESCRIPTION
## Summary
- Adds `mcp_video.cli` package with formatting and common helper modules.
- Moves Rich output helpers, error formatting, JSON argument parsing, and spinner execution out of `mcp_video.__main__`.
- Leaves parser construction, command dispatch, command names, flags, and output behavior unchanged.

## Why
This is the first low-risk step toward splitting the oversized CLI module. It reduces `__main__.py` while avoiding the higher-risk parser/handler split until the public surface characterization PR lands.

## Validation
- `python3 -m pytest tests/test_cli.py tests/test_doctor.py -q --tb=short`
- `python3 -m pytest tests/test_cli.py::TestCLIVersion::test_version_flag tests/test_cli.py::TestCLIInfo::test_info_outputs_json tests/test_doctor.py -q --tb=short`
- `python3 -m mcp_video --version`
- `python3 -m mcp_video --help`
- `python3 -m mcp_video doctor --json`
- `python3 -m ruff check mcp_video/__main__.py mcp_video/cli tests/test_cli.py`
- `python3 -m ruff format --check mcp_video/__main__.py mcp_video/cli`

## Not Tested
- Full non-slow suite after CLI helper extraction.