### PR TITLE
Extract engine mask compositing operation

### DIFF
--- a/mcp_video/engine.py
+++ b/mcp_video/engine.py
@@ -35,7 +35,7 @@ from .engine_export import export_video as export_video
 from .engine_extract_audio import extract_audio as extract_audio
 from .engine_frames import export_frames as export_frames
 from .engine_images import create_from_images as create_from_images
-from .engine_mask import apply_mask as apply_mask
+from .engine_mask import apply_mask as _apply_mask
 from .engine_merge import merge as merge
 from .engine_metadata import read_metadata as read_metadata
 from .engine_metadata import write_metadata as write_metadata
@@ -82,6 +82,8 @@ from .engine_text import add_text as add_text
 from .engine_thumbnail import thumbnail as thumbnail
 from .engine_transcode import normalize as normalize
 from .engine_watermark import watermark as watermark
+
+apply_mask = _apply_mask
 
 
 # ---------------------------------------------------------------------------

--- a/mcp_video/engine.py
+++ b/mcp_video/engine.py
@@ -35,6 +35,7 @@ from .engine_export import export_video as export_video
 from .engine_extract_audio import extract_audio as extract_audio
 from .engine_frames import export_frames as export_frames
 from .engine_images import create_from_images as create_from_images
+from .engine_mask import apply_mask as apply_mask
 from .engine_merge import merge as merge
 from .engine_metadata import read_metadata as read_metadata
 from .engine_metadata import write_metadata as write_metadata
@@ -984,78 +985,6 @@ def split_screen(
 # ---------------------------------------------------------------------------
 # Advanced masking
 # ---------------------------------------------------------------------------
-
-
-def apply_mask(
-    input_path: str,
-    mask_path: str,
-    feather: int = 5,
-    output_path: str | None = None,
-) -> EditResult:
-    """Apply an image mask to a video with edge feathering.
-
-    Uses alphamerge filter to composite the mask as an alpha channel.
-
-    Args:
-        input_path: Path to the input video.
-        mask_path: Path to the mask image (white = visible, black = transparent).
-        feather: Feather/blur amount at mask edges in pixels (default 5).
-        output_path: Where to save the output.
-    """
-    _validate_input(input_path)
-    _validate_input(mask_path)
-    _require_filter("alphamerge", "Advanced masking")
-    output = output_path or _auto_output(input_path, "masked")
-
-    # Get video dimensions to scale mask
-    info = probe(input_path)
-    w, h = info.width, info.height
-
-    # Scale mask to video dimensions, convert to alpha, and alphamerge
-    if feather > 0:
-        filter_complex = (
-            f"[1:v]format=gray,scale={w}:{h},colorchannelmixer=aa=1.0,boxblur={feather}[alpha];"
-            f"[0:v][alpha]alphamerge,format=yuv420p[out]"
-        )
-    else:
-        filter_complex = (
-            f"[1:v]format=gray,scale={w}:{h},colorchannelmixer=aa=1.0[alpha];[0:v][alpha]alphamerge,format=yuv420p[out]"
-        )
-
-    _run_ffmpeg(
-        [
-            "-i",
-            input_path,
-            "-i",
-            mask_path,
-            "-filter_complex",
-            filter_complex,
-            "-map",
-            "[out]",
-            "-map",
-            "0:a?",
-            "-c:v",
-            "libx264",
-            "-preset",
-            "fast",
-            "-crf",
-            "23",
-            "-c:a",
-            "copy",
-            *_movflags_args(output),
-            output,
-        ]
-    )
-
-    result_info = probe(output)
-    return EditResult(
-        output_path=output,
-        duration=result_info.duration,
-        resolution=result_info.resolution,
-        size_mb=result_info.size_mb,
-        format="mp4",
-        operation="apply_mask",
-    )
 
 
 # ---------------------------------------------------------------------------

--- a/mcp_video/engine_mask.py
+++ b/mcp_video/engine_mask.py
@@ -22,7 +22,16 @@ def apply_mask(
     feather: int = 5,
     output_path: str | None = None,
 ) -> EditResult:
-    """Apply an image mask to a video with edge feathering."""
+    """Apply an image mask to a video with edge feathering.
+
+    Uses alphamerge filter to composite the mask as an alpha channel.
+
+    Args:
+        input_path: Path to the input video.
+        mask_path: Path to the mask image (white = visible, black = transparent).
+        feather: Feather/blur amount at mask edges in pixels (default 5).
+        output_path: Where to save the output.
+    """
     _validate_input(input_path)
     _validate_input(mask_path)
     _require_filter("alphamerge", "Advanced masking")

--- a/mcp_video/engine_mask.py
+++ b/mcp_video/engine_mask.py
@@ -1,0 +1,79 @@
+"""Mask compositing operation for the FFmpeg engine."""
+
+from __future__ import annotations
+
+from .engine_probe import probe
+from .engine_runtime_utils import (
+    _auto_output,
+    _movflags_args,
+    _quality_args,
+    _require_filter,
+    _run_ffmpeg,
+    _sanitize_ffmpeg_number,
+    _validate_input,
+)
+from .ffmpeg_helpers import _escape_ffmpeg_filter_value
+from .models import EditResult
+
+
+def apply_mask(
+    input_path: str,
+    mask_path: str,
+    feather: int = 5,
+    output_path: str | None = None,
+) -> EditResult:
+    """Apply an image mask to a video with edge feathering."""
+    _validate_input(input_path)
+    _validate_input(mask_path)
+    _require_filter("alphamerge", "Advanced masking")
+    output = output_path or _auto_output(input_path, "masked")
+
+    info = probe(input_path)
+    filter_complex = _mask_filter(info.width, info.height, feather)
+
+    _run_ffmpeg(
+        [
+            "-i",
+            input_path,
+            "-i",
+            mask_path,
+            "-filter_complex",
+            filter_complex,
+            "-map",
+            "[out]",
+            "-map",
+            "0:a?",
+            "-c:v",
+            "libx264",
+            *_quality_args(),
+            "-c:a",
+            "copy",
+            *_movflags_args(output),
+            output,
+        ]
+    )
+
+    result_info = probe(output)
+    return EditResult(
+        output_path=output,
+        duration=result_info.duration,
+        resolution=result_info.resolution,
+        size_mb=result_info.size_mb,
+        format="mp4",
+        operation="apply_mask",
+    )
+
+
+def _mask_filter(width: int, height: int, feather: int) -> str:
+    safe_width = _escape_ffmpeg_filter_value(str(_sanitize_ffmpeg_number(width, "width")))
+    safe_height = _escape_ffmpeg_filter_value(str(_sanitize_ffmpeg_number(height, "height")))
+    safe_feather = _escape_ffmpeg_filter_value(str(_sanitize_ffmpeg_number(feather, "feather")))
+    if feather > 0:
+        return (
+            f"[1:v]format=gray,scale={safe_width}:{safe_height},colorchannelmixer=aa=1.0,boxblur={safe_feather}[alpha];"
+            f"[0:v][alpha]alphamerge,format=yuv420p[out]"
+        )
+    return (
+        f"[1:v]format=gray,scale={safe_width}:{safe_height},colorchannelmixer=aa=1.0[alpha];"
+        f"[0:v][alpha]alphamerge,format=yuv420p[out]"
+    )


### PR DESCRIPTION
## Why
The remediation plan is now through the low-conflict read/generation operations. `apply_mask` is the next bounded transform: it is isolated, tested, and smaller than the remaining overlay/split/composite/filter paths.

## What changed
- Added `mcp_video/engine_mask.py`.
- Kept `mcp_video.engine.apply_mask` as a compatibility import for client, server, CLI, and external callers.
- Moved mask filter construction into a private helper.
- Replaced hardcoded `-preset fast -crf 23` with `_quality_args()`.
- Sanitized and escaped width, height, and feather before filter-complex interpolation.

## Verification
- `ruff check mcp_video/engine.py mcp_video/engine_mask.py`
- `ruff format --check mcp_video/engine.py mcp_video/engine_mask.py`
- `python3 -m pytest tests/test_engine_advanced.py -k 'apply_mask' -q --tb=short`
- `python3 -m pytest tests/test_cli.py -k 'apply_mask' tests/test_server.py::TestVideoApplyMaskTool tests/test_red_team.py -k 'apply_mask' -q --tb=short`
- `python3 -m pytest tests/test_engine.py tests/test_e2e.py tests/test_server.py -q --tb=short`

Not run: full slow/real-media suite.
