### PR TITLE
Name shared FFmpeg helper timeouts

### DIFF
--- a/mcp_video/ffmpeg_helpers.py
+++ b/mcp_video/ffmpeg_helpers.py
@@ -11,6 +11,7 @@ import subprocess
 from typing import Any
 
 from .errors import InputFileError, ProcessingError
+from .limits import DEFAULT_FFMPEG_TIMEOUT, FFPROBE_TIMEOUT
 
 
 def _validate_input_path(path: str) -> str:
@@ -23,7 +24,7 @@ def _validate_input_path(path: str) -> str:
     return resolved
 
 
-def _run_ffmpeg(cmd: list[str], timeout: int = 600) -> subprocess.CompletedProcess[str]:
+def _run_ffmpeg(cmd: list[str], timeout: int = DEFAULT_FFMPEG_TIMEOUT) -> subprocess.CompletedProcess[str]:
     """Run an FFmpeg/FFprobe command with timeout and error handling."""
     # Ensure output directory exists — find the last non-flag argument (the output file)
     for arg in reversed(cmd):
@@ -85,7 +86,7 @@ def _run_ffprobe_json(path: str) -> dict[str, Any]:
         "-show_streams",
         path,
     ]
-    result = _run_ffmpeg(cmd, timeout=30)
+    result = _run_ffmpeg(cmd, timeout=FFPROBE_TIMEOUT)
     return _json.loads(result.stdout)
 
 

--- a/mcp_video/limits.py
+++ b/mcp_video/limits.py
@@ -9,6 +9,7 @@ MAX_FILE_SIZE_MB = 4096  # 4 GB
 MAX_CONCURRENT_PROCESSES = 4
 DEFAULT_FFMPEG_TIMEOUT = 600  # 10 minutes
 DOCTOR_COMMAND_TIMEOUT = 10  # Short version/probe commands should not hang
+FFPROBE_TIMEOUT = 30  # Metadata probes should fail quickly
 MAX_BATCH_SIZE = 50
 MAX_EXPORT_FRAMES_FPS = 60
 

--- a/tests/test_ffmpeg_helpers.py
+++ b/tests/test_ffmpeg_helpers.py
@@ -1,0 +1,28 @@
+"""Tests for shared FFmpeg helper contracts."""
+
+
+def test_ffprobe_timeout_constant_exists():
+    from mcp_video import limits
+
+    assert hasattr(limits, "FFPROBE_TIMEOUT")
+    assert limits.FFPROBE_TIMEOUT > 0
+    assert limits.FFPROBE_TIMEOUT < limits.DEFAULT_FFMPEG_TIMEOUT
+
+
+def test_run_ffprobe_json_uses_named_timeout(monkeypatch):
+    from mcp_video import ffmpeg_helpers
+    from mcp_video.limits import FFPROBE_TIMEOUT
+
+    captured = {}
+
+    class Result:
+        stdout = '{"format": {}, "streams": []}'
+
+    def fake_run_ffmpeg(cmd, timeout=0):
+        captured["timeout"] = timeout
+        return Result()
+
+    monkeypatch.setattr(ffmpeg_helpers, "_run_ffmpeg", fake_run_ffmpeg)
+
+    assert ffmpeg_helpers._run_ffprobe_json("/tmp/video.mp4") == {"format": {}, "streams": []}
+    assert captured["timeout"] == FFPROBE_TIMEOUT


### PR DESCRIPTION
## Summary
- Adds `FFPROBE_TIMEOUT` to `limits.py` for short metadata probes.
- Uses `DEFAULT_FFMPEG_TIMEOUT` as the shared helper default instead of a literal `600`.
- Uses `FFPROBE_TIMEOUT` in `_run_ffprobe_json()` instead of a literal `30`.
- Adds unit tests for the timeout constants and ffprobe helper timeout wiring.

## Why
This is a small helper-drift cleanup from the remediation audit. Timeout policy should live behind named constants so FFmpeg helper behavior is visible and reusable.

## Validation
- `python3 -m pytest tests/test_ffmpeg_helpers.py tests/test_adversarial_audit.py::TestLimitsModule -q --tb=short`
- `python3 -m ruff check mcp_video/ffmpeg_helpers.py mcp_video/limits.py tests/test_ffmpeg_helpers.py`
- `python3 -m ruff format --check mcp_video/ffmpeg_helpers.py mcp_video/limits.py tests/test_ffmpeg_helpers.py`

## Not Tested
- Full non-slow suite after helper timeout constant cleanup.