### PR TITLE
Extract engine scene detection operation

### DIFF
--- a/mcp_video/engine.py
+++ b/mcp_video/engine.py
@@ -26,7 +26,6 @@ from .models import (
     Position,
     QualityLevel,
     QualityMetricsResult,
-    SceneDetectionResult,
     SplitLayout,
     SubtitleResult,
     Timeline,
@@ -38,6 +37,7 @@ from .engine_audio_ops import add_audio as add_audio
 from .engine_audio_normalize import normalize_audio as normalize_audio
 from .engine_chroma_key import chroma_key as chroma_key
 from .engine_crop import crop as crop
+from .engine_detect_scenes import detect_scenes as detect_scenes
 from .engine_edit import trim as trim
 from .engine_export import export_video as export_video
 from .engine_extract_audio import extract_audio as extract_audio
@@ -1195,95 +1195,6 @@ def audio_waveform(
         max_level=round(max_level, 1),
         min_level=round(min_level, 1),
         silence_regions=silence_regions,
-    )
-
-
-# ---------------------------------------------------------------------------
-# Scene detection
-# ---------------------------------------------------------------------------
-
-
-def detect_scenes(
-    input_path: str,
-    threshold: float = 0.3,
-    min_scene_duration: float = 1.0,
-) -> SceneDetectionResult:
-    """Detect scene changes in a video.
-
-    Args:
-        input_path: Path to the input video.
-        threshold: Scene detection sensitivity (0.0-1.0, lower = more sensitive).
-        min_scene_duration: Minimum duration of a scene in seconds.
-    """
-    _validate_input(input_path)
-    if not isinstance(threshold, (int, float)) or not (0.0 <= threshold <= 1.0):
-        raise MCPVideoError(
-            f"threshold must be 0.0-1.0, got {threshold}", error_type="validation_error", code="invalid_parameter"
-        )
-    info = probe(input_path)
-    duration = info.duration
-
-    # Use FFmpeg select filter with scene detection
-    proc = subprocess.run(
-        [
-            _ffmpeg(),
-            "-i",
-            input_path,
-            "-vf",
-            f"select='gt(scene,{threshold})',showinfo",
-            "-f",
-            "null",
-            "-",
-        ],
-        capture_output=True,
-        text=True,
-        timeout=300,
-    )
-    if proc.returncode != 0:
-        raise parse_ffmpeg_error(proc.stderr)
-
-    # Parse showinfo output for scene change timestamps
-    scene_times: list[float] = []
-    for line in proc.stderr.split("\n"):
-        if "showinfo" in line and "pts_time:" in line:
-            try:
-                # Format: [showinfo @ ...] pts_time:X ...
-                pts_match = re.search(r"pts_time:(\d+\.?\d*)", line)
-                if pts_match:
-                    scene_times.append(float(pts_match.group(1)))
-            except (ValueError, IndexError):
-                continue
-
-    # Build scene list from timestamps
-    scenes: list[dict] = []
-    prev_time = 0.0
-    for t in scene_times:
-        if t - prev_time >= min_scene_duration:
-            scenes.append(
-                {
-                    "start": round(prev_time, 2),
-                    "end": round(t, 2),
-                    "start_frame": round(prev_time * info.fps),
-                    "end_frame": round(t * info.fps),
-                }
-            )
-            prev_time = t
-
-    # Add final scene
-    if duration - prev_time >= 0.1:
-        scenes.append(
-            {
-                "start": round(prev_time, 2),
-                "end": round(duration, 2),
-                "start_frame": round(prev_time * info.fps),
-                "end_frame": round(duration * info.fps),
-            }
-        )
-
-    return SceneDetectionResult(
-        scenes=scenes,
-        scene_count=len(scenes),
-        duration=duration,
     )
 
 

--- a/mcp_video/engine_detect_scenes.py
+++ b/mcp_video/engine_detect_scenes.py
@@ -1,0 +1,101 @@
+"""Scene detection operation for the FFmpeg engine."""
+
+from __future__ import annotations
+
+import re
+import subprocess
+
+from .engine_probe import probe
+from .engine_runtime_utils import _ffmpeg, _sanitize_ffmpeg_number, _validate_input
+from .errors import MCPVideoError, ProcessingError, parse_ffmpeg_error
+from .ffmpeg_helpers import _escape_ffmpeg_filter_value
+from .limits import DEFAULT_FFMPEG_TIMEOUT
+from .models import SceneDetectionResult
+
+
+def detect_scenes(
+    input_path: str,
+    threshold: float = 0.3,
+    min_scene_duration: float = 1.0,
+) -> SceneDetectionResult:
+    """Detect scene changes in a video.
+
+    Args:
+        input_path: Path to the input video.
+        threshold: Scene detection sensitivity (0.0-1.0, lower = more sensitive).
+        min_scene_duration: Minimum duration of a scene in seconds.
+    """
+    _validate_input(input_path)
+    if not isinstance(threshold, (int, float)) or not (0.0 <= threshold <= 1.0):
+        raise MCPVideoError(
+            f"threshold must be 0.0-1.0, got {threshold}", error_type="validation_error", code="invalid_parameter"
+        )
+    safe_threshold = _escape_ffmpeg_filter_value(str(_sanitize_ffmpeg_number(threshold, "threshold")))
+    info = probe(input_path)
+    duration = info.duration
+
+    try:
+        proc = subprocess.run(
+            [
+                _ffmpeg(),
+                "-i",
+                input_path,
+                "-vf",
+                f"select='gt(scene,{safe_threshold})',showinfo",
+                "-f",
+                "null",
+                "-",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=DEFAULT_FFMPEG_TIMEOUT,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise ProcessingError(f"Scene detection timed out after {DEFAULT_FFMPEG_TIMEOUT} seconds") from exc
+    if proc.returncode != 0:
+        raise parse_ffmpeg_error(proc.stderr)
+
+    scene_times = _parse_scene_times(proc.stderr)
+    scenes: list[dict] = []
+    prev_time = 0.0
+    for t in scene_times:
+        if t - prev_time >= min_scene_duration:
+            scenes.append(
+                {
+                    "start": round(prev_time, 2),
+                    "end": round(t, 2),
+                    "start_frame": round(prev_time * info.fps),
+                    "end_frame": round(t * info.fps),
+                }
+            )
+            prev_time = t
+
+    if duration - prev_time >= 0.1:
+        scenes.append(
+            {
+                "start": round(prev_time, 2),
+                "end": round(duration, 2),
+                "start_frame": round(prev_time * info.fps),
+                "end_frame": round(duration * info.fps),
+            }
+        )
+
+    return SceneDetectionResult(
+        scenes=scenes,
+        scene_count=len(scenes),
+        duration=duration,
+    )
+
+
+def _parse_scene_times(stderr: str) -> list[float]:
+    scene_times: list[float] = []
+    for line in stderr.split("\n"):
+        if "showinfo" not in line or "pts_time:" not in line:
+            continue
+        try:
+            pts_match = re.search(r"pts_time:(\d+\.?\d*)", line)
+            if pts_match:
+                scene_times.append(float(pts_match.group(1)))
+        except (ValueError, IndexError):
+            continue
+    return scene_times

--- a/mcp_video/engine_detect_scenes.py
+++ b/mcp_video/engine_detect_scenes.py
@@ -34,24 +34,29 @@ def detect_scenes(
     info = probe(input_path)
     duration = info.duration
 
+    cmd = [
+        _ffmpeg(),
+        "-i",
+        input_path,
+        "-vf",
+        f"select='gt(scene,{safe_threshold})',showinfo",
+        "-f",
+        "null",
+        "-",
+    ]
     try:
         proc = subprocess.run(
-            [
-                _ffmpeg(),
-                "-i",
-                input_path,
-                "-vf",
-                f"select='gt(scene,{safe_threshold})',showinfo",
-                "-f",
-                "null",
-                "-",
-            ],
+            cmd,
             capture_output=True,
             text=True,
             timeout=DEFAULT_FFMPEG_TIMEOUT,
         )
     except subprocess.TimeoutExpired as exc:
-        raise ProcessingError(f"Scene detection timed out after {DEFAULT_FFMPEG_TIMEOUT} seconds") from exc
+        raise ProcessingError(
+            " ".join(cmd),
+            -1,
+            f"Scene detection timed out after {DEFAULT_FFMPEG_TIMEOUT} seconds",
+        ) from exc
     if proc.returncode != 0:
         raise parse_ffmpeg_error(proc.stderr)
 

--- a/tests/test_engine_advanced.py
+++ b/tests/test_engine_advanced.py
@@ -1,6 +1,7 @@
 """Advanced engine tests for uncovered operations and edge cases — needs FFmpeg."""
 
 import os
+import subprocess
 
 import pytest
 
@@ -31,7 +32,7 @@ from mcp_video.engine import (
     watermark,
 )
 from mcp_video.models import Timeline, TimelineClip, TimelineTrack
-from mcp_video.errors import InputFileError, MCPVideoError
+from mcp_video.errors import InputFileError, MCPVideoError, ProcessingError
 
 
 def requires_filter(name: str, feature: str):
@@ -775,6 +776,18 @@ class TestSceneDetection:
         from mcp_video.engine import detect_scenes
         with pytest.raises(InputFileError):
             detect_scenes("/nonexistent/video.mp4")
+
+    def test_detect_scenes_timeout_raises_processing_error(self, sample_video, monkeypatch):
+        from mcp_video.engine import detect_scenes
+        from mcp_video import engine_detect_scenes
+
+        def raise_timeout(*args, **kwargs):
+            raise subprocess.TimeoutExpired(cmd=args[0], timeout=kwargs.get("timeout"))
+
+        monkeypatch.setattr(engine_detect_scenes.subprocess, "run", raise_timeout)
+
+        with pytest.raises(ProcessingError, match="timed out"):
+            detect_scenes(sample_video)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why
The adversarial audit keeps finding the same maintenance risk: `engine.py` still owns too many unrelated FFmpeg operations. `detect_scenes` is isolated, already covered by focused tests, and can move behind a narrow module boundary without changing the public API.

## What changed
- Added `mcp_video/engine_detect_scenes.py`.
- Kept `mcp_video.engine.detect_scenes` as a compatibility import for client, server, CLI, and external callers.
- Moved scene timestamp parsing into a private helper.
- Replaced the local hardcoded scene-detection timeout with `DEFAULT_FFMPEG_TIMEOUT`.
- Preserved FFmpeg error parsing and added explicit timeout handling through `ProcessingError`.
- Escaped the sanitized numeric threshold before interpolating it into the FFmpeg filter string.

## Verification
- `ruff check mcp_video/engine.py mcp_video/engine_detect_scenes.py`
- `ruff format --check mcp_video/engine.py mcp_video/engine_detect_scenes.py`
- `python3 -m pytest tests/test_engine_advanced.py -k 'detect_scenes' -q --tb=short`
- `python3 -m pytest tests/test_cli.py -k 'detect_scenes' tests/test_server.py::TestVideoDetectScenesTool tests/test_red_team.py -k 'detect_scenes' -q --tb=short`
- `python3 -m pytest tests/test_engine.py tests/test_e2e.py tests/test_server.py -q --tb=short`

Not run: full slow/real-media suite.
