### PR TITLE
Extract engine chroma key operation

### DIFF
--- a/mcp_video/engine.py
+++ b/mcp_video/engine.py
@@ -37,6 +37,7 @@ from .models import (
 )
 from .ffmpeg_helpers import _escape_ffmpeg_filter_value, _run_ffprobe_json, _seconds_to_srt_time
 from .engine_audio_ops import add_audio as add_audio
+from .engine_chroma_key import chroma_key as chroma_key
 from .engine_crop import crop as crop
 from .engine_edit import trim as trim
 from .engine_merge import merge as merge
@@ -1106,62 +1107,6 @@ def split_screen(
         format="mp4",
         operation=f"split_screen_{layout}",
     )
-
-
-def chroma_key(
-    input_path: str,
-    color: str = "0x00FF00",
-    similarity: float = 0.01,
-    blend: float = 0.0,
-    output_path: str | None = None,
-) -> EditResult:
-    """Remove a solid color background (green screen / chroma key).
-
-    Args:
-        input_path: Path to the input video.
-        color: Color to make transparent (default green: 0x00FF00).
-        similarity: How similar colors need to be to be keyed out (default 0.01).
-        blend: How much to blend the keyed color (default 0.0).
-        output_path: Where to save the output. Auto-generated if omitted.
-
-    Note: Use a .mov output path to preserve the alpha channel (transparent
-    background). Non-MOV outputs will encode with libx264 which does not
-    support transparency.
-    """
-    _validate_input(input_path)
-    output = output_path or _auto_output(input_path, "chromakey")
-
-    _require_filter("chromakey", "Chroma key filter")
-
-    # Validate color is a safe 0xRRGGBB hex value (prevents FFmpeg filter injection)
-    _validate_chroma_color(color)
-
-    # Use MOV with prores_ks (supports alpha) when outputting with transparency
-    is_mov = output.lower().endswith(".mov")
-
-    if is_mov:
-        vf = f"chromakey=color={color}:similarity={similarity}:blend={blend},format=yuva444p16le"
-        codec_args = ["-c:v", "prores_ks", "-pix_fmt", "yuva444p12le"]
-    else:
-        vf = f"chromakey=color={color}:similarity={similarity}:blend={blend}"
-        codec_args = ["-c:v", "libx264", "-preset", "fast", "-crf", "23", "-c:a", "aac", "-b:a", "128k"]
-
-    _run_ffmpeg(["-i", input_path, "-vf", vf, *codec_args, *_movflags_args(output), output])
-
-    info = probe(output)
-    return EditResult(
-        output_path=output,
-        duration=info.duration,
-        resolution=info.resolution,
-        size_mb=info.size_mb,
-        format="mp4",
-        operation="chroma_key",
-    )
-
-
-# ---------------------------------------------------------------------------
-# Subtitle generation
-# ---------------------------------------------------------------------------
 
 
 def generate_subtitles(

--- a/mcp_video/engine_chroma_key.py
+++ b/mcp_video/engine_chroma_key.py
@@ -1,0 +1,77 @@
+"""Chroma key operation for the FFmpeg engine."""
+
+from __future__ import annotations
+
+from .engine_probe import probe
+from .engine_runtime_utils import (
+    _auto_output,
+    _movflags_args,
+    _quality_args,
+    _require_filter,
+    _run_ffmpeg,
+    _sanitize_ffmpeg_number,
+    _validate_chroma_color,
+    _validate_input,
+)
+from .ffmpeg_helpers import _escape_ffmpeg_filter_value
+from .models import EditResult
+
+
+def chroma_key(
+    input_path: str,
+    color: str = "0x00FF00",
+    similarity: float = 0.01,
+    blend: float = 0.0,
+    output_path: str | None = None,
+) -> EditResult:
+    """Remove a solid color background (green screen / chroma key).
+
+    Args:
+        input_path: Path to the input video.
+        color: Color to make transparent (default green: 0x00FF00).
+        similarity: How similar colors need to be to be keyed out (default 0.01).
+        blend: How much to blend the keyed color (default 0.0).
+        output_path: Where to save the output. Auto-generated if omitted.
+
+    Note: Use a .mov output path to preserve the alpha channel (transparent
+    background). Non-MOV outputs will encode with libx264 which does not
+    support transparency.
+    """
+    _validate_input(input_path)
+    output = output_path or _auto_output(input_path, "chromakey")
+
+    _require_filter("chromakey", "Chroma key filter")
+
+    # Validate color is a safe 0xRRGGBB hex value (prevents FFmpeg filter injection)
+    _validate_chroma_color(color)
+
+    safe_color = _escape_ffmpeg_filter_value(color)
+    safe_similarity = _escape_ffmpeg_filter_value(str(_sanitize_ffmpeg_number(similarity, "similarity")))
+    safe_blend = _escape_ffmpeg_filter_value(str(_sanitize_ffmpeg_number(blend, "blend")))
+
+    # Use MOV with prores_ks (supports alpha) when outputting with transparency
+    is_mov = output.lower().endswith(".mov")
+
+    if is_mov:
+        vf = f"chromakey=color={safe_color}:similarity={safe_similarity}:blend={safe_blend},format=yuva444p16le"
+        codec_args = ["-c:v", "prores_ks", "-pix_fmt", "yuva444p12le"]
+    else:
+        vf = f"chromakey=color={safe_color}:similarity={safe_similarity}:blend={safe_blend}"
+        codec_args = ["-c:v", "libx264", *_quality_args(), "-c:a", "aac", "-b:a", "128k"]
+
+    _run_ffmpeg(["-i", input_path, "-vf", vf, *codec_args, *_movflags_args(output), output])
+
+    info = probe(output)
+    return EditResult(
+        output_path=output,
+        duration=info.duration,
+        resolution=info.resolution,
+        size_mb=info.size_mb,
+        format="mp4",
+        operation="chroma_key",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Subtitle generation
+# ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- move chroma_key into mcp_video/engine_chroma_key.py
- keep mcp_video.engine as the compatibility facade by re-exporting chroma_key
- preserve MOV alpha behavior, chroma color validation, output probing, and EditResult output
- escape all filter values before building the FFmpeg chromakey filter string
- use shared quality args for the libx264 branch

## Verification
- ruff check mcp_video/engine.py mcp_video/engine_chroma_key.py
- ruff format --check mcp_video/engine.py mcp_video/engine_chroma_key.py
- /opt/homebrew/bin/python3 chroma_key re-export smoke
- /opt/homebrew/bin/python3 -m pytest tests/test_engine.py -k 'chroma_key' tests/test_cli.py -k 'chroma_key or chroma-key' tests/test_server.py -k 'chroma_key' -q --tb=short
- /opt/homebrew/bin/python3 -m pytest tests/test_engine.py tests/test_e2e.py tests/test_server.py -q --tb=short
