### PR TITLE
Move edit and export CLI handlers into handlers module

### DIFF
--- a/mcp_video/__main__.py
+++ b/mcp_video/__main__.py
@@ -16,7 +16,6 @@ from .cli.formatting import (
     _format_batch_text,
     _format_edit_text,
     _format_error,
-    _format_extract_audio_text,
     _format_thumbnail_text,
     console,
     err_console,
@@ -55,126 +54,7 @@ def main() -> None:
         if handle_initial_command(args, use_json=use_json):
             return
 
-        if args.command == "subtitles":
-            from .engine import subtitles
-
-            result = _with_spinner(
-                "Burning subtitles...", subtitles, args.input, subtitle_path=args.subtitle, output_path=args.output
-            )
-            if use_json:
-                output_json(result)
-            else:
-                _format_edit_text(result)
-
-        elif args.command == "watermark":
-            from .engine import watermark
-
-            result = _with_spinner(
-                "Adding watermark...",
-                watermark,
-                args.input,
-                image_path=args.image,
-                position=args.position,
-                opacity=args.opacity,
-                margin=args.margin,
-                output_path=args.output,
-            )
-            if use_json:
-                output_json(result)
-            else:
-                _format_edit_text(result)
-
-        elif args.command == "crop":
-            from .engine import crop
-
-            result = _with_spinner(
-                "Cropping...",
-                crop,
-                args.input,
-                width=args.width,
-                height=args.height,
-                x=args.x,
-                y=args.y,
-                output_path=args.output,
-            )
-            if use_json:
-                output_json(result)
-            else:
-                _format_edit_text(result)
-
-        elif args.command == "rotate":
-            from .engine import rotate
-
-            result = _with_spinner(
-                "Rotating...",
-                rotate,
-                args.input,
-                angle=args.angle,
-                flip_horizontal=args.flip_h,
-                flip_vertical=args.flip_v,
-                output_path=args.output,
-            )
-            if use_json:
-                output_json(result)
-            else:
-                _format_edit_text(result)
-
-        elif args.command == "fade":
-            from .engine import fade
-
-            result = _with_spinner(
-                "Applying fade...",
-                fade,
-                args.input,
-                fade_in=args.fade_in,
-                fade_out=args.fade_out,
-                output_path=args.output,
-            )
-            if use_json:
-                output_json(result)
-            else:
-                _format_edit_text(result)
-
-        elif args.command == "export":
-            from .engine import export_video
-
-            result = _with_spinner(
-                "Exporting...", export_video, args.input, quality=args.quality, format=args.fmt, output_path=args.output
-            )
-            if use_json:
-                output_json(result)
-            else:
-                _format_edit_text(result)
-
-        elif args.command == "extract-audio":
-            from .engine import extract_audio
-
-            result = _with_spinner(
-                "Extracting audio...", extract_audio, args.input, output_path=args.output, format=args.audio_format
-            )
-            if use_json:
-                output_json({"success": True, "output_path": result})
-            else:
-                _format_extract_audio_text(result)
-
-        elif args.command == "edit":
-            from .models import Timeline
-
-            timeline_arg = args.timeline.strip()
-            if timeline_arg.startswith(("{", "[")):
-                tl = Timeline.model_validate(_parse_json_arg(timeline_arg, "timeline", json_mode=use_json))
-            else:
-                with open(timeline_arg) as f:
-                    tl = Timeline.model_validate(json.load(f))
-            from .engine import edit_timeline
-
-            result = _with_spinner("Editing timeline...", edit_timeline, tl, output_path=args.output)
-            if use_json:
-                output_json(result)
-            else:
-                _format_edit_text(result)
-
-        elif args.command == "filter":
+        if args.command == "filter":
             from .engine import apply_filter
 
             params = _parse_json_arg(args.params, "params", json_mode=use_json) if args.params else {}

--- a/mcp_video/__main__.py
+++ b/mcp_video/__main__.py
@@ -54,6 +54,7 @@ def main() -> None:
         if handle_initial_command(args, use_json=use_json):
             return
 
+        # Remaining command families are still handled here until their batches move.
         if args.command == "filter":
             from .engine import apply_filter
 

--- a/mcp_video/cli/handlers_core.py
+++ b/mcp_video/cli/handlers_core.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+import json
 from typing import Any
 
 from .common import _with_spinner, output_json
 from .formatting import (
     _format_doctor_text,
     _format_edit_text,
+    _format_extract_audio_text,
     _format_info_text,
     _format_storyboard_text,
     _format_thumbnail_text,
@@ -314,14 +316,10 @@ def handle_initial_command(args: Any, *, use_json: bool) -> bool:
         if use_json:
             output_json({"success": True, "output_path": result})
         else:
-            from .formatting import _format_extract_audio_text
-
             _format_extract_audio_text(result)
         return True
 
     if args.command == "edit":
-        import json
-
         from ..engine import edit_timeline
         from ..models import Timeline
         from .common import _parse_json_arg

--- a/mcp_video/cli/handlers_core.py
+++ b/mcp_video/cli/handlers_core.py
@@ -208,4 +208,136 @@ def handle_initial_command(args: Any, *, use_json: bool) -> bool:
             _format_storyboard_text(result)
         return True
 
+    if args.command == "subtitles":
+        from ..engine import subtitles
+
+        result = _with_spinner(
+            "Burning subtitles...", subtitles, args.input, subtitle_path=args.subtitle, output_path=args.output
+        )
+        if use_json:
+            output_json(result)
+        else:
+            _format_edit_text(result)
+        return True
+
+    if args.command == "watermark":
+        from ..engine import watermark
+
+        result = _with_spinner(
+            "Adding watermark...",
+            watermark,
+            args.input,
+            image_path=args.image,
+            position=args.position,
+            opacity=args.opacity,
+            margin=args.margin,
+            output_path=args.output,
+        )
+        if use_json:
+            output_json(result)
+        else:
+            _format_edit_text(result)
+        return True
+
+    if args.command == "crop":
+        from ..engine import crop
+
+        result = _with_spinner(
+            "Cropping...",
+            crop,
+            args.input,
+            width=args.width,
+            height=args.height,
+            x=args.x,
+            y=args.y,
+            output_path=args.output,
+        )
+        if use_json:
+            output_json(result)
+        else:
+            _format_edit_text(result)
+        return True
+
+    if args.command == "rotate":
+        from ..engine import rotate
+
+        result = _with_spinner(
+            "Rotating...",
+            rotate,
+            args.input,
+            angle=args.angle,
+            flip_horizontal=args.flip_h,
+            flip_vertical=args.flip_v,
+            output_path=args.output,
+        )
+        if use_json:
+            output_json(result)
+        else:
+            _format_edit_text(result)
+        return True
+
+    if args.command == "fade":
+        from ..engine import fade
+
+        result = _with_spinner(
+            "Applying fade...",
+            fade,
+            args.input,
+            fade_in=args.fade_in,
+            fade_out=args.fade_out,
+            output_path=args.output,
+        )
+        if use_json:
+            output_json(result)
+        else:
+            _format_edit_text(result)
+        return True
+
+    if args.command == "export":
+        from ..engine import export_video
+
+        result = _with_spinner(
+            "Exporting...", export_video, args.input, quality=args.quality, format=args.fmt, output_path=args.output
+        )
+        if use_json:
+            output_json(result)
+        else:
+            _format_edit_text(result)
+        return True
+
+    if args.command == "extract-audio":
+        from ..engine import extract_audio
+
+        result = _with_spinner(
+            "Extracting audio...", extract_audio, args.input, output_path=args.output, format=args.audio_format
+        )
+        if use_json:
+            output_json({"success": True, "output_path": result})
+        else:
+            from .formatting import _format_extract_audio_text
+
+            _format_extract_audio_text(result)
+        return True
+
+    if args.command == "edit":
+        import json
+
+        from ..engine import edit_timeline
+        from ..models import Timeline
+        from .common import _parse_json_arg
+
+        timeline_arg = args.timeline.strip()
+        if timeline_arg.startswith(("{", "[")):
+            tl = Timeline.model_validate(_parse_json_arg(timeline_arg, "timeline", json_mode=use_json))
+        else:
+            with open(timeline_arg) as f:
+                tl = Timeline.model_validate(json.load(f))
+
+        result = _with_spinner("Editing timeline...", edit_timeline, tl, output_path=args.output)
+        if use_json:
+            output_json(result)
+        else:
+            _format_edit_text(result)
+        return True
+
     return False


### PR DESCRIPTION
## Summary
- Moves `subtitles`, `watermark`, `crop`, `rotate`, `fade`, `export`, `extract-audio`, and `edit` dispatch branches into `mcp_video.cli.handlers_core`.
- Leaves remaining command families in `mcp_video.__main__`.
- Preserves command names, flags, lazy imports, and JSON/text output behavior.

## Validation
- `python3 -m pytest tests/test_cli.py::TestCLISubtitles tests/test_cli.py::TestCLIWatermark tests/test_cli.py::TestCLICrop tests/test_cli.py::TestCLIRotate tests/test_cli.py::TestCLIFade tests/test_cli.py::TestCLIExport tests/test_cli.py::TestCLIExtractAudio tests/test_cli.py::TestCLIEdit tests/test_public_surface.py -q --tb=short`
- `python3 -m pytest tests/test_cli.py tests/test_doctor.py tests/test_public_surface.py -q --tb=short`
- `python3 -m mcp_video --help`
- `python3 -m ruff check mcp_video/__main__.py mcp_video/cli tests/test_cli.py tests/test_public_surface.py`
- `python3 -m ruff format --check mcp_video/__main__.py mcp_video/cli`

## Not Tested
- Full non-slow suite after edit/export CLI handler extraction.