### PR TITLE
Extract visual effect CLI handlers

### DIFF
--- a/mcp_video/__main__.py
+++ b/mcp_video/__main__.py
@@ -9,8 +9,9 @@ from typing import Any
 from rich.panel import Panel
 from rich.table import Table
 
-from .cli.common import _auto_output, _parse_json_arg, _with_spinner, output_json
+from .cli.common import _parse_json_arg, _with_spinner, output_json
 from .cli.handlers_core import handle_initial_command
+from .cli.handlers_effects import handle_effect_command
 from .cli.handlers_transitions import handle_transition_command
 from .cli.parser import build_parser
 from .cli.formatting import (
@@ -53,6 +54,8 @@ def main() -> None:
     # CLI commands
     try:
         if handle_initial_command(args, use_json=use_json):
+            return
+        if handle_effect_command(args, use_json=use_json):
             return
         if handle_transition_command(args, use_json=use_json):
             return
@@ -656,113 +659,6 @@ def main() -> None:
                 if data.get("operations"):
                     lines.append(f"[bold green]Post-process ops:[/bold green] {', '.join(data['operations'])}")
                 console.print(Panel("\n".join(lines), border_style="green", title="Remotion Pipeline"))
-
-        # ------------------------------------------------------------------
-        # Effect commands
-        # ------------------------------------------------------------------
-
-        elif args.command == "effect-vignette":
-            from .effects_engine import effect_vignette
-
-            out = args.output or _auto_output(args.input, "vignette")
-            result = _with_spinner(
-                "Applying vignette...",
-                effect_vignette,
-                args.input,
-                out,
-                intensity=args.intensity,
-                radius=args.radius,
-                smoothness=args.smoothness,
-            )
-            if use_json:
-                output_json({"success": True, "output_path": result})
-            else:
-                console.print(
-                    Panel(f"[bold green]Vignette applied:[/bold green] {result}", border_style="green", title="Done")
-                )
-
-        elif args.command == "effect-glow":
-            from .effects_engine import effect_glow
-
-            out = args.output or _auto_output(args.input, "glow")
-            result = _with_spinner(
-                "Applying glow...",
-                effect_glow,
-                args.input,
-                out,
-                intensity=args.intensity,
-                radius=args.radius,
-                threshold=args.threshold,
-            )
-            if use_json:
-                output_json({"success": True, "output_path": result})
-            else:
-                console.print(
-                    Panel(f"[bold green]Glow applied:[/bold green] {result}", border_style="green", title="Done")
-                )
-
-        elif args.command == "effect-noise":
-            from .effects_engine import effect_noise
-
-            out = args.output or _auto_output(args.input, "noise")
-            result = _with_spinner(
-                "Applying noise...",
-                effect_noise,
-                args.input,
-                out,
-                intensity=args.intensity,
-                mode=args.mode,
-                animated=not args.static,
-            )
-            if use_json:
-                output_json({"success": True, "output_path": result})
-            else:
-                console.print(
-                    Panel(f"[bold green]Noise applied:[/bold green] {result}", border_style="green", title="Done")
-                )
-
-        elif args.command == "effect-scanlines":
-            from .effects_engine import effect_scanlines
-
-            out = args.output or _auto_output(args.input, "scanlines")
-            result = _with_spinner(
-                "Applying scanlines...",
-                effect_scanlines,
-                args.input,
-                out,
-                line_height=args.line_height,
-                opacity=args.opacity,
-                flicker=args.flicker,
-            )
-            if use_json:
-                output_json({"success": True, "output_path": result})
-            else:
-                console.print(
-                    Panel(f"[bold green]Scanlines applied:[/bold green] {result}", border_style="green", title="Done")
-                )
-
-        elif args.command == "effect-chromatic-aberration":
-            from .effects_engine import effect_chromatic_aberration
-
-            out = args.output or _auto_output(args.input, "chromatic")
-            result = _with_spinner(
-                "Applying chromatic aberration...",
-                effect_chromatic_aberration,
-                args.input,
-                out,
-                intensity=args.intensity,
-                angle=args.angle,
-            )
-            if use_json:
-                output_json({"success": True, "output_path": result})
-            else:
-                console.print(
-                    Panel(
-                        f"[bold green]Chromatic aberration applied:[/bold green] {result}",
-                        border_style="green",
-                        title="Done",
-                    )
-                )
 
         # ------------------------------------------------------------------
         # AI commands

--- a/mcp_video/cli/handlers_effects.py
+++ b/mcp_video/cli/handlers_effects.py
@@ -1,0 +1,101 @@
+"""CLI handlers for visual effect commands."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from rich.panel import Panel
+
+from .common import _auto_output, _with_spinner, output_json
+from .formatting import console
+
+
+def _print_effect_result(label: str, result: str, *, use_json: bool) -> None:
+    if use_json:
+        output_json({"success": True, "output_path": result})
+    else:
+        console.print(Panel(f"[bold green]{label} applied:[/bold green] {result}", border_style="green", title="Done"))
+
+
+def handle_effect_command(args: Any, *, use_json: bool) -> bool:
+    """Handle visual effect commands extracted from the main dispatcher."""
+    if args.command == "effect-vignette":
+        from ..effects_engine import effect_vignette
+
+        out = args.output or _auto_output(args.input, "vignette")
+        result = _with_spinner(
+            "Applying vignette...",
+            effect_vignette,
+            args.input,
+            out,
+            intensity=args.intensity,
+            radius=args.radius,
+            smoothness=args.smoothness,
+        )
+        _print_effect_result("Vignette", result, use_json=use_json)
+        return True
+
+    if args.command == "effect-glow":
+        from ..effects_engine import effect_glow
+
+        out = args.output or _auto_output(args.input, "glow")
+        result = _with_spinner(
+            "Applying glow...",
+            effect_glow,
+            args.input,
+            out,
+            intensity=args.intensity,
+            radius=args.radius,
+            threshold=args.threshold,
+        )
+        _print_effect_result("Glow", result, use_json=use_json)
+        return True
+
+    if args.command == "effect-noise":
+        from ..effects_engine import effect_noise
+
+        out = args.output or _auto_output(args.input, "noise")
+        result = _with_spinner(
+            "Applying noise...",
+            effect_noise,
+            args.input,
+            out,
+            intensity=args.intensity,
+            mode=args.mode,
+            animated=not args.static,
+        )
+        _print_effect_result("Noise", result, use_json=use_json)
+        return True
+
+    if args.command == "effect-scanlines":
+        from ..effects_engine import effect_scanlines
+
+        out = args.output or _auto_output(args.input, "scanlines")
+        result = _with_spinner(
+            "Applying scanlines...",
+            effect_scanlines,
+            args.input,
+            out,
+            line_height=args.line_height,
+            opacity=args.opacity,
+            flicker=args.flicker,
+        )
+        _print_effect_result("Scanlines", result, use_json=use_json)
+        return True
+
+    if args.command == "effect-chromatic-aberration":
+        from ..effects_engine import effect_chromatic_aberration
+
+        out = args.output or _auto_output(args.input, "chromatic")
+        result = _with_spinner(
+            "Applying chromatic aberration...",
+            effect_chromatic_aberration,
+            args.input,
+            out,
+            intensity=args.intensity,
+            angle=args.angle,
+        )
+        _print_effect_result("Chromatic aberration", result, use_json=use_json)
+        return True
+
+    return False

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -510,6 +510,56 @@ class TestCLIFade:
         assert "Done" in result.stdout
 
 
+class TestCLIVisualEffects:
+    @pytest.mark.parametrize(
+        ("command", "output_name", "label", "extra_args"),
+        [
+            ("effect-vignette", "vignette.mp4", "Vignette", {"intensity": 0.5, "radius": 0.8, "smoothness": 0.5}),
+            ("effect-glow", "glow.mp4", "Glow", {"intensity": 0.5, "radius": 10, "threshold": 0.7}),
+            ("effect-noise", "noise.mp4", "Noise", {"intensity": 0.05, "mode": "film", "static": False}),
+            ("effect-scanlines", "scanlines.mp4", "Scanlines", {"line_height": 2, "opacity": 0.3, "flicker": 0.1}),
+            ("effect-chromatic-aberration", "chromatic.mp4", "Chromatic aberration", {"intensity": 2.0, "angle": 0}),
+        ],
+    )
+    def test_effect_handler_outputs_json(
+        self, command, output_name, label, extra_args, sample_video, tmp_path, monkeypatch, capsys
+    ):
+        output = tmp_path / output_name
+        from mcp_video.cli import handlers_effects
+
+        output.write_bytes(b"fake video")
+        monkeypatch.setattr(handlers_effects, "_with_spinner", lambda *args, **kwargs: str(output))
+        args = SimpleNamespace(command=command, input=sample_video, output=str(output), **extra_args)
+
+        handled = handlers_effects.handle_effect_command(args, use_json=True)
+        data = json.loads(capsys.readouterr().out)
+
+        assert handled is True
+        assert data["success"] is True
+        assert data["output_path"] == str(output)
+
+    def test_effect_handler_outputs_text(self, sample_video, tmp_path, monkeypatch, capsys):
+        output = tmp_path / "vignette.mp4"
+        from mcp_video.cli import handlers_effects
+
+        monkeypatch.setattr(handlers_effects, "_with_spinner", lambda *args, **kwargs: str(output))
+        args = SimpleNamespace(
+            command="effect-vignette",
+            input=sample_video,
+            output=str(output),
+            intensity=0.5,
+            radius=0.8,
+            smoothness=0.5,
+        )
+
+        handled = handlers_effects.handle_effect_command(args, use_json=False)
+        stdout = capsys.readouterr().out
+
+        assert handled is True
+        assert "Vignette applied" in stdout
+        assert output.name in stdout
+
+
 class TestCLITransitions:
     def test_transition_glitch_outputs_json(self, sample_video, tmp_path):
         output = tmp_path / "glitch.mp4"


### PR DESCRIPTION
## Summary
- move visual effect CLI dispatch into mcp_video/cli/handlers_effects.py
- preserve lazy imports, auto-output suffixes, JSON shape, and text labels
- add fast handler-level coverage for all five visual effect commands

## Verification
- ruff check mcp_video/__main__.py mcp_video/cli/handlers_effects.py tests/test_cli.py
- python3 -m pytest tests/test_cli.py -k 'effect' -q --tb=short
- python3 -m pytest tests/test_cli.py -q --tb=short
