### PR TITLE
Preserve unsupported quality metric behavior

### DIFF
--- a/mcp_video/engine_compare_quality.py
+++ b/mcp_video/engine_compare_quality.py
@@ -27,17 +27,20 @@ def compare_quality(
     _validate_input(original_path)
     _validate_input(distorted_path)
     requested_metrics = metrics or ["psnr", "ssim"]
+    supported_metrics = [metric.lower() for metric in requested_metrics if metric.lower() in ("psnr", "ssim")]
 
     computed: dict[str, float] = {}
+    if not supported_metrics:
+        return QualityMetricsResult(
+            metrics=computed,
+            overall_quality="unknown",
+        )
+
     orig_info = probe(original_path)
     target_w = orig_info.width
     target_h = orig_info.height
 
-    for metric in requested_metrics:
-        metric_lower = metric.lower()
-        if metric_lower not in ("psnr", "ssim"):
-            continue
-
+    for metric_lower in supported_metrics:
         try:
             stderr = _run_metric(original_path, distorted_path, metric_lower, target_w, target_h)
             _parse_metric(stderr, metric_lower, computed)

--- a/tests/test_engine_advanced.py
+++ b/tests/test_engine_advanced.py
@@ -906,6 +906,19 @@ class TestQualityMetrics:
         result = compare_quality(sample_video, sample_video, metrics=["psnr", "ssim"])
         assert "psnr" in result.metrics or "ssim" in result.metrics
 
+    def test_compare_quality_unsupported_metrics_skip_probe(self, sample_video, monkeypatch):
+        from mcp_video.engine import compare_quality
+        from mcp_video import engine_compare_quality
+
+        def fail_probe(_path):
+            raise AssertionError("unsupported metrics should not probe")
+
+        monkeypatch.setattr(engine_compare_quality, "probe", fail_probe)
+
+        result = compare_quality(sample_video, sample_video, metrics=["vmaf"])
+        assert result.metrics == {}
+        assert result.overall_quality == "unknown"
+
     def test_compare_quality_nonexistent_original(self, sample_video):
         from mcp_video.engine import compare_quality
         with pytest.raises(InputFileError):


### PR DESCRIPTION
## Why
Codex reviewed PR #94 after it merged and caught a compatibility regression: unsupported quality metrics such as `vmaf` should remain a no-op after path validation, returning `overall_quality="unknown"` without probing or running FFmpeg.

## What changed
- Filters requested quality metrics to supported names before probing.
- Returns the previous empty-metrics/unknown-quality result when no supported metrics are requested.
- Adds a regression test that fails if unsupported metrics trigger `probe()`.

## Verification
- `ruff check mcp_video/engine_compare_quality.py tests/test_engine_advanced.py`
- `ruff format --check mcp_video/engine_compare_quality.py`
- `python3 -m pytest tests/test_engine_advanced.py -k 'compare_quality' -q --tb=short`
- `python3 -m pytest tests/test_cli.py -k 'compare_quality' tests/test_server.py::TestVideoCompareQualityTool tests/test_red_team.py -k 'compare_quality' -q --tb=short`
- `python3 -m pytest tests/test_engine.py tests/test_e2e.py tests/test_server.py -q --tb=short`

Not run: full slow/real-media suite.
