### PR TITLE
Extract engine thumbnail operation

### DIFF
--- a/mcp_video/engine.py
+++ b/mcp_video/engine.py
@@ -33,7 +33,6 @@ from .models import (
     SplitLayout,
     StoryboardResult,
     SubtitleResult,
-    ThumbnailResult,
     Timeline,
     TimelineImageOverlay,
     WaveformResult,
@@ -49,6 +48,7 @@ from .engine_text import add_text as add_text
 from .engine_audio_ops import add_audio as add_audio
 from .engine_resize import resize as resize
 from .engine_speed import speed as speed
+from .engine_thumbnail import thumbnail as thumbnail
 from .engine_runtime_utils import (
     _auto_output as _auto_output,
     _auto_output_dir as _auto_output_dir,
@@ -281,46 +281,6 @@ def convert(
         operation="convert",
         progress=100.0,
         thumbnail_base64=thumb_b64,
-    )
-
-
-def thumbnail(
-    input_path: str,
-    timestamp: float | None = None,
-    output_path: str | None = None,
-) -> ThumbnailResult:
-    """Extract a single frame from a video."""
-    _validate_input(input_path)
-
-    if timestamp is None:
-        # Grab frame at 10% of video duration
-        dur = get_duration(input_path)
-        timestamp = dur * 0.1
-    else:
-        # Clamp to valid range
-        dur = get_duration(input_path)
-        timestamp = min(timestamp, dur * 0.99)
-
-    output = output_path or _auto_output(input_path, f"frame_{timestamp:.1f}s", ext=".jpg")
-
-    _run_ffmpeg(
-        [
-            "-ss",
-            str(timestamp),
-            "-i",
-            input_path,
-            "-vframes",
-            "1",
-            "-q:v",
-            "2",
-            "-y",
-            output,
-        ]
-    )
-
-    return ThumbnailResult(
-        frame_path=output,
-        timestamp=timestamp,
     )
 
 

--- a/mcp_video/engine_thumbnail.py
+++ b/mcp_video/engine_thumbnail.py
@@ -1,0 +1,47 @@
+"""Thumbnail/frame extraction operations for the FFmpeg engine."""
+
+from __future__ import annotations
+
+from .engine_probe import get_duration
+from .engine_runtime_utils import _auto_output, _run_ffmpeg, _validate_input
+from .models import ThumbnailResult
+
+
+def thumbnail(
+    input_path: str,
+    timestamp: float | None = None,
+    output_path: str | None = None,
+) -> ThumbnailResult:
+    """Extract a single frame from a video."""
+    _validate_input(input_path)
+
+    if timestamp is None:
+        # Grab frame at 10% of video duration
+        dur = get_duration(input_path)
+        timestamp = dur * 0.1
+    else:
+        # Clamp to valid range
+        dur = get_duration(input_path)
+        timestamp = min(timestamp, dur * 0.99)
+
+    output = output_path or _auto_output(input_path, f"frame_{timestamp:.1f}s", ext=".jpg")
+
+    _run_ffmpeg(
+        [
+            "-ss",
+            str(timestamp),
+            "-i",
+            input_path,
+            "-vframes",
+            "1",
+            "-q:v",
+            "2",
+            "-y",
+            output,
+        ]
+    )
+
+    return ThumbnailResult(
+        frame_path=output,
+        timestamp=timestamp,
+    )


### PR DESCRIPTION
## Summary
- move thumbnail into mcp_video/engine_thumbnail.py
- keep mcp_video.engine as the compatibility facade by re-exporting thumbnail
- preserve timestamp clamping, output-path generation, FFmpeg invocation, and ThumbnailResult behavior

## Verification
- ruff check --fix mcp_video/engine.py mcp_video/engine_thumbnail.py
- /opt/homebrew/bin/python3 thumbnail re-export smoke
- /opt/homebrew/bin/python3 -m pytest tests/test_engine.py -k 'thumbnail' tests/test_server.py -k 'thumbnail' tests/test_cli.py -k 'thumbnail' tests/test_e2e.py -k 'thumbnail' -q --tb=short
- /opt/homebrew/bin/python3 -m pytest tests/test_engine.py tests/test_e2e.py tests/test_server.py -q --tb=short
