### PR TITLE
Extract engine resize operation

### DIFF
--- a/mcp_video/engine.py
+++ b/mcp_video/engine.py
@@ -17,7 +17,6 @@ from .errors import (
     parse_ffmpeg_error,
 )
 from .models import (
-    ASPECT_RATIOS,
     PREVIEW_PRESETS,
     QUALITY_PRESETS,
     ColorPreset,
@@ -48,6 +47,7 @@ from .engine_merge import _merge_with_transitions as _merge_with_transitions
 from .engine_merge import merge as merge
 from .engine_text import add_text as add_text
 from .engine_audio_ops import add_audio as add_audio
+from .engine_resize import resize as resize
 from .engine_runtime_utils import (
     _auto_output as _auto_output,
     _auto_output_dir as _auto_output_dir,
@@ -78,82 +78,6 @@ from .engine_runtime_utils import (
 # ---------------------------------------------------------------------------
 # Core operations
 # ---------------------------------------------------------------------------
-
-
-def resize(
-    input_path: str,
-    width: int | None = None,
-    height: int | None = None,
-    aspect_ratio: str | None = None,
-    quality: QualityLevel = "high",
-    output_path: str | None = None,
-) -> EditResult:
-    """Resize a video. Use aspect_ratio for preset sizes (e.g. '9:16')."""
-    _validate_input(input_path)
-
-    info = probe(input_path)
-    if info.width == 0 or info.height == 0:
-        raise MCPVideoError(
-            "Cannot resize: video has zero dimensions",
-            error_type="processing_error",
-            code="invalid_input",
-        )
-
-    if aspect_ratio and aspect_ratio in ASPECT_RATIOS:
-        w, h = ASPECT_RATIOS[aspect_ratio]
-    elif aspect_ratio:
-        raise MCPVideoError(
-            f"Unknown aspect ratio: {aspect_ratio}. Available: {', '.join(ASPECT_RATIOS.keys())}",
-            error_type="input_error",
-            code="invalid_aspect_ratio",
-        )
-    elif width and height:
-        w, h = width, height
-    elif width:
-        ratio = info.height / info.width
-        w, h = width, int(width * ratio)
-    elif height:
-        ratio = info.width / info.height
-        w, h = int(height * ratio), height
-    else:
-        raise MCPVideoError("resize requires width+height, aspect_ratio, or single dimension")
-
-    preset = QUALITY_PRESETS[quality]
-    output = output_path or _auto_output(input_path, f"{w}x{h}")
-
-    # Scale to fit within target, then pad to exact dimensions
-    vf = f"scale={w}:{h}:force_original_aspect_ratio=decrease,pad={w}:{h}:(ow-iw)/2:(oh-ih)/2:black"
-
-    _run_ffmpeg(
-        [
-            "-i",
-            input_path,
-            "-vf",
-            vf,
-            "-c:v",
-            "libx264",
-            "-crf",
-            str(preset["crf"]),
-            "-preset",
-            preset["preset"],
-            "-c:a",
-            "aac",
-            "-b:a",
-            "128k",
-            *_movflags_args(output),
-            output,
-        ]
-    )
-
-    info = probe(output)
-    return EditResult(
-        output_path=output,
-        duration=info.duration,
-        resolution=info.resolution,
-        size_mb=info.size_mb,
-        format="mp4",
-        operation="resize",
-    )
 
 
 def convert(

--- a/mcp_video/engine_resize.py
+++ b/mcp_video/engine_resize.py
@@ -1,0 +1,84 @@
+"""Resize operations for the FFmpeg engine."""
+
+from __future__ import annotations
+
+from .engine_probe import probe
+from .engine_runtime_utils import _auto_output, _movflags_args, _run_ffmpeg, _validate_input
+from .errors import MCPVideoError
+from .models import ASPECT_RATIOS, QUALITY_PRESETS, EditResult, QualityLevel
+
+
+def resize(
+    input_path: str,
+    width: int | None = None,
+    height: int | None = None,
+    aspect_ratio: str | None = None,
+    quality: QualityLevel = "high",
+    output_path: str | None = None,
+) -> EditResult:
+    """Resize a video. Use aspect_ratio for preset sizes (e.g. '9:16')."""
+    _validate_input(input_path)
+
+    info = probe(input_path)
+    if info.width == 0 or info.height == 0:
+        raise MCPVideoError(
+            "Cannot resize: video has zero dimensions",
+            error_type="processing_error",
+            code="invalid_input",
+        )
+
+    if aspect_ratio and aspect_ratio in ASPECT_RATIOS:
+        w, h = ASPECT_RATIOS[aspect_ratio]
+    elif aspect_ratio:
+        raise MCPVideoError(
+            f"Unknown aspect ratio: {aspect_ratio}. Available: {', '.join(ASPECT_RATIOS.keys())}",
+            error_type="input_error",
+            code="invalid_aspect_ratio",
+        )
+    elif width and height:
+        w, h = width, height
+    elif width:
+        ratio = info.height / info.width
+        w, h = width, int(width * ratio)
+    elif height:
+        ratio = info.width / info.height
+        w, h = int(height * ratio), height
+    else:
+        raise MCPVideoError("resize requires width+height, aspect_ratio, or single dimension")
+
+    preset = QUALITY_PRESETS[quality]
+    output = output_path or _auto_output(input_path, f"{w}x{h}")
+
+    # Scale to fit within target, then pad to exact dimensions
+    vf = f"scale={w}:{h}:force_original_aspect_ratio=decrease,pad={w}:{h}:(ow-iw)/2:(oh-ih)/2:black"
+
+    _run_ffmpeg(
+        [
+            "-i",
+            input_path,
+            "-vf",
+            vf,
+            "-c:v",
+            "libx264",
+            "-crf",
+            str(preset["crf"]),
+            "-preset",
+            preset["preset"],
+            "-c:a",
+            "aac",
+            "-b:a",
+            "128k",
+            *_movflags_args(output),
+            output,
+        ]
+    )
+
+    info = probe(output)
+    return EditResult(
+        output_path=output,
+        duration=info.duration,
+        resolution=info.resolution,
+        size_mb=info.size_mb,
+        format="mp4",
+        operation="resize",
+    )


### PR DESCRIPTION
## Summary
- move resize into mcp_video/engine_resize.py
- keep mcp_video.engine as the compatibility facade by re-exporting resize
- preserve aspect-ratio handling, quality presets, output probing, and EditResult behavior

## Verification
- ruff check --fix mcp_video/engine.py mcp_video/engine_resize.py
- /opt/homebrew/bin/python3 resize re-export smoke
- /opt/homebrew/bin/python3 -m pytest tests/test_engine.py -k 'resize' tests/test_server.py -k 'resize' tests/test_e2e.py -q --tb=short
- /opt/homebrew/bin/python3 -m pytest tests/test_engine.py tests/test_e2e.py tests/test_server.py -q --tb=short
