### PR TITLE
Keep release metadata links canonical

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This project follows a simple release-note style:
 
 - Updated public tool count messaging from 82 to the current 83 MCP tools.
 - Updated the landing page with crawl metadata and structured software/source metadata.
+- Normalized root metadata links to the canonical repository URL.
 
 ## 1.2.1 - 2026-04-13
 

--- a/README.md
+++ b/README.md
@@ -833,7 +833,7 @@ pytest tests/ -v -m "not slow and not remotion"
 - Security reports: see [SECURITY.md](SECURITY.md) (private reporting path).
 - Need help or want to request a feature? Start with [SUPPORT.md](SUPPORT.md).
 - Expected behavior in community spaces: [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md).
-- Discussions: ask questions, share demos, and float ideas in [GitHub Discussions](https://github.com/Pastorsimon1798/mcp-video/discussions).
+- Discussions: ask questions, share demos, and float ideas in [GitHub Discussions](https://github.com/pastorsimon1798/mcp-video/discussions).
 - Governance and maintainer expectations: [GOVERNANCE.md](GOVERNANCE.md) and [MAINTAINERS.md](MAINTAINERS.md).
 - Release history: [CHANGELOG.md](CHANGELOG.md).
 

--- a/server.json
+++ b/server.json
@@ -5,7 +5,7 @@
   "description": "Video editing MCP server for AI agents using FFmpeg and Remotion structured tools.",
   "version": "1.2.1",
   "repository": {
-    "url": "https://github.com/Pastorsimon1798/mcp-video",
+    "url": "https://github.com/pastorsimon1798/mcp-video",
     "source": "github"
   },
   "packages": [


### PR DESCRIPTION
## Summary
- Normalizes root metadata links to the canonical lowercase repository URL.
- Updates README Discussions URL and `server.json` repository URL.
- Notes the metadata-link normalization in CHANGELOG.

## Validation
- `./scripts/repo-readiness-audit.py`
- Metadata parse/version/url smoke
- `python3 -c "import mcp_video; print(mcp_video.__version__)"`
- `python3 -m pytest tests/test_cli.py tests/test_public_surface.py tests/test_server.py -q --tb=short`
- `git diff --check`

## Not Tested
- Full repo test command remains blocked by existing missing real-media fixture `out/McpVideoExplainer-FINAL.mp4`.