### PR TITLE
Extract engine crop operation

### DIFF
--- a/mcp_video/engine.py
+++ b/mcp_video/engine.py
@@ -77,6 +77,7 @@ from .engine_text import add_text as add_text
 from .engine_thumbnail import thumbnail as thumbnail
 from .engine_transcode import normalize as normalize
 from .engine_watermark import watermark as watermark
+from .engine_crop import crop as crop
 
 
 # ---------------------------------------------------------------------------
@@ -284,63 +285,6 @@ def convert(
         operation="convert",
         progress=100.0,
         thumbnail_base64=thumb_b64,
-    )
-
-
-def crop(
-    input_path: str,
-    width: int,
-    height: int,
-    x: int | None = None,
-    y: int | None = None,
-    output_path: str | None = None,
-) -> EditResult:
-    """Crop a video to a rectangular region."""
-    _validate_input(input_path)
-    if width <= 0 or height <= 0:
-        raise MCPVideoError("Crop dimensions must be positive", code="invalid_crop")
-
-    info = probe(input_path)
-    if width > info.width or height > info.height:
-        raise MCPVideoError(
-            f"Crop size ({width}x{height}) larger than video ({info.width}x{info.height})",
-            code="crop_too_large",
-        )
-
-    if x is None:
-        x = (info.width - width) // 2
-    if y is None:
-        y = (info.height - height) // 2
-
-    output = output_path or _auto_output(input_path, f"crop_{width}x{height}")
-
-    _run_ffmpeg(
-        [
-            "-i",
-            input_path,
-            "-vf",
-            f"crop={width}:{height}:{x}:{y}",
-            "-c:v",
-            "libx264",
-            "-preset",
-            "fast",
-            "-crf",
-            "23",
-            "-c:a",
-            "copy",
-            *_movflags_args(output),
-            output,
-        ]
-    )
-
-    result_info = probe(output)
-    return EditResult(
-        output_path=output,
-        duration=result_info.duration,
-        resolution=result_info.resolution,
-        size_mb=result_info.size_mb,
-        format="mp4",
-        operation="crop",
     )
 
 

--- a/mcp_video/engine_crop.py
+++ b/mcp_video/engine_crop.py
@@ -1,0 +1,64 @@
+"""Crop operation for the FFmpeg engine."""
+
+from __future__ import annotations
+
+from .engine_probe import probe
+from .engine_runtime_utils import _auto_output, _movflags_args, _quality_args, _run_ffmpeg, _validate_input
+from .errors import MCPVideoError
+from .ffmpeg_helpers import _escape_ffmpeg_filter_value
+from .models import EditResult
+
+
+def crop(
+    input_path: str,
+    width: int,
+    height: int,
+    x: int | None = None,
+    y: int | None = None,
+    output_path: str | None = None,
+) -> EditResult:
+    """Crop a video to a rectangular region."""
+    _validate_input(input_path)
+    if width <= 0 or height <= 0:
+        raise MCPVideoError("Crop dimensions must be positive", code="invalid_crop")
+
+    info = probe(input_path)
+    if width > info.width or height > info.height:
+        raise MCPVideoError(
+            f"Crop size ({width}x{height}) larger than video ({info.width}x{info.height})",
+            code="crop_too_large",
+        )
+
+    if x is None:
+        x = (info.width - width) // 2
+    if y is None:
+        y = (info.height - height) // 2
+
+    output = output_path or _auto_output(input_path, f"crop_{width}x{height}")
+    crop_filter = f"crop={_escape_ffmpeg_filter_value(str(width))}:{_escape_ffmpeg_filter_value(str(height))}:{_escape_ffmpeg_filter_value(str(x))}:{_escape_ffmpeg_filter_value(str(y))}"
+
+    _run_ffmpeg(
+        [
+            "-i",
+            input_path,
+            "-vf",
+            crop_filter,
+            "-c:v",
+            "libx264",
+            *_quality_args(),
+            "-c:a",
+            "copy",
+            *_movflags_args(output),
+            output,
+        ]
+    )
+
+    result_info = probe(output)
+    return EditResult(
+        output_path=output,
+        duration=result_info.duration,
+        resolution=result_info.resolution,
+        size_mb=result_info.size_mb,
+        format="mp4",
+        operation="crop",
+    )


### PR DESCRIPTION
## Summary
- move crop into mcp_video/engine_crop.py
- keep mcp_video.engine as the compatibility facade by re-exporting crop
- preserve crop validation, centered defaults, FFmpeg crop filter, and EditResult output behavior

## Verification
- ruff check --fix mcp_video/engine.py mcp_video/engine_crop.py
- /opt/homebrew/bin/python3 crop re-export smoke
- /opt/homebrew/bin/python3 -m pytest tests/test_cli.py -k 'crop' tests/test_server.py -k 'crop' -q --tb=short
- /opt/homebrew/bin/python3 -m pytest tests/test_engine.py tests/test_e2e.py tests/test_server.py -q --tb=short
