### PR TITLE
Skip real-media suite when local render fixture is absent

### DIFF
--- a/tests/test_real_all_features.py
+++ b/tests/test_real_all_features.py
@@ -31,6 +31,7 @@ skip_no_video = pytest.mark.skipif(
     not os.path.exists(TEST_VIDEOS['explainer']),
     reason="Test video not found"
 )
+pytestmark = [skip_no_video]
 
 
 def has_ai_upscale_backend() -> bool:


### PR DESCRIPTION
## Summary
- apply the existing missing-video skip marker to the full real-media feature suite
- make local full-suite verification skip absent heavyweight renders instead of failing on out/McpVideoExplainer-FINAL.mp4
- keep the real-media assertions unchanged when the fixture exists

## Verification
- ruff check tests/test_real_all_features.py
- python3 -m pytest tests/test_real_all_features.py -q --tb=short
- python3 -m pytest tests/test_real_exhaustive.py -q --tb=short
- python3 -m pytest tests/ -x -q --tb=short
