### PR TITLE
Extract initial CLI command handlers

### DIFF
--- a/mcp_video/__main__.py
+++ b/mcp_video/__main__.py
@@ -10,14 +10,13 @@ from rich.panel import Panel
 from rich.table import Table
 
 from .cli.common import _auto_output, _parse_json_arg, _with_spinner, output_json
+from .cli.handlers_core import handle_initial_command
 from .cli.parser import build_parser
 from .cli.formatting import (
     _format_batch_text,
-    _format_doctor_text,
     _format_edit_text,
     _format_error,
     _format_extract_audio_text,
-    _format_info_text,
     _format_storyboard_text,
     _format_thumbnail_text,
     console,
@@ -54,38 +53,10 @@ def main() -> None:
 
     # CLI commands
     try:
-        if args.command == "doctor":
-            from .doctor import run_diagnostics
+        if handle_initial_command(args, use_json=use_json):
+            return
 
-            report = run_diagnostics()
-            if use_json or args.json:
-                output_json(report)
-            else:
-                _format_doctor_text(report)
-
-        elif args.command == "info":
-            from .engine import probe
-
-            info = probe(args.input)
-            if use_json:
-                info_dict = info.model_dump() if hasattr(info, "model_dump") else info
-                output_json({"success": True, "data": info_dict})
-            else:
-                _format_info_text(info)
-
-        elif args.command == "extract-frame":
-            from .engine import thumbnail
-
-            result = _with_spinner(
-                "Extracting frame...", thumbnail, args.input, timestamp=args.timestamp, output_path=args.output
-            )
-            if use_json:
-                result_dict = result.model_dump() if hasattr(result, "model_dump") else result
-                output_json({"success": True, **result_dict})
-            else:
-                _format_thumbnail_text(result)
-
-        elif args.command == "trim":
+        if args.command == "trim":
             from .engine import trim
 
             result = _with_spinner(

--- a/mcp_video/cli/handlers_core.py
+++ b/mcp_video/cli/handlers_core.py
@@ -1,0 +1,50 @@
+"""Core CLI command handlers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .common import _with_spinner, output_json
+from .formatting import _format_doctor_text, _format_info_text, _format_thumbnail_text
+
+
+def handle_initial_command(args: Any, *, use_json: bool) -> bool:
+    """Handle initial low-risk commands extracted from ``__main__``.
+
+    Returns True when a command was handled and no further dispatch is needed.
+    """
+    if args.command == "doctor":
+        from ..doctor import run_diagnostics
+
+        report = run_diagnostics()
+        if use_json or args.json:
+            output_json(report)
+        else:
+            _format_doctor_text(report)
+        return True
+
+    if args.command == "info":
+        from ..engine import probe
+
+        info = probe(args.input)
+        if use_json:
+            info_dict = info.model_dump() if hasattr(info, "model_dump") else info
+            output_json({"success": True, "data": info_dict})
+        else:
+            _format_info_text(info)
+        return True
+
+    if args.command == "extract-frame":
+        from ..engine import thumbnail
+
+        result = _with_spinner(
+            "Extracting frame...", thumbnail, args.input, timestamp=args.timestamp, output_path=args.output
+        )
+        if use_json:
+            result_dict = result.model_dump() if hasattr(result, "model_dump") else result
+            output_json({"success": True, **result_dict})
+        else:
+            _format_thumbnail_text(result)
+        return True
+
+    return False


### PR DESCRIPTION
## Summary
- Adds `mcp_video.cli.handlers_core`.
- Moves the low-risk `doctor`, `info`, and `extract-frame` dispatch branches out of `mcp_video.__main__`.
- Leaves all other command dispatch in place.
- Preserves command names, lazy imports, and JSON/text output behavior.

## Why
This proves the handler extraction pattern before moving larger CLI command families. It is the next incremental slice of the CLI module decomposition.

## Validation
- `python3 -m pytest tests/test_cli.py tests/test_doctor.py tests/test_public_surface.py -q --tb=short`
- `python3 -m pytest tests/test_cli.py::TestCLIInfo::test_info_outputs_json tests/test_cli.py::TestCLIError::test_invalid_file_outputs_json_error tests/test_doctor.py -q --tb=short`
- `python3 -m ruff check mcp_video/__main__.py mcp_video/cli tests/test_cli.py tests/test_public_surface.py`
- `python3 -m ruff format --check mcp_video/__main__.py mcp_video/cli`

## Not Tested
- Full non-slow suite after initial handler extraction.