### PR TITLE
Extract engine quality comparison operation

### DIFF
--- a/mcp_video/engine.py
+++ b/mcp_video/engine.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import os
-import re
 import shutil
 import subprocess
 import tempfile
@@ -13,7 +12,6 @@ from collections.abc import Callable
 from .errors import (
     MCPVideoError,
     InputFileError,
-    ProcessingError,
     parse_ffmpeg_error,
 )
 from .models import (
@@ -25,7 +23,6 @@ from .models import (
     NamedPosition,
     Position,
     QualityLevel,
-    QualityMetricsResult,
     SplitLayout,
     SubtitleResult,
     Timeline,
@@ -36,6 +33,7 @@ from .engine_audio_waveform import audio_waveform as audio_waveform
 from .engine_audio_ops import add_audio as add_audio
 from .engine_audio_normalize import normalize_audio as normalize_audio
 from .engine_chroma_key import chroma_key as chroma_key
+from .engine_compare_quality import compare_quality as compare_quality
 from .engine_crop import crop as crop
 from .engine_detect_scenes import detect_scenes as detect_scenes
 from .engine_edit import trim as trim
@@ -1192,119 +1190,6 @@ def create_from_images(
         size_mb=result_info.size_mb,
         format="mp4",
         operation="create_from_images",
-    )
-
-
-# ---------------------------------------------------------------------------
-# Quality metrics
-# ---------------------------------------------------------------------------
-
-
-def compare_quality(
-    original_path: str,
-    distorted_path: str,
-    metrics: list[str] | None = None,
-) -> QualityMetricsResult:
-    """Compare video quality between original and distorted versions.
-
-    Args:
-        original_path: Path to the original/reference video.
-        distorted_path: Path to the distorted/processed video.
-        metrics: List of metrics to compute (default: ["psnr", "ssim"]).
-    """
-    _validate_input(original_path)
-    _validate_input(distorted_path)
-    metrics = metrics or ["psnr", "ssim"]
-
-    computed: dict[str, float] = {}
-
-    for metric in metrics:
-        metric_lower = metric.lower()
-        if metric_lower not in ("psnr", "ssim"):
-            continue
-
-        try:
-            # Get original resolution to scale distorted video to match
-            orig_info = probe(original_path)
-            target_w = orig_info.width
-            target_h = orig_info.height
-
-            # Scale distorted to match original resolution, then compare
-            filter_str = f"[1:v]scale={target_w}:{target_h}[scaled];[0:v][scaled]{metric_lower}"
-            proc = subprocess.run(
-                [
-                    _ffmpeg(),
-                    "-i",
-                    original_path,
-                    "-i",
-                    distorted_path,
-                    "-lavfi",
-                    filter_str,
-                    "-f",
-                    "null",
-                    "-",
-                ],
-                capture_output=True,
-                text=True,
-                timeout=300,
-            )
-            if proc.returncode != 0:
-                raise ProcessingError(
-                    f"ffmpeg -i {original_path} -i {distorted_path} -lavfi {metric_lower}",
-                    proc.returncode,
-                    proc.stderr[:500],
-                )
-
-            # Parse metric value from stderr
-            for line in proc.stderr.split("\n"):
-                if metric_lower == "psnr" and "average:" in line.lower():
-                    try:
-                        # Format: [Parsed_psnr ...] average:XX.XX
-                        val_match = re.search(r"average:\s*([0-9.]+)", line, re.IGNORECASE)
-                        if val_match:
-                            computed["psnr"] = float(val_match.group(1))
-                    except (ValueError, IndexError):
-                        continue
-                elif metric_lower == "ssim" and "All:" in line:
-                    try:
-                        # Format: [Parsed_ssim ...] All:X.XXXXXX
-                        val_match = re.search(r"All[:\s]+([0-9.]+)", line)
-                        if val_match:
-                            computed["ssim"] = float(val_match.group(1))
-                    except (ValueError, IndexError):
-                        continue
-        except Exception as e:
-            if isinstance(e, ProcessingError):
-                raise
-            raise ProcessingError(
-                f"ffmpeg -i {original_path} -i {distorted_path} -lavfi {metric_lower}",
-                1,
-                str(e)[:500],
-            ) from e
-
-    # Determine overall quality
-    if "ssim" in computed:
-        ssim_val = computed["ssim"]
-        if ssim_val >= 0.95:
-            overall = "high"
-        elif ssim_val >= 0.80:
-            overall = "medium"
-        else:
-            overall = "low"
-    elif "psnr" in computed:
-        psnr_val = computed["psnr"]
-        if psnr_val >= 40:
-            overall = "high"
-        elif psnr_val >= 30:
-            overall = "medium"
-        else:
-            overall = "low"
-    else:
-        overall = "unknown"
-
-    return QualityMetricsResult(
-        metrics=computed,
-        overall_quality=overall,
     )
 
 

--- a/mcp_video/engine_compare_quality.py
+++ b/mcp_video/engine_compare_quality.py
@@ -1,0 +1,128 @@
+"""Quality comparison operation for the FFmpeg engine."""
+
+from __future__ import annotations
+
+import re
+import subprocess
+
+from .engine_probe import probe
+from .engine_runtime_utils import _ffmpeg, _validate_input
+from .errors import ProcessingError
+from .limits import DEFAULT_FFMPEG_TIMEOUT
+from .models import QualityMetricsResult
+
+
+def compare_quality(
+    original_path: str,
+    distorted_path: str,
+    metrics: list[str] | None = None,
+) -> QualityMetricsResult:
+    """Compare video quality between original and distorted versions.
+
+    Args:
+        original_path: Path to the original/reference video.
+        distorted_path: Path to the distorted/processed video.
+        metrics: List of metrics to compute (default: ["psnr", "ssim"]).
+    """
+    _validate_input(original_path)
+    _validate_input(distorted_path)
+    requested_metrics = metrics or ["psnr", "ssim"]
+
+    computed: dict[str, float] = {}
+    orig_info = probe(original_path)
+    target_w = orig_info.width
+    target_h = orig_info.height
+
+    for metric in requested_metrics:
+        metric_lower = metric.lower()
+        if metric_lower not in ("psnr", "ssim"):
+            continue
+
+        try:
+            stderr = _run_metric(original_path, distorted_path, metric_lower, target_w, target_h)
+            _parse_metric(stderr, metric_lower, computed)
+        except Exception as e:
+            if isinstance(e, ProcessingError):
+                raise
+            raise ProcessingError(
+                _metric_command_label(original_path, distorted_path, metric_lower),
+                1,
+                str(e)[:500],
+            ) from e
+
+    return QualityMetricsResult(
+        metrics=computed,
+        overall_quality=_overall_quality(computed),
+    )
+
+
+def _run_metric(original_path: str, distorted_path: str, metric_lower: str, target_w: int, target_h: int) -> str:
+    filter_str = f"[1:v]scale={target_w}:{target_h}[scaled];[0:v][scaled]{metric_lower}"
+    cmd = [
+        _ffmpeg(),
+        "-i",
+        original_path,
+        "-i",
+        distorted_path,
+        "-lavfi",
+        filter_str,
+        "-f",
+        "null",
+        "-",
+    ]
+    try:
+        proc = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=DEFAULT_FFMPEG_TIMEOUT,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise ProcessingError(
+            " ".join(cmd),
+            -1,
+            f"Quality metric '{metric_lower}' timed out after {DEFAULT_FFMPEG_TIMEOUT} seconds",
+        ) from exc
+    if proc.returncode != 0:
+        raise ProcessingError(" ".join(cmd), proc.returncode, proc.stderr)
+    return proc.stderr
+
+
+def _parse_metric(stderr: str, metric_lower: str, computed: dict[str, float]) -> None:
+    for line in stderr.split("\n"):
+        if metric_lower == "psnr" and "average:" in line.lower():
+            try:
+                val_match = re.search(r"average:\s*([0-9.]+)", line, re.IGNORECASE)
+                if val_match:
+                    computed["psnr"] = float(val_match.group(1))
+            except (ValueError, IndexError):
+                continue
+        elif metric_lower == "ssim" and "All:" in line:
+            try:
+                val_match = re.search(r"All[:\s]+([0-9.]+)", line)
+                if val_match:
+                    computed["ssim"] = float(val_match.group(1))
+            except (ValueError, IndexError):
+                continue
+
+
+def _overall_quality(computed: dict[str, float]) -> str:
+    if "ssim" in computed:
+        ssim_val = computed["ssim"]
+        if ssim_val >= 0.95:
+            return "high"
+        if ssim_val >= 0.80:
+            return "medium"
+        return "low"
+    if "psnr" in computed:
+        psnr_val = computed["psnr"]
+        if psnr_val >= 40:
+            return "high"
+        if psnr_val >= 30:
+            return "medium"
+        return "low"
+    return "unknown"
+
+
+def _metric_command_label(original_path: str, distorted_path: str, metric_lower: str) -> str:
+    return f"ffmpeg -i {original_path} -i {distorted_path} -lavfi {metric_lower}"


### PR DESCRIPTION
## Why
The approved remediation plan is reducing `engine.py` one isolated operation at a time. `compare_quality` is a read-only analysis operation with focused engine, CLI, server, and red-team coverage, making it a low-conflict extraction after waveform.

## What changed
- Added `mcp_video/engine_compare_quality.py`.
- Kept `mcp_video.engine.compare_quality` as a compatibility import for client, server, CLI, and external callers.
- Moved PSNR/SSIM subprocess execution, parsing, and overall quality classification into private helpers.
- Replaced the local hardcoded subprocess timeout with `DEFAULT_FFMPEG_TIMEOUT`.
- Preserved existing behavior for unsupported metric names by skipping them.

## Verification
- `ruff check mcp_video/engine.py mcp_video/engine_compare_quality.py`
- `ruff format --check mcp_video/engine.py mcp_video/engine_compare_quality.py`
- `python3 -m pytest tests/test_engine_advanced.py -k 'compare_quality' -q --tb=short`
- `python3 -m pytest tests/test_cli.py -k 'compare_quality' tests/test_server.py::TestVideoCompareQualityTool tests/test_red_team.py -k 'compare_quality' -q --tb=short`
- `python3 -m pytest tests/test_engine.py tests/test_e2e.py tests/test_server.py -q --tb=short`

Not run: full slow/real-media suite.
