### PR TITLE
Extract engine fade operation

### DIFF
--- a/mcp_video/engine.py
+++ b/mcp_video/engine.py
@@ -47,6 +47,7 @@ from .engine_probe import get_duration as get_duration
 from .engine_probe import probe as probe
 from .engine_resize import resize as resize
 from .engine_rotate import rotate as rotate
+from .engine_fade import fade as fade
 from .engine_runtime_utils import (
     _auto_output as _auto_output,
     _auto_output_dir as _auto_output_dir,
@@ -286,58 +287,6 @@ def convert(
         operation="convert",
         progress=100.0,
         thumbnail_base64=thumb_b64,
-    )
-
-
-def fade(
-    input_path: str,
-    fade_in: float = 0.0,
-    fade_out: float = 0.0,
-    output_path: str | None = None,
-    crf: int | None = None,
-    preset: str | None = None,
-) -> EditResult:
-    """Add fade in/out effect to a video."""
-    _validate_input(input_path)
-    if fade_in <= 0 and fade_out <= 0:
-        raise MCPVideoError("Specify fade_in and/or fade_out > 0", code="no_fade")
-
-    output = output_path or _auto_output(input_path, "faded")
-    info = probe(input_path)
-
-    vf_parts: list[str] = []
-    if fade_in > 0:
-        vf_parts.append(f"fade=t=in:st=0:d={fade_in}")
-    if fade_out > 0:
-        fade_start = max(0, info.duration - fade_out)
-        vf_parts.append(f"fade=t=out:st={fade_start:.3f}:d={fade_out}")
-
-    vf = ",".join(vf_parts)
-
-    _run_ffmpeg(
-        [
-            "-i",
-            input_path,
-            "-vf",
-            vf,
-            "-c:v",
-            "libx264",
-            *_quality_args(crf=crf, preset=preset),
-            "-c:a",
-            "copy",
-            *_movflags_args(output),
-            output,
-        ]
-    )
-
-    result_info = probe(output)
-    return EditResult(
-        output_path=output,
-        duration=result_info.duration,
-        resolution=result_info.resolution,
-        size_mb=result_info.size_mb,
-        format="mp4",
-        operation="fade",
     )
 
 

--- a/mcp_video/engine_fade.py
+++ b/mcp_video/engine_fade.py
@@ -1,0 +1,60 @@
+"""Fade operation for the FFmpeg engine."""
+
+from __future__ import annotations
+
+from .engine_probe import probe
+from .engine_runtime_utils import _auto_output, _movflags_args, _quality_args, _run_ffmpeg, _validate_input
+from .errors import MCPVideoError
+from .models import EditResult
+
+
+def fade(
+    input_path: str,
+    fade_in: float = 0.0,
+    fade_out: float = 0.0,
+    output_path: str | None = None,
+    crf: int | None = None,
+    preset: str | None = None,
+) -> EditResult:
+    """Add fade in/out effect to a video."""
+    _validate_input(input_path)
+    if fade_in <= 0 and fade_out <= 0:
+        raise MCPVideoError("Specify fade_in and/or fade_out > 0", code="no_fade")
+
+    output = output_path or _auto_output(input_path, "faded")
+    info = probe(input_path)
+
+    vf_parts: list[str] = []
+    if fade_in > 0:
+        vf_parts.append(f"fade=t=in:st=0:d={fade_in}")
+    if fade_out > 0:
+        fade_start = max(0, info.duration - fade_out)
+        vf_parts.append(f"fade=t=out:st={fade_start:.3f}:d={fade_out}")
+
+    vf = ",".join(vf_parts)
+
+    _run_ffmpeg(
+        [
+            "-i",
+            input_path,
+            "-vf",
+            vf,
+            "-c:v",
+            "libx264",
+            *_quality_args(crf=crf, preset=preset),
+            "-c:a",
+            "copy",
+            *_movflags_args(output),
+            output,
+        ]
+    )
+
+    result_info = probe(output)
+    return EditResult(
+        output_path=output,
+        duration=result_info.duration,
+        resolution=result_info.resolution,
+        size_mb=result_info.size_mb,
+        format="mp4",
+        operation="fade",
+    )


### PR DESCRIPTION
## Summary
- move fade into mcp_video/engine_fade.py
- keep mcp_video.engine as the compatibility facade by re-exporting fade
- preserve no-fade validation, fade timing, quality args, audio copy behavior, and EditResult output

## Verification
- ruff check --fix mcp_video/engine.py mcp_video/engine_fade.py
- /opt/homebrew/bin/python3 fade re-export smoke
- /opt/homebrew/bin/python3 -m pytest tests/test_cli.py -k 'fade' tests/test_server.py -k 'fade' -q --tb=short
- /opt/homebrew/bin/python3 -m pytest tests/test_engine.py tests/test_e2e.py tests/test_server.py -q --tb=short
