### PR TITLE
Extract engine audio normalization operation

### DIFF
--- a/mcp_video/engine.py
+++ b/mcp_video/engine.py
@@ -35,6 +35,7 @@ from .models import (
 )
 from .ffmpeg_helpers import _escape_ffmpeg_filter_value, _seconds_to_srt_time
 from .engine_audio_ops import add_audio as add_audio
+from .engine_audio_normalize import normalize_audio as normalize_audio
 from .engine_chroma_key import chroma_key as chroma_key
 from .engine_crop import crop as crop
 from .engine_edit import trim as trim
@@ -786,66 +787,6 @@ def apply_filter(
         size_mb=info.size_mb,
         format="mp4",
         operation=f"filter_{filter_type}",
-    )
-
-
-# ---------------------------------------------------------------------------
-# Audio normalization
-# ---------------------------------------------------------------------------
-
-
-def normalize_audio(
-    input_path: str,
-    target_lufs: float = -16.0,
-    lra: float = 11.0,
-    output_path: str | None = None,
-) -> EditResult:
-    """Normalize audio loudness to a target LUFS level.
-
-    Args:
-        input_path: Path to the input video.
-        target_lufs: Target integrated loudness in LUFS. Common values:
-            -16 (YouTube), -23 (EBU R128/broadcast), -14 (Apple/Spotify).
-        lra: Loudness range target in LU. Default 11.0.
-        output_path: Where to save the output.
-    """
-    _validate_input(input_path)
-    if not isinstance(target_lufs, (int, float)) or not (-70 <= target_lufs <= -5):
-        raise MCPVideoError(
-            f"target_lufs must be -70 to -5, got {target_lufs}", error_type="validation_error", code="invalid_parameter"
-        )
-    _require_filter("loudnorm", "Audio normalization")
-    output = output_path or _auto_output(input_path, "normalized")
-
-    # loudnorm parameters: I=integrated loudness, TP=true peak, LRA=loudness range
-    # TP (true peak) should be a fixed value near -1.5 dBTP regardless of target LUFS.
-    tp = -1.5
-
-    _run_ffmpeg(
-        [
-            "-i",
-            input_path,
-            "-af",
-            f"loudnorm=I={target_lufs}:TP={tp}:LRA={lra}",
-            "-c:v",
-            "copy",
-            "-c:a",
-            "aac",
-            "-b:a",
-            "192k",
-            *_movflags_args(output),
-            output,
-        ]
-    )
-
-    info = probe(output)
-    return EditResult(
-        output_path=output,
-        duration=info.duration,
-        resolution=info.resolution,
-        size_mb=info.size_mb,
-        format="mp4",
-        operation="normalize_audio",
     )
 
 

--- a/mcp_video/engine_audio_normalize.py
+++ b/mcp_video/engine_audio_normalize.py
@@ -1,0 +1,74 @@
+"""Audio normalization operation for the FFmpeg engine."""
+
+from __future__ import annotations
+
+from .engine_probe import probe
+from .engine_runtime_utils import (
+    _auto_output,
+    _movflags_args,
+    _require_filter,
+    _run_ffmpeg,
+    _sanitize_ffmpeg_number,
+    _validate_input,
+)
+from .errors import MCPVideoError
+from .ffmpeg_helpers import _escape_ffmpeg_filter_value
+from .models import EditResult
+
+
+def normalize_audio(
+    input_path: str,
+    target_lufs: float = -16.0,
+    lra: float = 11.0,
+    output_path: str | None = None,
+) -> EditResult:
+    """Normalize audio loudness to a target LUFS level.
+
+    Args:
+        input_path: Path to the input video.
+        target_lufs: Target integrated loudness in LUFS. Common values:
+            -16 (YouTube), -23 (EBU R128/broadcast), -14 (Apple/Spotify).
+        lra: Loudness range target in LU. Default 11.0.
+        output_path: Where to save the output.
+    """
+    _validate_input(input_path)
+    if not isinstance(target_lufs, (int, float)) or not (-70 <= target_lufs <= -5):
+        raise MCPVideoError(
+            f"target_lufs must be -70 to -5, got {target_lufs}", error_type="validation_error", code="invalid_parameter"
+        )
+    _require_filter("loudnorm", "Audio normalization")
+    output = output_path or _auto_output(input_path, "normalized")
+
+    safe_target_lufs = _escape_ffmpeg_filter_value(str(_sanitize_ffmpeg_number(target_lufs, "target_lufs")))
+    safe_lra = _escape_ffmpeg_filter_value(str(_sanitize_ffmpeg_number(lra, "lra")))
+
+    # loudnorm parameters: I=integrated loudness, TP=true peak, LRA=loudness range
+    # TP (true peak) should be a fixed value near -1.5 dBTP regardless of target LUFS.
+    safe_tp = _escape_ffmpeg_filter_value(str(-1.5))
+
+    _run_ffmpeg(
+        [
+            "-i",
+            input_path,
+            "-af",
+            f"loudnorm=I={safe_target_lufs}:TP={safe_tp}:LRA={safe_lra}",
+            "-c:v",
+            "copy",
+            "-c:a",
+            "aac",
+            "-b:a",
+            "192k",
+            *_movflags_args(output),
+            output,
+        ]
+    )
+
+    info = probe(output)
+    return EditResult(
+        output_path=output,
+        duration=info.duration,
+        resolution=info.resolution,
+        size_mb=info.size_mb,
+        format="mp4",
+        operation="normalize_audio",
+    )


### PR DESCRIPTION
## Summary
- move normalize_audio into mcp_video/engine_audio_normalize.py
- keep mcp_video.engine as the compatibility facade by re-exporting normalize_audio
- preserve target LUFS validation, loudnorm behavior, audio bitrate, video copy behavior, and EditResult output
- sanitize and escape numeric loudnorm filter values before building the FFmpeg filter string

## Verification
- ruff check mcp_video/engine.py mcp_video/engine_audio_normalize.py
- ruff format --check mcp_video/engine.py mcp_video/engine_audio_normalize.py
- /opt/homebrew/bin/python3 normalize_audio re-export smoke
- /opt/homebrew/bin/python3 -m pytest tests/test_engine_advanced.py::TestNormalizeAudio tests/test_cli.py::TestCLINormalizeAudio tests/test_server.py::TestVideoNormalizeAudioTool tests/test_client.py::TestClientNormalizeAudio -q --tb=short
- /opt/homebrew/bin/python3 -m pytest tests/test_engine.py tests/test_e2e.py tests/test_server.py -q --tb=short
