### PR TITLE
Extract engine export wrapper

### DIFF
--- a/mcp_video/engine.py
+++ b/mcp_video/engine.py
@@ -40,6 +40,7 @@ from .engine_audio_ops import add_audio as add_audio
 from .engine_chroma_key import chroma_key as chroma_key
 from .engine_crop import crop as crop
 from .engine_edit import trim as trim
+from .engine_export import export_video as export_video
 from .engine_merge import merge as merge
 from .engine_preview import preview as preview
 
@@ -290,30 +291,6 @@ def convert(
         progress=100.0,
         thumbnail_base64=thumb_b64,
     )
-
-
-def export_video(
-    input_path: str,
-    output_path: str | None = None,
-    quality: QualityLevel = "high",
-    format: ExportFormat = "mp4",
-    on_progress: Callable[[float], None] | None = None,
-    two_pass: bool = False,
-    target_bitrate: int | None = None,
-) -> EditResult:
-    """Export a video with specified quality and format settings."""
-    _validate_input(input_path)
-    result = convert(
-        input_path,
-        format=format,
-        quality=quality,
-        output_path=output_path,
-        on_progress=on_progress,
-        two_pass=two_pass,
-        target_bitrate=target_bitrate,
-    )
-    result.operation = "export"
-    return result
 
 
 # ---------------------------------------------------------------------------

--- a/mcp_video/engine_export.py
+++ b/mcp_video/engine_export.py
@@ -1,0 +1,34 @@
+"""Export operation wrapper for the FFmpeg engine."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from .engine_runtime_utils import _validate_input
+from .models import EditResult, ExportFormat, QualityLevel
+
+
+def export_video(
+    input_path: str,
+    output_path: str | None = None,
+    quality: QualityLevel = "high",
+    format: ExportFormat = "mp4",
+    on_progress: Callable[[float], None] | None = None,
+    two_pass: bool = False,
+    target_bitrate: int | None = None,
+) -> EditResult:
+    """Export a video with specified quality and format settings."""
+    _validate_input(input_path)
+    from . import engine as _engine
+
+    result = _engine.convert(
+        input_path,
+        format=format,
+        quality=quality,
+        output_path=output_path,
+        on_progress=on_progress,
+        two_pass=two_pass,
+        target_bitrate=target_bitrate,
+    )
+    result.operation = "export"
+    return result


### PR DESCRIPTION
## Summary
- move export_video into mcp_video/engine_export.py
- keep mcp_video.engine as the compatibility facade by re-exporting export_video
- preserve progress forwarding, two-pass args, output operation marking, and the mcp_video.engine.convert patch point

## Verification
- ruff check mcp_video/engine.py mcp_video/engine_export.py
- ruff format --check mcp_video/engine.py mcp_video/engine_export.py
- /opt/homebrew/bin/python3 export_video re-export smoke
- /opt/homebrew/bin/python3 -m pytest tests/test_engine_advanced.py::TestExportVideo tests/test_engine_advanced.py::TestTwoPassEncoding::test_export_video_two_pass tests/test_cli.py::TestCLIExport tests/test_server.py::TestVideoExportTool -q --tb=short
- /opt/homebrew/bin/python3 -m pytest tests/test_engine.py tests/test_e2e.py tests/test_server.py -q --tb=short
