### PR TITLE
Move remaining CLI common helpers out of main

### DIFF
--- a/mcp_video/__main__.py
+++ b/mcp_video/__main__.py
@@ -9,7 +9,7 @@ from typing import Any
 from rich.panel import Panel
 from rich.table import Table
 
-from .cli.common import _parse_json_arg, _with_spinner
+from .cli.common import _auto_output, _parse_json_arg, _with_spinner, output_json
 from .cli.parser import build_parser
 from .cli.formatting import (
     _format_batch_text,
@@ -51,19 +51,6 @@ def main() -> None:
         return
 
     use_json = args.format == "json"
-
-    def _auto_output(input_path: str, suffix: str) -> str:
-        """Generate an output path next to the input file."""
-        import os
-
-        base, ext = os.path.splitext(input_path)
-        return f"{base}_{suffix}{ext}"
-
-    # Helper to output result
-    def output_json(data: Any) -> None:
-        if hasattr(data, "model_dump"):
-            data = data.model_dump()
-        print(json.dumps(data, indent=2))
 
     # CLI commands
     try:

--- a/mcp_video/cli/common.py
+++ b/mcp_video/cli/common.py
@@ -3,11 +3,25 @@
 from __future__ import annotations
 
 import json
+import os
 from typing import Any
 
 from rich.progress import Progress, SpinnerColumn, TextColumn, TimeElapsedColumn
 
 from .formatting import console
+
+
+def _auto_output(input_path: str, suffix: str) -> str:
+    """Generate an output path next to the input file."""
+    base, ext = os.path.splitext(input_path)
+    return f"{base}_{suffix}{ext}"
+
+
+def output_json(data: Any) -> None:
+    """Print a JSON response, converting Pydantic models first."""
+    if hasattr(data, "model_dump"):
+        data = data.model_dump()
+    print(json.dumps(data, indent=2))
 
 
 def _parse_json_arg(value: str, arg_name: str = "argument", json_mode: bool = False) -> Any:


### PR DESCRIPTION
## Summary
- Moves `_auto_output()` and `output_json()` from `mcp_video.__main__` into `mcp_video.cli.common`.
- Leaves command dispatch behavior unchanged.
- Continues the incremental CLI module split after #41 and #43.

## Validation
- `python3 -m pytest tests/test_cli.py tests/test_doctor.py -q --tb=short`
- `python3 -m pytest tests/test_cli.py::TestCLIError::test_invalid_file_outputs_json_error tests/test_cli.py tests/test_doctor.py -q --tb=short`
- `python3 -m mcp_video --version`
- `python3 -m mcp_video doctor --json`
- `python3 -m ruff check mcp_video/__main__.py mcp_video/cli tests/test_cli.py`
- `python3 -m ruff format --check mcp_video/__main__.py mcp_video/cli`

## Not Tested
- Full non-slow suite after small CLI helper cleanup.