### PR TITLE
Extract engine text overlay operation

### DIFF
--- a/mcp_video/engine.py
+++ b/mcp_video/engine.py
@@ -46,6 +46,7 @@ from .engine_transcode import normalize as normalize
 from .engine_edit import trim as trim
 from .engine_merge import _merge_with_transitions as _merge_with_transitions
 from .engine_merge import merge as merge
+from .engine_text import add_text as add_text
 from .engine_runtime_utils import (
     _auto_output as _auto_output,
     _auto_output_dir as _auto_output_dir,
@@ -76,95 +77,6 @@ from .engine_runtime_utils import (
 # ---------------------------------------------------------------------------
 # Core operations
 # ---------------------------------------------------------------------------
-
-
-def add_text(
-    input_path: str,
-    text: str,
-    position: Position = "top-center",
-    font: str | None = None,
-    size: int = 48,
-    color: str = "white",
-    shadow: bool = True,
-    start_time: float | None = None,
-    duration: float | None = None,
-    output_path: str | None = None,
-    crf: int | None = None,
-    preset: str | None = None,
-) -> EditResult:
-    """Overlay text on a video."""
-    _validate_input(input_path)
-    _require_filter("drawtext", "Text overlay")
-    _validate_color(color)
-    output = output_path or _auto_output(input_path, "titled")
-
-    coords = _position_coords(position)
-    fontfile = font or _default_font()
-
-    # Validate font file exists when explicitly provided
-    if font is not None and not os.path.isfile(fontfile):
-        raise FileNotFoundError(f"Font file not found: {fontfile}")
-
-    # Escape font path for FFmpeg filter syntax
-    escaped_fontfile = _escape_ffmpeg_filter_value(fontfile)
-
-    # Escape FFmpeg drawtext special characters
-    # Colons and backslashes must be escaped even inside single quotes
-    # because FFmpeg parses filter options as key=value pairs with : delimiters
-    escaped_text = (
-        text.replace("\\", "\\\\")
-        .replace("'", "'\\''")
-        .replace(":", "\\:")
-        .replace("[", "\\[")
-        .replace("]", "\\]")
-        .replace(";", "\\;")
-    )
-
-    filter_parts = [
-        f"drawtext=text='{escaped_text}'",
-        f"fontsize={size}",
-        f"fontcolor={color}",
-        f"fontfile={escaped_fontfile}",
-        coords,
-    ]
-
-    if shadow:
-        filter_parts.append("shadowcolor=black@0.5")
-        filter_parts.append("shadowx=2")
-        filter_parts.append("shadowy=2")
-
-    if start_time is not None and duration is not None:
-        filter_parts.append(f"enable='between(t\\,{start_time}\\,{start_time + duration})'")
-    elif start_time is not None:
-        filter_parts.append(f"enable='gte(t\\,{start_time})'")
-
-    vf = ":".join(filter_parts)
-
-    _run_ffmpeg(
-        [
-            "-i",
-            input_path,
-            "-vf",
-            vf,
-            "-c:v",
-            "libx264",
-            *_quality_args(crf=crf, preset=preset),
-            "-c:a",
-            "copy",
-            *_movflags_args(output),
-            output,
-        ]
-    )
-
-    info = probe(output)
-    return EditResult(
-        output_path=output,
-        duration=info.duration,
-        resolution=info.resolution,
-        size_mb=info.size_mb,
-        format="mp4",
-        operation="add_text",
-    )
 
 
 def add_audio(

--- a/mcp_video/engine_text.py
+++ b/mcp_video/engine_text.py
@@ -1,0 +1,109 @@
+"""Text overlay operations for the FFmpeg engine."""
+
+from __future__ import annotations
+
+import os
+
+from .engine_probe import probe
+from .engine_runtime_utils import (
+    _auto_output,
+    _default_font,
+    _movflags_args,
+    _position_coords,
+    _quality_args,
+    _require_filter,
+    _run_ffmpeg,
+    _validate_color,
+    _validate_input,
+)
+from .ffmpeg_helpers import _escape_ffmpeg_filter_value
+from .models import EditResult, Position
+
+
+def add_text(
+    input_path: str,
+    text: str,
+    position: Position = "top-center",
+    font: str | None = None,
+    size: int = 48,
+    color: str = "white",
+    shadow: bool = True,
+    start_time: float | None = None,
+    duration: float | None = None,
+    output_path: str | None = None,
+    crf: int | None = None,
+    preset: str | None = None,
+) -> EditResult:
+    """Overlay text on a video."""
+    _validate_input(input_path)
+    _require_filter("drawtext", "Text overlay")
+    _validate_color(color)
+    output = output_path or _auto_output(input_path, "titled")
+
+    coords = _position_coords(position)
+    fontfile = font or _default_font()
+
+    # Validate font file exists when explicitly provided
+    if font is not None and not os.path.isfile(fontfile):
+        raise FileNotFoundError(f"Font file not found: {fontfile}")
+
+    # Escape font path for FFmpeg filter syntax
+    escaped_fontfile = _escape_ffmpeg_filter_value(fontfile)
+
+    # Escape FFmpeg drawtext special characters
+    # Colons and backslashes must be escaped even inside single quotes
+    # because FFmpeg parses filter options as key=value pairs with : delimiters
+    escaped_text = (
+        text.replace("\\", "\\\\")
+        .replace("'", "'\\''")
+        .replace(":", "\\:")
+        .replace("[", "\\[")
+        .replace("]", "\\]")
+        .replace(";", "\\;")
+    )
+
+    filter_parts = [
+        f"drawtext=text='{escaped_text}'",
+        f"fontsize={size}",
+        f"fontcolor={color}",
+        f"fontfile={escaped_fontfile}",
+        coords,
+    ]
+
+    if shadow:
+        filter_parts.append("shadowcolor=black@0.5")
+        filter_parts.append("shadowx=2")
+        filter_parts.append("shadowy=2")
+
+    if start_time is not None and duration is not None:
+        filter_parts.append(f"enable='between(t\\,{start_time}\\,{start_time + duration})'")
+    elif start_time is not None:
+        filter_parts.append(f"enable='gte(t\\,{start_time})'")
+
+    vf = ":".join(filter_parts)
+
+    _run_ffmpeg(
+        [
+            "-i",
+            input_path,
+            "-vf",
+            vf,
+            "-c:v",
+            "libx264",
+            *_quality_args(crf=crf, preset=preset),
+            "-c:a",
+            "copy",
+            *_movflags_args(output),
+            output,
+        ]
+    )
+
+    info = probe(output)
+    return EditResult(
+        output_path=output,
+        duration=info.duration,
+        resolution=info.resolution,
+        size_mb=info.size_mb,
+        format="mp4",
+        operation="add_text",
+    )


### PR DESCRIPTION
## Summary
- move add_text into mcp_video/engine_text.py
- keep mcp_video.engine as the compatibility facade by re-exporting add_text
- preserve drawtext escaping, validation, output probing, and EditResult behavior

## Verification
- ruff check --fix mcp_video/engine.py mcp_video/engine_text.py
- /opt/homebrew/bin/python3 add_text re-export smoke
- /opt/homebrew/bin/python3 -m pytest tests/test_engine.py -k 'add_text or text' tests/test_server.py -k 'add_text' tests/test_e2e.py -q --tb=short
- /opt/homebrew/bin/python3 -m pytest tests/test_engine.py tests/test_e2e.py tests/test_server.py -q --tb=short
