### PR TITLE
Extract MCP resource registrations

### DIFF
--- a/mcp_video/server.py
+++ b/mcp_video/server.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 import os
 import re
 from typing import Any
@@ -47,6 +46,12 @@ from .engine import (
 )
 from .errors import MCPVideoError
 from .server_app import _error_result, _result, mcp
+from .server_resources import (
+    templates_resource as templates_resource,
+    video_audio_resource as video_audio_resource,
+    video_info_resource as video_info_resource,
+    video_preview_resource as video_preview_resource,
+)
 from .limits import (
     MAX_BATCH_SIZE,
     MAX_CONCURRENCY,
@@ -79,82 +84,6 @@ from .validation import (
     VALID_WAVEFORMS,
     VALID_WHISPER_MODELS,
 )
-
-
-# ---------------------------------------------------------------------------
-# MCP Resources
-# ---------------------------------------------------------------------------
-
-
-@mcp.resource("mcp-video://video/{path}/info")
-def video_info_resource(path: str) -> str:
-    """Get metadata about a video file (duration, resolution, codec, etc.)."""
-    try:
-        info = probe(path)
-        return info.model_dump_json(indent=2)
-    except MCPVideoError as e:
-        return json.dumps(_error_result(e), indent=2)
-
-
-@mcp.resource("mcp-video://video/{path}/preview")
-def video_preview_resource(path: str) -> str:
-    """Get a text storyboard description (key frame timestamps)."""
-    try:
-        info = probe(path)
-        frames = []
-        dur = info.duration
-        count = 8
-        for i in range(count):
-            ts = dur * (i + 1) / (count + 1)
-            frames.append(f"Frame {i + 1}: {ts:.1f}s")
-        return "\n".join(frames)
-    except MCPVideoError as e:
-        return json.dumps(_error_result(e), indent=2)
-
-
-@mcp.resource("mcp-video://video/{path}/audio")
-def video_audio_resource(path: str) -> str:
-    """Extract and describe the audio track of a video."""
-    try:
-        info = probe(path)
-        if info.audio_codec:
-            return (
-                f"Audio codec: {info.audio_codec}\n"
-                f"Sample rate: {info.audio_sample_rate} Hz\n"
-                f"Duration: {info.duration:.1f}s"
-            )
-        return "No audio track found."
-    except MCPVideoError as e:
-        return json.dumps(_error_result(e), indent=2)
-
-
-@mcp.resource("mcp-video://templates")
-def templates_resource() -> str:
-    """List available editing templates (aspect ratios, quality presets)."""
-    from .models import ASPECT_RATIOS, QUALITY_PRESETS
-    import json
-
-    data = {
-        "aspect_ratios": {k: f"{v[0]}x{v[1]}" for k, v in ASPECT_RATIOS.items()},
-        "quality_presets": {
-            k: f"CRF {v['crf']}, preset={v['preset']}, max_height={v['max_height']}" for k, v in QUALITY_PRESETS.items()
-        },
-        "transition_types": ["fade", "dissolve", "wipe-left", "wipe-right", "wipe-up", "wipe-down"],
-        "export_formats": ["mp4", "webm", "gif", "mov"],
-        "text_positions": [
-            "top-left",
-            "top-center",
-            "top-right",
-            "center-left",
-            "center",
-            "center-right",
-            "bottom-left",
-            "bottom-center",
-            "bottom-right",
-        ],
-    }
-    return json.dumps(data, indent=2)
-
 
 # ---------------------------------------------------------------------------
 # MCP Tools

--- a/mcp_video/server_resources.py
+++ b/mcp_video/server_resources.py
@@ -1,0 +1,79 @@
+"""MCP resource registrations for the mcp-video server."""
+
+from __future__ import annotations
+
+import json
+
+from .engine import probe
+from .errors import MCPVideoError
+from .server_app import _error_result, mcp
+
+
+@mcp.resource("mcp-video://video/{path}/info")
+def video_info_resource(path: str) -> str:
+    """Get metadata about a video file (duration, resolution, codec, etc.)."""
+    try:
+        info = probe(path)
+        return info.model_dump_json(indent=2)
+    except MCPVideoError as e:
+        return json.dumps(_error_result(e), indent=2)
+
+
+@mcp.resource("mcp-video://video/{path}/preview")
+def video_preview_resource(path: str) -> str:
+    """Get a text storyboard description (key frame timestamps)."""
+    try:
+        info = probe(path)
+        frames = []
+        dur = info.duration
+        count = 8
+        for i in range(count):
+            ts = dur * (i + 1) / (count + 1)
+            frames.append(f"Frame {i + 1}: {ts:.1f}s")
+        return "\n".join(frames)
+    except MCPVideoError as e:
+        return json.dumps(_error_result(e), indent=2)
+
+
+@mcp.resource("mcp-video://video/{path}/audio")
+def video_audio_resource(path: str) -> str:
+    """Extract and describe the audio track of a video."""
+    try:
+        info = probe(path)
+        if info.audio_codec:
+            return (
+                f"Audio codec: {info.audio_codec}\n"
+                f"Sample rate: {info.audio_sample_rate} Hz\n"
+                f"Duration: {info.duration:.1f}s"
+            )
+        return "No audio track found."
+    except MCPVideoError as e:
+        return json.dumps(_error_result(e), indent=2)
+
+
+@mcp.resource("mcp-video://templates")
+def templates_resource() -> str:
+    """List available editing templates (aspect ratios, quality presets)."""
+    from .models import ASPECT_RATIOS, QUALITY_PRESETS
+
+    data = {
+        "aspect_ratios": {k: f"{v[0]}x{v[1]}" for k, v in ASPECT_RATIOS.items()},
+        "quality_presets": {
+            k: f"CRF {v['crf']}, preset={v['preset']}, max_height={v['max_height']}"
+            for k, v in QUALITY_PRESETS.items()
+        },
+        "transition_types": ["fade", "dissolve", "wipe-left", "wipe-right", "wipe-up", "wipe-down"],
+        "export_formats": ["mp4", "webm", "gif", "mov"],
+        "text_positions": [
+            "top-left",
+            "top-center",
+            "top-right",
+            "center-left",
+            "center",
+            "center-right",
+            "bottom-left",
+            "bottom-center",
+            "bottom-right",
+        ],
+    }
+    return json.dumps(data, indent=2)

--- a/mcp_video/server_resources.py
+++ b/mcp_video/server_resources.py
@@ -59,8 +59,7 @@ def templates_resource() -> str:
     data = {
         "aspect_ratios": {k: f"{v[0]}x{v[1]}" for k, v in ASPECT_RATIOS.items()},
         "quality_presets": {
-            k: f"CRF {v['crf']}, preset={v['preset']}, max_height={v['max_height']}"
-            for k, v in QUALITY_PRESETS.items()
+            k: f"CRF {v['crf']}, preset={v['preset']}, max_height={v['max_height']}" for k, v in QUALITY_PRESETS.items()
         },
         "transition_types": ["fade", "dissolve", "wipe-left", "wipe-right", "wipe-up", "wipe-down"],
         "export_formats": ["mp4", "webm", "gif", "mov"],

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -282,6 +282,7 @@ class TestErrorHandling:
 
     def test_result_helper_with_model(self):
         from mcp_video.models import EditResult
+
         edit = EditResult(output_path="/tmp/out.mp4", operation="trim")
         result = _result(edit)
         assert result["success"] is True

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -6,6 +6,7 @@ import os
 import pytest
 
 from mcp_video.engine import _check_filter_available
+from mcp_video import server_resources
 from mcp_video.server import (
     _error_result,
     _result,
@@ -111,6 +112,20 @@ class TestServerInitialization:
         assert templates_resource is not None
         result = templates_resource()
         assert len(result) > 0
+
+    def test_resource_split_preserves_exports_without_duplicate_registration(self):
+        assert video_info_resource is server_resources.video_info_resource
+        assert video_preview_resource is server_resources.video_preview_resource
+        assert video_audio_resource is server_resources.video_audio_resource
+        assert templates_resource is server_resources.templates_resource
+
+        resource_manager = mcp._resource_manager
+        assert set(resource_manager._resources) == {"mcp-video://templates"}
+        assert set(resource_manager._templates) == {
+            "mcp-video://video/{path}/info",
+            "mcp-video://video/{path}/preview",
+            "mcp-video://video/{path}/audio",
+        }
 
 
 class TestVideoInfoTool:


### PR DESCRIPTION
## Summary
- Adds `mcp_video.server_resources` for MCP resource registrations.
- Moves `video_info_resource`, `video_preview_resource`, `video_audio_resource`, and `templates_resource` out of `server.py`.
- Keeps `mcp_video.server` re-export compatibility.
- Adds a focused test that resource exports point at the split module and resources are not duplicate-registered.

## Why
This is the next server decomposition step after extracting `server_app.py`. Resources are lower-risk than tool handlers and give the tool-registration split a safer foundation.

## Validation
- `python3 -m pytest tests/test_server.py::TestServerInitialization tests/test_server.py::TestTemplatesResource tests/test_public_surface.py -q --tb=short`
- `python3 -m ruff check mcp_video/server.py mcp_video/server_resources.py tests/test_server.py tests/test_public_surface.py`

## Not Tested
- Full non-slow suite after resource registration split.