### PR TITLE
Move media CLI handlers into handlers module

### DIFF
--- a/mcp_video/__main__.py
+++ b/mcp_video/__main__.py
@@ -17,7 +17,6 @@ from .cli.formatting import (
     _format_edit_text,
     _format_error,
     _format_extract_audio_text,
-    _format_storyboard_text,
     _format_thumbnail_text,
     console,
     err_console,
@@ -56,76 +55,7 @@ def main() -> None:
         if handle_initial_command(args, use_json=use_json):
             return
 
-        if args.command == "resize":
-            from .engine import resize
-
-            result = _with_spinner(
-                "Resizing...",
-                resize,
-                args.input,
-                width=args.width,
-                height=args.height,
-                aspect_ratio=args.aspect_ratio,
-                quality=args.quality,
-                output_path=args.output,
-            )
-            if use_json:
-                output_json(result)
-            else:
-                _format_edit_text(result)
-
-        elif args.command == "speed":
-            from .engine import speed
-
-            result = _with_spinner("Changing speed...", speed, args.input, factor=args.factor, output_path=args.output)
-            if use_json:
-                output_json(result)
-            else:
-                _format_edit_text(result)
-
-        elif args.command == "convert":
-            from .engine import convert
-
-            result = _with_spinner(
-                "Converting...", convert, args.input, format=args.fmt, quality=args.quality, output_path=args.output
-            )
-            if use_json:
-                output_json(result)
-            else:
-                _format_edit_text(result)
-
-        elif args.command == "thumbnail":
-            from .engine import thumbnail
-
-            result = thumbnail(args.input, timestamp=args.timestamp, output_path=args.output)
-            if use_json:
-                output_json(result)
-            else:
-                _format_edit_text(result)
-
-        elif args.command == "preview":
-            from .engine import preview
-
-            result = _with_spinner(
-                "Generating preview...", preview, args.input, output_path=args.output, scale_factor=args.scale
-            )
-            if use_json:
-                output_json(result)
-            else:
-                _format_edit_text(result)
-
-        elif args.command == "storyboard":
-            from .engine import storyboard
-
-            result = _with_spinner(
-                "Extracting storyboard...", storyboard, args.input, output_dir=args.output_dir, frame_count=args.frames
-            )
-            if use_json:
-                output_json(result)
-            else:
-                _format_storyboard_text(result)
-
-        elif args.command == "subtitles":
+        if args.command == "subtitles":
             from .engine import subtitles
 
             result = _with_spinner(

--- a/mcp_video/cli/handlers_core.py
+++ b/mcp_video/cli/handlers_core.py
@@ -5,7 +5,13 @@ from __future__ import annotations
 from typing import Any
 
 from .common import _with_spinner, output_json
-from .formatting import _format_doctor_text, _format_edit_text, _format_info_text, _format_thumbnail_text
+from .formatting import (
+    _format_doctor_text,
+    _format_edit_text,
+    _format_info_text,
+    _format_storyboard_text,
+    _format_thumbnail_text,
+)
 
 
 def handle_initial_command(args: Any, *, use_json: bool) -> bool:
@@ -125,6 +131,81 @@ def handle_initial_command(args: Any, *, use_json: bool) -> bool:
             output_json(result)
         else:
             _format_edit_text(result)
+        return True
+
+    if args.command == "resize":
+        from ..engine import resize
+
+        result = _with_spinner(
+            "Resizing...",
+            resize,
+            args.input,
+            width=args.width,
+            height=args.height,
+            aspect_ratio=args.aspect_ratio,
+            quality=args.quality,
+            output_path=args.output,
+        )
+        if use_json:
+            output_json(result)
+        else:
+            _format_edit_text(result)
+        return True
+
+    if args.command == "speed":
+        from ..engine import speed
+
+        result = _with_spinner("Changing speed...", speed, args.input, factor=args.factor, output_path=args.output)
+        if use_json:
+            output_json(result)
+        else:
+            _format_edit_text(result)
+        return True
+
+    if args.command == "convert":
+        from ..engine import convert
+
+        result = _with_spinner(
+            "Converting...", convert, args.input, format=args.fmt, quality=args.quality, output_path=args.output
+        )
+        if use_json:
+            output_json(result)
+        else:
+            _format_edit_text(result)
+        return True
+
+    if args.command == "thumbnail":
+        from ..engine import thumbnail
+
+        result = thumbnail(args.input, timestamp=args.timestamp, output_path=args.output)
+        if use_json:
+            output_json(result)
+        else:
+            _format_edit_text(result)
+        return True
+
+    if args.command == "preview":
+        from ..engine import preview
+
+        result = _with_spinner(
+            "Generating preview...", preview, args.input, output_path=args.output, scale_factor=args.scale
+        )
+        if use_json:
+            output_json(result)
+        else:
+            _format_edit_text(result)
+        return True
+
+    if args.command == "storyboard":
+        from ..engine import storyboard
+
+        result = _with_spinner(
+            "Extracting storyboard...", storyboard, args.input, output_dir=args.output_dir, frame_count=args.frames
+        )
+        if use_json:
+            output_json(result)
+        else:
+            _format_storyboard_text(result)
         return True
 
     return False


### PR DESCRIPTION
## Summary
- Moves `resize`, `speed`, `convert`, `thumbnail`, `preview`, and `storyboard` CLI dispatch branches into `mcp_video.cli.handlers_core`.
- Leaves remaining command families in `mcp_video.__main__`.
- Preserves command names, flags, lazy imports, and JSON/text output behavior.

## Validation
- `python3 -m pytest tests/test_cli.py::TestCLIResize tests/test_cli.py::TestCLISpeed tests/test_cli.py::TestCLIConvert tests/test_cli.py::TestCLIThumbnail tests/test_cli.py::TestCLIPreview tests/test_cli.py::TestCLIStoryboard tests/test_public_surface.py -q --tb=short`
- `python3 -m pytest tests/test_cli.py tests/test_doctor.py tests/test_public_surface.py -q --tb=short`
- `python3 -m mcp_video --help`
- `python3 -m ruff check mcp_video/__main__.py mcp_video/cli tests/test_cli.py tests/test_public_surface.py`
- `python3 -m ruff format --check mcp_video/__main__.py mcp_video/cli`

## Not Tested
- Full non-slow suite after media CLI handler extraction.