### PR TITLE
Extract composition CLI handlers

### DIFF
--- a/mcp_video/__main__.py
+++ b/mcp_video/__main__.py
@@ -10,6 +10,7 @@ from rich.panel import Panel
 from rich.table import Table
 
 from .cli.common import _parse_json_arg, _with_spinner, output_json
+from .cli.handlers_composition import handle_composition_command
 from .cli.handlers_core import handle_initial_command
 from .cli.handlers_effects import handle_effect_command
 from .cli.handlers_transitions import handle_transition_command
@@ -58,6 +59,8 @@ def main() -> None:
         if handle_effect_command(args, use_json=use_json):
             return
         if handle_transition_command(args, use_json=use_json):
+            return
+        if handle_composition_command(args, use_json=use_json):
             return
 
         # Remaining command families are still handled here until their batches move.
@@ -991,141 +994,6 @@ def main() -> None:
                 console.print(
                     Panel(
                         f"[bold green]Audio effects applied:[/bold green] {result}", border_style="green", title="Done"
-                    )
-                )
-
-        # ------------------------------------------------------------------
-        # Motion graphics commands
-        # ------------------------------------------------------------------
-
-        elif args.command == "video-text-animated":
-            from .effects_engine import text_animated
-
-            result = _with_spinner(
-                "Adding animated text...",
-                text_animated,
-                args.input,
-                args.text,
-                args.output,
-                animation=args.animation,
-                font=args.font,
-                size=args.size,
-                color=args.color,
-                position=args.position,
-                start=args.start,
-                duration=args.duration,
-            )
-            if use_json:
-                output_json({"success": True, "output_path": result})
-            else:
-                console.print(
-                    Panel(
-                        f"[bold green]Animated text ({args.animation}):[/bold green] {result}",
-                        border_style="green",
-                        title="Done",
-                    )
-                )
-
-        elif args.command == "video-mograph-count":
-            from .effects_engine import mograph_count
-
-            style = _parse_json_arg(args.style, "style", json_mode=use_json) if args.style else None
-            result = _with_spinner(
-                "Generating counter...",
-                mograph_count,
-                args.start,
-                args.end,
-                args.duration,
-                args.output,
-                style=style,
-                fps=args.fps,
-            )
-            if use_json:
-                output_json({"success": True, "output_path": result})
-            else:
-                console.print(
-                    Panel(
-                        f"[bold green]Counter ({args.start}-{args.end}):[/bold green] {result}",
-                        border_style="green",
-                        title="Done",
-                    )
-                )
-
-        elif args.command == "video-mograph-progress":
-            from .effects_engine import mograph_progress
-
-            result = _with_spinner(
-                "Generating progress animation...",
-                mograph_progress,
-                args.duration,
-                args.output,
-                style=args.style,
-                color=args.color,
-                track_color=args.track_color,
-                fps=args.fps,
-            )
-            if use_json:
-                output_json({"success": True, "output_path": result})
-            else:
-                console.print(
-                    Panel(
-                        f"[bold green]Progress bar ({args.style}):[/bold green] {result}",
-                        border_style="green",
-                        title="Done",
-                    )
-                )
-
-        # ------------------------------------------------------------------
-        # Layout commands
-        # ------------------------------------------------------------------
-
-        elif args.command == "video-layout-grid":
-            from .effects_engine import layout_grid
-
-            result = _with_spinner(
-                "Creating grid layout...",
-                layout_grid,
-                args.inputs,
-                args.layout,
-                args.output,
-                gap=args.gap,
-                padding=args.padding,
-                background=args.background,
-            )
-            if use_json:
-                output_json({"success": True, "output_path": result})
-            else:
-                console.print(
-                    Panel(
-                        f"[bold green]Grid layout ({args.layout}):[/bold green] {result}",
-                        border_style="green",
-                        title="Done",
-                    )
-                )
-
-        elif args.command == "video-layout-pip":
-            from .effects_engine import layout_pip
-
-            result = _with_spinner(
-                "Creating PIP layout...",
-                layout_pip,
-                args.main,
-                args.pip,
-                args.output,
-                position=args.position,
-                size=args.size,
-                margin=args.margin,
-                border=args.border,
-                border_color=args.border_color,
-                border_width=args.border_width,
-                rounded_corners=args.rounded_corners,
-            )
-            if use_json:
-                output_json({"success": True, "output_path": result})
-            else:
-                console.print(
-                    Panel(
-                        f"[bold green]PIP ({args.position}):[/bold green] {result}", border_style="green", title="Done"
                     )
                 )
 

--- a/mcp_video/cli/handlers_composition.py
+++ b/mcp_video/cli/handlers_composition.py
@@ -1,0 +1,111 @@
+"""CLI handlers for motion graphics and layout commands."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from rich.panel import Panel
+
+from .common import _parse_json_arg, _with_spinner, output_json
+from .formatting import console
+
+
+def _print_output(label: str, result: str, *, use_json: bool) -> None:
+    if use_json:
+        output_json({"success": True, "output_path": result})
+    else:
+        console.print(Panel(f"[bold green]{label}:[/bold green] {result}", border_style="green", title="Done"))
+
+
+def handle_composition_command(args: Any, *, use_json: bool) -> bool:
+    """Handle motion graphics and layout commands extracted from main."""
+    if args.command == "video-text-animated":
+        from ..effects_engine import text_animated
+
+        result = _with_spinner(
+            "Adding animated text...",
+            text_animated,
+            args.input,
+            args.text,
+            args.output,
+            animation=args.animation,
+            font=args.font,
+            size=args.size,
+            color=args.color,
+            position=args.position,
+            start=args.start,
+            duration=args.duration,
+        )
+        _print_output(f"Animated text ({args.animation})", result, use_json=use_json)
+        return True
+
+    if args.command == "video-mograph-count":
+        from ..effects_engine import mograph_count
+
+        style = _parse_json_arg(args.style, "style", json_mode=use_json) if args.style else None
+        result = _with_spinner(
+            "Generating counter...",
+            mograph_count,
+            args.start,
+            args.end,
+            args.duration,
+            args.output,
+            style=style,
+            fps=args.fps,
+        )
+        _print_output(f"Counter ({args.start}-{args.end})", result, use_json=use_json)
+        return True
+
+    if args.command == "video-mograph-progress":
+        from ..effects_engine import mograph_progress
+
+        result = _with_spinner(
+            "Generating progress animation...",
+            mograph_progress,
+            args.duration,
+            args.output,
+            style=args.style,
+            color=args.color,
+            track_color=args.track_color,
+            fps=args.fps,
+        )
+        _print_output(f"Progress bar ({args.style})", result, use_json=use_json)
+        return True
+
+    if args.command == "video-layout-grid":
+        from ..effects_engine import layout_grid
+
+        result = _with_spinner(
+            "Creating grid layout...",
+            layout_grid,
+            args.inputs,
+            args.layout,
+            args.output,
+            gap=args.gap,
+            padding=args.padding,
+            background=args.background,
+        )
+        _print_output(f"Grid layout ({args.layout})", result, use_json=use_json)
+        return True
+
+    if args.command == "video-layout-pip":
+        from ..effects_engine import layout_pip
+
+        result = _with_spinner(
+            "Creating PIP layout...",
+            layout_pip,
+            args.main,
+            args.pip,
+            args.output,
+            position=args.position,
+            size=args.size,
+            margin=args.margin,
+            border=args.border,
+            border_color=args.border_color,
+            border_width=args.border_width,
+            rounded_corners=args.rounded_corners,
+        )
+        _print_output(f"PIP ({args.position})", result, use_json=use_json)
+        return True
+
+    return False

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -569,6 +569,99 @@ class TestCLITransitions:
         assert data["output_path"] == str(output)
         assert output.exists()
 
+
+class TestCLICompositionHandlers:
+    @pytest.mark.parametrize(
+        ("command", "output_name", "label", "extra_args"),
+        [
+            (
+                "video-text-animated",
+                "text.mp4",
+                "Animated text",
+                {
+                    "input": "in.mp4",
+                    "text": "Hello",
+                    "animation": "fade",
+                    "font": "Arial",
+                    "size": 48,
+                    "color": "white",
+                    "position": "center",
+                    "start": 0,
+                    "duration": 3.0,
+                },
+            ),
+            (
+                "video-mograph-count",
+                "count.mp4",
+                "Counter",
+                {"start": 1, "end": 10, "duration": 2.0, "style": '{"font": "Arial"}', "fps": 30},
+            ),
+            (
+                "video-mograph-progress",
+                "progress.mp4",
+                "Progress bar",
+                {"duration": 2.0, "style": "bar", "color": "#CCFF00", "track_color": "#333333", "fps": 30},
+            ),
+            (
+                "video-layout-grid",
+                "grid.mp4",
+                "Grid layout",
+                {"inputs": ["a.mp4", "b.mp4"], "layout": "2x2", "gap": 10, "padding": 20, "background": "#141414"},
+            ),
+            (
+                "video-layout-pip",
+                "pip.mp4",
+                "PIP",
+                {
+                    "main": "main.mp4",
+                    "pip": "pip.mp4",
+                    "position": "bottom-right",
+                    "size": 0.25,
+                    "margin": 20,
+                    "border": True,
+                    "border_color": "#CCFF00",
+                    "border_width": 2,
+                    "rounded_corners": True,
+                },
+            ),
+        ],
+    )
+    def test_composition_handler_outputs_json(self, command, output_name, label, extra_args, tmp_path, monkeypatch, capsys):
+        output = tmp_path / output_name
+        from mcp_video.cli import handlers_composition
+
+        monkeypatch.setattr(handlers_composition, "_with_spinner", lambda *args, **kwargs: str(output))
+        args = SimpleNamespace(command=command, output=str(output), **extra_args)
+
+        handled = handlers_composition.handle_composition_command(args, use_json=True)
+        data = json.loads(capsys.readouterr().out)
+
+        assert handled is True
+        assert data["success"] is True
+        assert data["output_path"] == str(output)
+
+    def test_composition_handler_outputs_text(self, tmp_path, monkeypatch, capsys):
+        output = tmp_path / "progress.mp4"
+        from mcp_video.cli import handlers_composition
+
+        monkeypatch.setattr(handlers_composition, "_with_spinner", lambda *args, **kwargs: str(output))
+        args = SimpleNamespace(
+            command="video-mograph-progress",
+            output=str(output),
+            duration=2.0,
+            style="bar",
+            color="#CCFF00",
+            track_color="#333333",
+            fps=30,
+        )
+
+        handled = handlers_composition.handle_composition_command(args, use_json=False)
+        stdout = capsys.readouterr().out
+
+        assert handled is True
+        assert "Progress bar" in stdout
+        assert output.name in stdout
+
     def test_transition_morph_outputs_text(self, sample_video, tmp_path):
         output = tmp_path / "morph.mp4"
         result = run_cli("transition-morph", sample_video, sample_video, "-o", str(output), "-d", "0.2")


### PR DESCRIPTION
## Summary
- move text, mograph, and layout CLI dispatch into mcp_video/cli/handlers_composition.py
- preserve parser arguments, lazy imports, JSON output shape, labels, and mograph-count style JSON parsing
- add fast handler-level coverage for all moved commands

## Verification
- ruff check mcp_video/__main__.py mcp_video/cli/handlers_composition.py tests/test_cli.py
- /opt/homebrew/bin/python3 -m pytest tests/test_cli.py -k 'composition' -q --tb=short
- /opt/homebrew/bin/python3 -m pytest tests/test_cli.py -q --tb=short
