### PR TITLE
Extract engine subtitle burn-in operation

### DIFF
--- a/mcp_video/engine.py
+++ b/mcp_video/engine.py
@@ -72,6 +72,7 @@ from .engine_runtime_utils import (
 )
 from .engine_speed import speed as speed
 from .engine_storyboard import storyboard as storyboard
+from .engine_subtitles import subtitles as subtitles
 from .engine_text import add_text as add_text
 from .engine_thumbnail import thumbnail as thumbnail
 from .engine_transcode import normalize as normalize
@@ -282,52 +283,6 @@ def convert(
         operation="convert",
         progress=100.0,
         thumbnail_base64=thumb_b64,
-    )
-
-
-def subtitles(
-    input_path: str,
-    subtitle_path: str,
-    output_path: str | None = None,
-    style: str = "FontSize=22,PrimaryColour=&Hffffff&,OutlineColour=&H000000&,Outline=2,Shadow=1",
-) -> EditResult:
-    """Burn subtitles (SRT/VTT) into a video."""
-    _validate_input(input_path)
-    _validate_input(subtitle_path)
-    _require_filter("subtitles", "Subtitle burn-in")
-    output = output_path or _auto_output(input_path, "subtitled")
-
-    # Escape special characters for FFmpeg subtitle filter path
-    escaped_sub_path = _escape_ffmpeg_filter_value(subtitle_path)
-    escaped_style = _escape_ffmpeg_filter_value(style)
-
-    _run_ffmpeg(
-        [
-            "-i",
-            input_path,
-            "-vf",
-            f"subtitles={escaped_sub_path}:force_style={escaped_style}",
-            "-c:v",
-            "libx264",
-            "-preset",
-            "fast",
-            "-crf",
-            "23",
-            "-c:a",
-            "copy",
-            *_movflags_args(output),
-            output,
-        ]
-    )
-
-    info = probe(output)
-    return EditResult(
-        output_path=output,
-        duration=info.duration,
-        resolution=info.resolution,
-        size_mb=info.size_mb,
-        format="mp4",
-        operation="subtitles",
     )
 
 

--- a/mcp_video/engine_subtitles.py
+++ b/mcp_video/engine_subtitles.py
@@ -1,0 +1,54 @@
+"""Subtitle burn-in operation for the FFmpeg engine."""
+
+from __future__ import annotations
+
+from .engine_probe import probe
+from .engine_runtime_utils import _auto_output, _movflags_args, _require_filter, _run_ffmpeg, _validate_input
+from .ffmpeg_helpers import _escape_ffmpeg_filter_value
+from .models import EditResult
+
+
+def subtitles(
+    input_path: str,
+    subtitle_path: str,
+    output_path: str | None = None,
+    style: str = "FontSize=22,PrimaryColour=&Hffffff&,OutlineColour=&H000000&,Outline=2,Shadow=1",
+) -> EditResult:
+    """Burn subtitles (SRT/VTT) into a video."""
+    _validate_input(input_path)
+    _validate_input(subtitle_path)
+    _require_filter("subtitles", "Subtitle burn-in")
+    output = output_path or _auto_output(input_path, "subtitled")
+
+    # Escape special characters for FFmpeg subtitle filter path
+    escaped_sub_path = _escape_ffmpeg_filter_value(subtitle_path)
+    escaped_style = _escape_ffmpeg_filter_value(style)
+
+    _run_ffmpeg(
+        [
+            "-i",
+            input_path,
+            "-vf",
+            f"subtitles={escaped_sub_path}:force_style={escaped_style}",
+            "-c:v",
+            "libx264",
+            "-preset",
+            "fast",
+            "-crf",
+            "23",
+            "-c:a",
+            "copy",
+            *_movflags_args(output),
+            output,
+        ]
+    )
+
+    info = probe(output)
+    return EditResult(
+        output_path=output,
+        duration=info.duration,
+        resolution=info.resolution,
+        size_mb=info.size_mb,
+        format="mp4",
+        operation="subtitles",
+    )


### PR DESCRIPTION
## Summary
- move subtitles into mcp_video/engine_subtitles.py
- keep mcp_video.engine as the compatibility facade by re-exporting subtitles
- preserve subtitle/style escaping, subtitles filter requirement, output probing, and EditResult behavior

## Verification
- ruff check --fix mcp_video/engine.py mcp_video/engine_subtitles.py
- /opt/homebrew/bin/python3 subtitles re-export smoke
- /opt/homebrew/bin/python3 -m pytest tests/test_engine.py -k 'subtitles' tests/test_server.py -k 'subtitles' tests/test_cli.py -k 'subtitles' -q --tb=short
- /opt/homebrew/bin/python3 -m pytest tests/test_engine.py tests/test_e2e.py tests/test_server.py -q --tb=short
