### PR TITLE
Extract shared MCP app helpers

### DIFF
--- a/mcp_video/server.py
+++ b/mcp_video/server.py
@@ -3,12 +3,9 @@
 from __future__ import annotations
 
 import json
-import logging
 import os
 import re
 from typing import Any
-
-from mcp.server.fastmcp import FastMCP
 
 from .engine import (
     _validate_chroma_color,
@@ -49,6 +46,7 @@ from .engine import (
     write_metadata,
 )
 from .errors import MCPVideoError
+from .server_app import _error_result, _result, mcp
 from .limits import (
     MAX_BATCH_SIZE,
     MAX_CONCURRENCY,
@@ -81,51 +79,6 @@ from .validation import (
     VALID_WAVEFORMS,
     VALID_WHISPER_MODELS,
 )
-
-mcp = FastMCP(
-    "mcp-video",
-    instructions=(
-        "mcp-video is a video editing MCP server. Use these tools to trim, merge, "
-        "add text overlays, sync audio, resize, convert, and export video files. "
-        "All file paths should be absolute. Output files are generated automatically "
-        "if no output_path is provided."
-    ),
-)
-
-logger = logging.getLogger(__name__)
-
-
-def _error_result(err: MCPVideoError | Exception) -> dict[str, Any]:
-    if isinstance(err, MCPVideoError):
-        return {"success": False, "error": err.to_dict()}
-    # Unexpected exception — log full traceback, return generic message
-    logger.exception("Unexpected error in MCP tool handler")
-    return {
-        "success": False,
-        "error": {
-            "type": "internal_error",
-            "code": "internal_error",
-            "message": "An internal error occurred. Check server logs for details.",
-        },
-    }
-
-
-def _result(result: Any) -> dict[str, Any]:
-    if result is None:
-        return {
-            "success": False,
-            "error": {"type": "processing_error", "code": "no_result", "message": "Operation returned no result"},
-        }
-    if hasattr(result, "model_dump"):
-        data = result.model_dump()
-        # Include thumbnail_base64 only if it was generated (keep MCP responses lean)
-        if not data.get("thumbnail_base64"):
-            data.pop("thumbnail_base64", None)
-        return data
-    if isinstance(result, dict):
-        result.setdefault("success", True)
-        return result
-    return {"success": True, "output_path": str(result)}
 
 
 # ---------------------------------------------------------------------------

--- a/mcp_video/server_app.py
+++ b/mcp_video/server_app.py
@@ -1,0 +1,55 @@
+"""Shared FastMCP app and result helpers."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from mcp.server.fastmcp import FastMCP
+
+from .errors import MCPVideoError
+
+mcp = FastMCP(
+    "mcp-video",
+    instructions=(
+        "mcp-video is a video editing MCP server. Use these tools to trim, merge, "
+        "add text overlays, sync audio, resize, convert, and export video files. "
+        "All file paths should be absolute. Output files are generated automatically "
+        "if no output_path is provided."
+    ),
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _error_result(err: MCPVideoError | Exception) -> dict[str, Any]:
+    if isinstance(err, MCPVideoError):
+        return {"success": False, "error": err.to_dict()}
+    # Unexpected exception — log full traceback, return generic message
+    logger.exception("Unexpected error in MCP tool handler")
+    return {
+        "success": False,
+        "error": {
+            "type": "internal_error",
+            "code": "internal_error",
+            "message": "An internal error occurred. Check server logs for details.",
+        },
+    }
+
+
+def _result(result: Any) -> dict[str, Any]:
+    if result is None:
+        return {
+            "success": False,
+            "error": {"type": "processing_error", "code": "no_result", "message": "Operation returned no result"},
+        }
+    if hasattr(result, "model_dump"):
+        data = result.model_dump()
+        # Include thumbnail_base64 only if it was generated (keep MCP responses lean)
+        if not data.get("thumbnail_base64"):
+            data.pop("thumbnail_base64", None)
+        return data
+    if isinstance(result, dict):
+        result.setdefault("success", True)
+        return result
+    return {"success": True, "output_path": str(result)}


### PR DESCRIPTION
## Summary
- Adds `mcp_video.server_app` with the shared `FastMCP` app, `_result`, and `_error_result` helpers.
- Keeps `mcp_video.server` as the public registration/re-export surface.
- Preserves direct imports of `mcp`, `_result`, and `_error_result` from `mcp_video.server`.

## Why
This is the first server decomposition step. Extracting the shared app/helpers first lets future PRs split tool registration modules without circular imports or duplicate MCP registration.

## Validation
- `python3 -m pytest tests/test_server.py::TestServerInitialization tests/test_server.py::TestErrorHandling tests/test_public_surface.py -q --tb=short`
- `python3 -m ruff check mcp_video/server.py mcp_video/server_app.py tests/test_server.py tests/test_public_surface.py`
- `python3 -m ruff format --check mcp_video/server.py mcp_video/server_app.py`
- Async smoke check: `mcp.list_tools()` returns 83 tools

## Not Tested
- Full non-slow suite after server app extraction.