### PR TITLE
Extract engine preview operation

### DIFF
--- a/mcp_video/engine.py
+++ b/mcp_video/engine.py
@@ -17,7 +17,6 @@ from .errors import (
     parse_ffmpeg_error,
 )
 from .models import (
-    PREVIEW_PRESETS,
     QUALITY_PRESETS,
     ColorPreset,
     EditResult,
@@ -49,6 +48,7 @@ from .engine_audio_ops import add_audio as add_audio
 from .engine_resize import resize as resize
 from .engine_speed import speed as speed
 from .engine_thumbnail import thumbnail as thumbnail
+from .engine_preview import preview as preview
 from .engine_runtime_utils import (
     _auto_output as _auto_output,
     _auto_output_dir as _auto_output_dir,
@@ -281,56 +281,6 @@ def convert(
         operation="convert",
         progress=100.0,
         thumbnail_base64=thumb_b64,
-    )
-
-
-def preview(
-    input_path: str,
-    output_path: str | None = None,
-    scale_factor: int = 4,
-) -> EditResult:
-    """Generate a fast low-resolution preview for quick review."""
-    _validate_input(input_path)
-    if scale_factor < 1:
-        raise MCPVideoError("scale_factor must be at least 1", code="invalid_scale_factor")
-    info = probe(input_path)
-
-    w = max(info.width // scale_factor, 320)
-    h = max(info.height // scale_factor, 240)
-
-    output = output_path or _auto_output(input_path, "preview")
-
-    _run_ffmpeg(
-        [
-            "-i",
-            input_path,
-            "-vf",
-            f"scale={w}:{h}",
-            "-c:v",
-            "libx264",
-            "-crf",
-            str(PREVIEW_PRESETS["crf"]),
-            "-preset",
-            PREVIEW_PRESETS["preset"],
-            "-c:a",
-            "aac",
-            "-b:a",
-            "64k",
-            "-ac",
-            "2",
-            *_movflags_args(output),
-            output,
-        ]
-    )
-
-    result_info = probe(output)
-    return EditResult(
-        output_path=output,
-        duration=result_info.duration,
-        resolution=result_info.resolution,
-        size_mb=result_info.size_mb,
-        format="mp4",
-        operation="preview",
     )
 
 

--- a/mcp_video/engine_preview.py
+++ b/mcp_video/engine_preview.py
@@ -1,0 +1,58 @@
+"""Preview generation operation for the FFmpeg engine."""
+
+from __future__ import annotations
+
+from .engine_probe import probe
+from .engine_runtime_utils import _auto_output, _movflags_args, _run_ffmpeg, _validate_input
+from .errors import MCPVideoError
+from .models import PREVIEW_PRESETS, EditResult
+
+
+def preview(
+    input_path: str,
+    output_path: str | None = None,
+    scale_factor: int = 4,
+) -> EditResult:
+    """Generate a fast low-resolution preview for quick review."""
+    _validate_input(input_path)
+    if scale_factor < 1:
+        raise MCPVideoError("scale_factor must be at least 1", code="invalid_scale_factor")
+    info = probe(input_path)
+
+    w = max(info.width // scale_factor, 320)
+    h = max(info.height // scale_factor, 240)
+
+    output = output_path or _auto_output(input_path, "preview")
+
+    _run_ffmpeg(
+        [
+            "-i",
+            input_path,
+            "-vf",
+            f"scale={w}:{h}",
+            "-c:v",
+            "libx264",
+            "-crf",
+            str(PREVIEW_PRESETS["crf"]),
+            "-preset",
+            PREVIEW_PRESETS["preset"],
+            "-c:a",
+            "aac",
+            "-b:a",
+            "64k",
+            "-ac",
+            "2",
+            *_movflags_args(output),
+            output,
+        ]
+    )
+
+    result_info = probe(output)
+    return EditResult(
+        output_path=output,
+        duration=result_info.duration,
+        resolution=result_info.resolution,
+        size_mb=result_info.size_mb,
+        format="mp4",
+        operation="preview",
+    )


### PR DESCRIPTION
## Summary
- move preview into mcp_video/engine_preview.py
- keep mcp_video.engine as the compatibility facade by re-exporting preview
- preserve scale validation, preview presets, output probing, and EditResult behavior

## Verification
- ruff check --fix mcp_video/engine.py mcp_video/engine_preview.py
- /opt/homebrew/bin/python3 preview re-export smoke
- /opt/homebrew/bin/python3 -m pytest tests/test_engine.py -k 'preview' tests/test_server.py -k 'preview' tests/test_cli.py -k 'preview' tests/test_e2e.py -k 'preview' -q --tb=short
- /opt/homebrew/bin/python3 -m pytest tests/test_engine.py tests/test_e2e.py tests/test_server.py -q --tb=short
