### PR TITLE
Ignore build virtualenv directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ dist/
 build/
 *.egg
 .venv/
+.venv-build/
 venv/
 .env
 .pytest_cache/


### PR DESCRIPTION
## Summary
- ignore local .venv-build directories
- prevent accidental dependency environment bloat from entering future commits

## Verification
- printf '.venv-build/\\n' | git check-ignore -v --stdin
- python3 -m pytest tests/test_public_surface.py -q --tb=short
