### PR TITLE
Extract engine reverse operation

### DIFF
--- a/mcp_video/engine.py
+++ b/mcp_video/engine.py
@@ -47,6 +47,7 @@ from .engine_probe import get_duration as get_duration
 from .engine_probe import probe as probe
 from .engine_resize import resize as resize
 from .engine_rotate import rotate as rotate
+from .engine_reverse import reverse as reverse
 from .engine_fade import fade as fade
 from .engine_runtime_utils import (
     _auto_output as _auto_output,
@@ -1104,48 +1105,6 @@ def split_screen(
         size_mb=info.size_mb,
         format="mp4",
         operation=f"split_screen_{layout}",
-    )
-
-
-def reverse(
-    input_path: str,
-    output_path: str | None = None,
-) -> EditResult:
-    """Reverse video and audio playback.
-
-    Args:
-        input_path: Path to the input video.
-        output_path: Where to save the output. Auto-generated if omitted.
-    """
-    _validate_input(input_path)
-    output = output_path or _auto_output(input_path, "reversed")
-
-    input_info = probe(input_path)
-
-    args = ["-i", input_path, "-vf", "reverse"]
-    # Only reverse audio if the input has an audio stream
-    if input_info.audio_codec:
-        args += ["-af", "areverse", "-c:a", "aac", "-b:a", "128k"]
-    else:
-        args += ["-an"]
-    args += ["-c:v", "libx264", "-preset", "fast", "-crf", "23"]
-
-    _run_ffmpeg(
-        args
-        + _movflags_args(output)
-        + [
-            output,
-        ]
-    )
-
-    info = probe(output)
-    return EditResult(
-        output_path=output,
-        duration=info.duration,
-        resolution=info.resolution,
-        size_mb=info.size_mb,
-        format="mp4",
-        operation="reverse",
     )
 
 

--- a/mcp_video/engine_reverse.py
+++ b/mcp_video/engine_reverse.py
@@ -1,0 +1,49 @@
+"""Reverse playback operation for the FFmpeg engine."""
+
+from __future__ import annotations
+
+from .engine_probe import probe
+from .engine_runtime_utils import _auto_output, _movflags_args, _quality_args, _run_ffmpeg, _validate_input
+from .models import EditResult
+
+
+def reverse(
+    input_path: str,
+    output_path: str | None = None,
+) -> EditResult:
+    """Reverse video and audio playback.
+
+    Args:
+        input_path: Path to the input video.
+        output_path: Where to save the output. Auto-generated if omitted.
+    """
+    _validate_input(input_path)
+    output = output_path or _auto_output(input_path, "reversed")
+
+    input_info = probe(input_path)
+
+    args = ["-i", input_path, "-vf", "reverse"]
+    # Only reverse audio if the input has an audio stream
+    if input_info.audio_codec:
+        args += ["-af", "areverse", "-c:a", "aac", "-b:a", "128k"]
+    else:
+        args += ["-an"]
+    args += ["-c:v", "libx264", *_quality_args()]
+
+    _run_ffmpeg(
+        args
+        + _movflags_args(output)
+        + [
+            output,
+        ]
+    )
+
+    info = probe(output)
+    return EditResult(
+        output_path=output,
+        duration=info.duration,
+        resolution=info.resolution,
+        size_mb=info.size_mb,
+        format="mp4",
+        operation="reverse",
+    )


### PR DESCRIPTION
## Summary
- move reverse into mcp_video/engine_reverse.py
- keep mcp_video.engine as the compatibility facade by re-exporting reverse
- preserve audio/no-audio behavior, output probing, and EditResult output
- use the shared quality-args helper instead of hardcoded libx264 CRF/preset values

## Verification
- ruff check --fix mcp_video/engine.py mcp_video/engine_reverse.py
- /opt/homebrew/bin/python3 reverse re-export smoke
- /opt/homebrew/bin/python3 -m pytest tests/test_engine.py -k 'reverse' tests/test_cli.py -k 'reverse' tests/test_server.py -k 'reverse' -q --tb=short
- /opt/homebrew/bin/python3 -m pytest tests/test_engine.py tests/test_e2e.py tests/test_server.py -q --tb=short
