### PR TITLE
Extract image MCP tools

### DIFF
--- a/mcp_video/server.py
+++ b/mcp_video/server.py
@@ -60,6 +60,11 @@ from .server_tools_advanced import (
     video_stabilize as video_stabilize,
     video_write_metadata as video_write_metadata,
 )
+from .server_tools_image import (
+    image_analyze_product as image_analyze_product,
+    image_extract_colors as image_extract_colors,
+    image_generate_palette as image_generate_palette,
+)
 from .limits import (
     MAX_CONCURRENCY,
     MAX_CRF,
@@ -93,82 +98,6 @@ from .validation import (
 # ---------------------------------------------------------------------------
 # Image Analysis Tools
 # ---------------------------------------------------------------------------
-
-
-@mcp.tool()
-def image_extract_colors(
-    image_path: str,
-    n_colors: int = 5,
-) -> dict[str, Any]:
-    """Extract dominant colors from an image.
-
-    Uses K-means clustering to find the most prominent colors. Returns hex codes,
-    RGB values, CSS color names, and percentage coverage.
-
-    Args:
-        image_path: Absolute path to the image file.
-        n_colors: Number of dominant colors to extract (1-20, default 5).
-    """
-    try:
-        from .image_engine import extract_colors
-
-        return _result(extract_colors(image_path, n_colors=n_colors))
-    except MCPVideoError as e:
-        return _error_result(e)
-    except Exception as e:
-        return _error_result(e)
-
-
-@mcp.tool()
-def image_generate_palette(
-    image_path: str,
-    harmony: str = "complementary",
-    n_colors: int = 5,
-) -> dict[str, Any]:
-    """Generate a color harmony palette from an image.
-
-    Extracts the dominant color and generates harmonious colors based on
-    color theory (complementary, analogous, triadic, split_complementary).
-
-    Args:
-        image_path: Absolute path to the image file.
-        harmony: Harmony type (complementary, analogous, triadic, split_complementary).
-        n_colors: Number of dominant colors to base palette on (default 5).
-    """
-    try:
-        from .image_engine import generate_palette
-
-        return _result(generate_palette(image_path, harmony=harmony, n_colors=n_colors))
-    except MCPVideoError as e:
-        return _error_result(e)
-    except Exception as e:
-        return _error_result(e)
-
-
-@mcp.tool()
-def image_analyze_product(
-    image_path: str,
-    use_ai: bool = False,
-    n_colors: int = 5,
-) -> dict[str, Any]:
-    """Analyze a product image — extract colors and optionally generate AI description.
-
-    Extracts dominant colors from an image. Optionally uses Claude Vision to
-    generate a natural language description of the product.
-
-    Args:
-        image_path: Absolute path to the image file.
-        use_ai: If True, use Claude Vision to generate a description (requires ANTHROPIC_API_KEY).
-        n_colors: Number of dominant colors to extract (default 5).
-    """
-    try:
-        from .image_engine import analyze_product
-
-        return _result(analyze_product(image_path, use_ai=use_ai, n_colors=n_colors))
-    except MCPVideoError as e:
-        return _error_result(e)
-    except Exception as e:
-        return _error_result(e)
 
 
 # ---------------------------------------------------------------------------

--- a/mcp_video/server_tools_image.py
+++ b/mcp_video/server_tools_image.py
@@ -1,0 +1,84 @@
+"""Image MCP tool registrations."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .errors import MCPVideoError
+from .server_app import _error_result, _result, mcp
+
+
+@mcp.tool()
+def image_extract_colors(
+    image_path: str,
+    n_colors: int = 5,
+) -> dict[str, Any]:
+    """Extract dominant colors from an image.
+
+    Uses K-means clustering to find the most prominent colors. Returns hex codes,
+    RGB values, CSS color names, and percentage coverage.
+
+    Args:
+        image_path: Absolute path to the image file.
+        n_colors: Number of dominant colors to extract (1-20, default 5).
+    """
+    try:
+        from .image_engine import extract_colors
+
+        return _result(extract_colors(image_path, n_colors=n_colors))
+    except MCPVideoError as e:
+        return _error_result(e)
+    except Exception as e:
+        return _error_result(e)
+
+
+@mcp.tool()
+def image_generate_palette(
+    image_path: str,
+    harmony: str = "complementary",
+    n_colors: int = 5,
+) -> dict[str, Any]:
+    """Generate a color harmony palette from an image.
+
+    Extracts the dominant color and generates harmonious colors based on
+    color theory (complementary, analogous, triadic, split_complementary).
+
+    Args:
+        image_path: Absolute path to the image file.
+        harmony: Harmony type (complementary, analogous, triadic, split_complementary).
+        n_colors: Number of dominant colors to base palette on (default 5).
+    """
+    try:
+        from .image_engine import generate_palette
+
+        return _result(generate_palette(image_path, harmony=harmony, n_colors=n_colors))
+    except MCPVideoError as e:
+        return _error_result(e)
+    except Exception as e:
+        return _error_result(e)
+
+
+@mcp.tool()
+def image_analyze_product(
+    image_path: str,
+    use_ai: bool = False,
+    n_colors: int = 5,
+) -> dict[str, Any]:
+    """Analyze a product image — extract colors and optionally generate AI description.
+
+    Extracts dominant colors from an image. Optionally uses Claude Vision to
+    generate a natural language description of the product.
+
+    Args:
+        image_path: Absolute path to the image file.
+        use_ai: If True, use Claude Vision to generate a description (requires ANTHROPIC_API_KEY).
+        n_colors: Number of dominant colors to extract (default 5).
+    """
+    try:
+        from .image_engine import analyze_product
+
+        return _result(analyze_product(image_path, use_ai=use_ai, n_colors=n_colors))
+    except MCPVideoError as e:
+        return _error_result(e)
+    except Exception as e:
+        return _error_result(e)


### PR DESCRIPTION
## Summary
- Adds `mcp_video.server_tools_image`.
- Moves `image_extract_colors`, `image_generate_palette`, and `image_analyze_product` out of `server.py`.
- Keeps `server.py` as the public façade and re-exports moved handlers.
- Preserves registration with the shared `mcp` app.

## Validation
- `python3 -m pytest tests/test_public_surface.py tests/test_server.py::TestServerInitialization -q --tb=short`
- `python3 -m ruff check mcp_video/server.py mcp_video/server_tools_image.py tests/test_public_surface.py`
- `python3 -m ruff format --check mcp_video/server.py mcp_video/server_tools_image.py`
- Async smoke: `mcp.list_tools()` returns 83 tools including moved names

## Not Tested
- Full non-slow suite after image tool extraction.