### PR TITLE
Extract transition CLI handlers

### DIFF
--- a/mcp_video/__main__.py
+++ b/mcp_video/__main__.py
@@ -11,6 +11,7 @@ from rich.table import Table
 
 from .cli.common import _auto_output, _parse_json_arg, _with_spinner, output_json
 from .cli.handlers_core import handle_initial_command
+from .cli.handlers_transitions import handle_transition_command
 from .cli.parser import build_parser
 from .cli.formatting import (
     _format_batch_text,
@@ -52,6 +53,8 @@ def main() -> None:
     # CLI commands
     try:
         if handle_initial_command(args, use_json=use_json):
+            return
+        if handle_transition_command(args, use_json=use_json):
             return
 
         # Remaining command families are still handled here until their batches move.
@@ -759,67 +762,6 @@ def main() -> None:
                         border_style="green",
                         title="Done",
                     )
-                )
-
-        # ------------------------------------------------------------------
-        # Transition commands
-        # ------------------------------------------------------------------
-
-        elif args.command == "transition-glitch":
-            from .transitions_engine import transition_glitch
-
-            result = _with_spinner(
-                "Applying glitch transition...",
-                transition_glitch,
-                args.clip1,
-                args.clip2,
-                args.output,
-                duration=args.duration,
-                intensity=args.intensity,
-            )
-            if use_json:
-                output_json({"success": True, "output_path": result})
-            else:
-                console.print(
-                    Panel(f"[bold green]Glitch transition:[/bold green] {result}", border_style="green", title="Done")
-                )
-
-        elif args.command == "transition-morph":
-            from .transitions_engine import transition_morph
-
-            result = _with_spinner(
-                "Applying morph transition...",
-                transition_morph,
-                args.clip1,
-                args.clip2,
-                args.output,
-                duration=args.duration,
-                mesh_size=args.mesh_size,
-            )
-            if use_json:
-                output_json({"success": True, "output_path": result})
-            else:
-                console.print(
-                    Panel(f"[bold green]Morph transition:[/bold green] {result}", border_style="green", title="Done")
-                )
-
-        elif args.command == "transition-pixelate":
-            from .transitions_engine import transition_pixelate
-
-            result = _with_spinner(
-                "Applying pixelate transition...",
-                transition_pixelate,
-                args.clip1,
-                args.clip2,
-                args.output,
-                duration=args.duration,
-                pixel_size=args.pixel_size,
-            )
-            if use_json:
-                output_json({"success": True, "output_path": result})
-            else:
-                console.print(
-                    Panel(f"[bold green]Pixelate transition:[/bold green] {result}", border_style="green", title="Done")
                 )
 
         # ------------------------------------------------------------------

--- a/mcp_video/cli/handlers_transitions.py
+++ b/mcp_video/cli/handlers_transitions.py
@@ -1,0 +1,67 @@
+"""CLI handlers for transition commands."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from rich.panel import Panel
+
+from .common import _with_spinner, output_json
+from .formatting import console
+
+
+def _print_transition_result(label: str, result: str, *, use_json: bool) -> None:
+    if use_json:
+        output_json({"success": True, "output_path": result})
+    else:
+        console.print(Panel(f"[bold green]{label}:[/bold green] {result}", border_style="green", title="Done"))
+
+
+def handle_transition_command(args: Any, *, use_json: bool) -> bool:
+    """Handle transition commands extracted from the main dispatcher."""
+    if args.command == "transition-glitch":
+        from ..transitions_engine import transition_glitch
+
+        result = _with_spinner(
+            "Applying glitch transition...",
+            transition_glitch,
+            args.clip1,
+            args.clip2,
+            args.output,
+            duration=args.duration,
+            intensity=args.intensity,
+        )
+        _print_transition_result("Glitch transition", result, use_json=use_json)
+        return True
+
+    if args.command == "transition-morph":
+        from ..transitions_engine import transition_morph
+
+        result = _with_spinner(
+            "Applying morph transition...",
+            transition_morph,
+            args.clip1,
+            args.clip2,
+            args.output,
+            duration=args.duration,
+            mesh_size=args.mesh_size,
+        )
+        _print_transition_result("Morph transition", result, use_json=use_json)
+        return True
+
+    if args.command == "transition-pixelate":
+        from ..transitions_engine import transition_pixelate
+
+        result = _with_spinner(
+            "Applying pixelate transition...",
+            transition_pixelate,
+            args.clip1,
+            args.clip2,
+            args.output,
+            duration=args.duration,
+            pixel_size=args.pixel_size,
+        )
+        _print_transition_result("Pixelate transition", result, use_json=use_json)
+        return True
+
+    return False

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,6 +3,7 @@
 import json
 import subprocess
 import sys
+from types import SimpleNamespace
 
 import pytest
 
@@ -507,3 +508,42 @@ class TestCLIFade:
     def test_fade_outputs_text(self, sample_video):
         result = run_cli("fade", sample_video, "--fade-in", "0.5", "--fade-out", "0.5")
         assert "Done" in result.stdout
+
+
+class TestCLITransitions:
+    def test_transition_glitch_outputs_json(self, sample_video, tmp_path):
+        output = tmp_path / "glitch.mp4"
+        result = run_cli_json("transition-glitch", sample_video, sample_video, "-o", str(output), "-d", "0.2")
+        data = json.loads(result.stdout)
+        assert data["success"] is True
+        assert data["output_path"] == str(output)
+        assert output.exists()
+
+    def test_transition_morph_outputs_text(self, sample_video, tmp_path):
+        output = tmp_path / "morph.mp4"
+        result = run_cli("transition-morph", sample_video, sample_video, "-o", str(output), "-d", "0.2")
+        assert "Morph transition" in result.stdout
+        assert output.name in result.stdout
+        assert output.exists()
+
+    def test_transition_pixelate_handler_outputs_json(self, sample_video, tmp_path, monkeypatch, capsys):
+        output = tmp_path / "pixelate.mp4"
+        from mcp_video.cli import handlers_transitions
+
+        output.write_bytes(b"fake video")
+        monkeypatch.setattr(handlers_transitions, "_with_spinner", lambda *args, **kwargs: str(output))
+
+        args = SimpleNamespace(
+            command="transition-pixelate",
+            clip1=sample_video,
+            clip2=sample_video,
+            output=str(output),
+            duration=0.2,
+            pixel_size=50,
+        )
+        handled = handlers_transitions.handle_transition_command(args, use_json=True)
+        data = json.loads(capsys.readouterr().out)
+        assert handled is True
+        assert data["success"] is True
+        assert data["output_path"] == str(output)
+        assert output.exists()


### PR DESCRIPTION
## Summary
- move transition CLI dispatch into mcp_video/cli/handlers_transitions.py
- keep parser arguments, lazy imports, JSON output, and text labels unchanged
- add CLI subprocess coverage for glitch, morph, and pixelate transition commands

## Verification
- ruff check mcp_video/__main__.py mcp_video/cli/handlers_transitions.py tests/test_cli.py
- python3 -m pytest tests/test_cli.py -k 'transition' -q --tb=short
- python3 -m pytest tests/test_cli.py -q --tb=short
