### PR TITLE
Extract engine video overlay operation

### DIFF
--- a/mcp_video/engine.py
+++ b/mcp_video/engine.py
@@ -16,7 +16,6 @@ from .models import (
     ExportFormat,
     FilterType,
     NamedPosition,
-    Position,
     QualityLevel,
     SplitLayout,
     Timeline,
@@ -39,6 +38,7 @@ from .engine_mask import apply_mask as _apply_mask
 from .engine_merge import merge as merge
 from .engine_metadata import read_metadata as read_metadata
 from .engine_metadata import write_metadata as write_metadata
+from .engine_overlay import overlay_video as _overlay_video
 from .engine_preview import preview as preview
 
 # Compatibility re-export: callers still import get_duration from mcp_video.engine.
@@ -84,6 +84,7 @@ from .engine_transcode import normalize as normalize
 from .engine_watermark import watermark as watermark
 
 apply_mask = _apply_mask
+overlay_video = _overlay_video
 
 
 # ---------------------------------------------------------------------------
@@ -791,114 +792,6 @@ def apply_filter(
 # ---------------------------------------------------------------------------
 # Compositing & overlays
 # ---------------------------------------------------------------------------
-
-
-def overlay_video(
-    background_path: str,
-    overlay_path: str,
-    position: Position = "top-right",
-    width: int | None = None,
-    height: int | None = None,
-    opacity: float = 0.8,
-    start_time: float | None = None,
-    duration: float | None = None,
-    output_path: str | None = None,
-    crf: int | None = None,
-    preset: str | None = None,
-) -> EditResult:
-    """Picture-in-picture: overlay a video on top of another.
-
-    Args:
-        background_path: Path to the background video.
-        overlay_path: Path to the overlay video.
-        position: Position of the overlay on screen.
-        width: Width to scale the overlay to.
-        height: Height to scale the overlay to.
-        opacity: Opacity of the overlay (0.0 to 1.0).
-        start_time: When the overlay appears (seconds).
-        duration: How long the overlay is visible (seconds).
-        output_path: Where to save the output.
-    """
-    _validate_input(background_path)
-    _validate_input(overlay_path)
-    _require_filter("overlay", "Video overlay")
-    output = output_path or _auto_output(background_path, "overlay")
-
-    # Build scale filter for overlay
-    scale_parts = []
-    if width and height:
-        scale_parts.append(f"scale={width}:{height}")
-    elif width:
-        scale_parts.append(f"scale={width}:-1")
-    elif height:
-        scale_parts.append(f"scale=-1:{height}")
-    scale_filter = ",".join(scale_parts) if scale_parts else ""
-
-    # Build the overlay filter chain
-    opacity_fmt = f"{opacity:.2f}"
-    overlay_chain_parts = ["format=rgba", f"colorchannelmixer=aa={opacity_fmt}"]
-    if scale_filter:
-        overlay_chain_parts.insert(0, scale_filter)
-    overlay_chain = ",".join(overlay_chain_parts)
-
-    # Position map (same as watermark but without margin)
-    position_map: dict[NamedPosition, str] = {
-        "top-left": "0:0",
-        "top-center": "(main_w-overlay_w)/2:0",
-        "top-right": "main_w-overlay_w:0",
-        "center-left": "0:(main_h-overlay_h)/2",
-        "center": "(main_w-overlay_w)/2:(main_h-overlay_h)/2",
-        "center-right": "main_w-overlay_w:(main_h-overlay_h)/2",
-        "bottom-left": "0:main_h-overlay_h",
-        "bottom-center": "(main_w-overlay_w)/2:main_h-overlay_h",
-        "bottom-right": "main_w-overlay_w:main_h-overlay_h",
-    }
-    overlay_pos = _resolve_position(position, position_map, "top-right")
-
-    # Optional enable expression for timing
-    enable_expr = ""
-    if start_time is not None or duration is not None:
-        parts = []
-        if start_time is not None and duration is not None:
-            end = start_time + duration
-            parts.append(f"between(t,{start_time},{end})")
-        elif start_time is not None:
-            parts.append(f"gte(t,{start_time})")
-        elif duration is not None:
-            parts.append(f"lte(t,{duration})")
-        enable_expr = f":enable='{parts[0]}'"
-
-    filter_complex = f"[1:v]{overlay_chain}[ov];[0:v][ov]overlay={overlay_pos}{enable_expr}"
-
-    _run_ffmpeg(
-        [
-            "-i",
-            background_path,
-            "-i",
-            overlay_path,
-            "-filter_complex",
-            filter_complex,
-            "-c:v",
-            "libx264",
-            *_quality_args(crf=crf, preset=preset),
-            "-c:a",
-            "aac",
-            "-b:a",
-            "128k",
-            *_movflags_args(output),
-            output,
-        ]
-    )
-
-    info = probe(output)
-    return EditResult(
-        output_path=output,
-        duration=info.duration,
-        resolution=info.resolution,
-        size_mb=info.size_mb,
-        format="mp4",
-        operation="overlay_video",
-    )
 
 
 def split_screen(

--- a/mcp_video/engine_overlay.py
+++ b/mcp_video/engine_overlay.py
@@ -1,0 +1,164 @@
+"""Video overlay operation for the FFmpeg engine."""
+
+from __future__ import annotations
+
+from .engine_probe import probe
+from .engine_runtime_utils import (
+    _auto_output,
+    _movflags_args,
+    _quality_args,
+    _require_filter,
+    _resolve_position,
+    _run_ffmpeg,
+    _sanitize_ffmpeg_number,
+    _validate_input,
+)
+from .errors import MCPVideoError
+from .ffmpeg_helpers import _escape_ffmpeg_filter_value
+from .models import EditResult, NamedPosition, Position
+
+
+def overlay_video(
+    background_path: str,
+    overlay_path: str,
+    position: Position = "top-right",
+    width: int | None = None,
+    height: int | None = None,
+    opacity: float = 0.8,
+    start_time: float | None = None,
+    duration: float | None = None,
+    output_path: str | None = None,
+    crf: int | None = None,
+    preset: str | None = None,
+) -> EditResult:
+    """Picture-in-picture: overlay a video on top of another.
+
+    Args:
+        background_path: Path to the background video.
+        overlay_path: Path to the overlay video.
+        position: Position of the overlay on screen.
+        width: Width to scale the overlay to.
+        height: Height to scale the overlay to.
+        opacity: Opacity of the overlay (0.0 to 1.0).
+        start_time: When the overlay appears (seconds).
+        duration: How long the overlay is visible (seconds).
+        output_path: Where to save the output.
+    """
+    _validate_input(background_path)
+    _validate_input(overlay_path)
+    _require_filter("overlay", "Video overlay")
+    _validate_dimensions(width, height)
+    safe_opacity = _validate_opacity(opacity)
+    output = output_path or _auto_output(background_path, "overlay")
+
+    scale_filter = _scale_filter(width, height)
+    overlay_chain = _overlay_chain(scale_filter, safe_opacity)
+    overlay_pos = _overlay_position(position)
+    enable_expr = _enable_expression(start_time, duration)
+    filter_complex = f"[1:v]{overlay_chain}[ov];[0:v][ov]overlay={overlay_pos}{enable_expr}"
+
+    _run_ffmpeg(
+        [
+            "-i",
+            background_path,
+            "-i",
+            overlay_path,
+            "-filter_complex",
+            filter_complex,
+            "-c:v",
+            "libx264",
+            *_quality_args(crf=crf, preset=preset),
+            "-c:a",
+            "aac",
+            "-b:a",
+            "128k",
+            *_movflags_args(output),
+            output,
+        ]
+    )
+
+    info = probe(output)
+    return EditResult(
+        output_path=output,
+        duration=info.duration,
+        resolution=info.resolution,
+        size_mb=info.size_mb,
+        format="mp4",
+        operation="overlay_video",
+    )
+
+
+def _validate_dimensions(width: int | None, height: int | None) -> None:
+    for name, value in (("width", width), ("height", height)):
+        if value is not None and _sanitize_ffmpeg_number(value, name) <= 0:
+            raise MCPVideoError(
+                f"{name} must be positive, got {value}",
+                error_type="validation_error",
+                code="invalid_parameter",
+            )
+
+
+def _validate_opacity(opacity: float) -> str:
+    opacity_num = _sanitize_ffmpeg_number(opacity, "opacity")
+    if not 0.0 <= opacity_num <= 1.0:
+        raise MCPVideoError(
+            f"opacity must be between 0 and 1, got {opacity}",
+            error_type="validation_error",
+            code="invalid_parameter",
+        )
+    return _escape_ffmpeg_filter_value(f"{opacity_num:.2f}")
+
+
+def _scale_filter(width: int | None, height: int | None) -> str:
+    if width is not None and height is not None:
+        safe_width = _escape_ffmpeg_filter_value(str(_sanitize_ffmpeg_number(width, "width")))
+        safe_height = _escape_ffmpeg_filter_value(str(_sanitize_ffmpeg_number(height, "height")))
+        return f"scale={safe_width}:{safe_height}"
+    if width is not None:
+        safe_width = _escape_ffmpeg_filter_value(str(_sanitize_ffmpeg_number(width, "width")))
+        return f"scale={safe_width}:-1"
+    if height is not None:
+        safe_height = _escape_ffmpeg_filter_value(str(_sanitize_ffmpeg_number(height, "height")))
+        return f"scale=-1:{safe_height}"
+    return ""
+
+
+def _overlay_chain(scale_filter: str, safe_opacity: str) -> str:
+    overlay_chain_parts = ["format=rgba", f"colorchannelmixer=aa={safe_opacity}"]
+    if scale_filter:
+        overlay_chain_parts.insert(0, scale_filter)
+    return ",".join(overlay_chain_parts)
+
+
+def _overlay_position(position: Position) -> str:
+    position_map: dict[NamedPosition, str] = {
+        "top-left": "0:0",
+        "top-center": "(main_w-overlay_w)/2:0",
+        "top-right": "main_w-overlay_w:0",
+        "center-left": "0:(main_h-overlay_h)/2",
+        "center": "(main_w-overlay_w)/2:(main_h-overlay_h)/2",
+        "center-right": "main_w-overlay_w:(main_h-overlay_h)/2",
+        "bottom-left": "0:main_h-overlay_h",
+        "bottom-center": "(main_w-overlay_w)/2:main_h-overlay_h",
+        "bottom-right": "main_w-overlay_w:main_h-overlay_h",
+    }
+    return _resolve_position(position, position_map, "top-right")
+
+
+def _enable_expression(start_time: float | None, duration: float | None) -> str:
+    if start_time is None and duration is None:
+        return ""
+    if start_time is not None:
+        safe_start = _escape_ffmpeg_filter_value(str(_sanitize_ffmpeg_number(start_time, "start_time")))
+    if duration is not None:
+        safe_duration = _escape_ffmpeg_filter_value(str(_sanitize_ffmpeg_number(duration, "duration")))
+
+    if start_time is not None and duration is not None:
+        end = _sanitize_ffmpeg_number(start_time, "start_time") + _sanitize_ffmpeg_number(duration, "duration")
+        safe_end = _escape_ffmpeg_filter_value(str(end))
+        expression = f"between(t,{safe_start},{safe_end})"
+    elif start_time is not None:
+        expression = f"gte(t,{safe_start})"
+    else:
+        expression = f"lte(t,{safe_duration})"
+    return f":enable='{expression}'"


### PR DESCRIPTION
## Why
After the smaller engine extractions, the remaining surface is mostly composition/filter-heavy. `overlay_video` is a bounded next slice: isolated public operation, focused tests, and separate enough from split-screen/composite overlays to avoid overlap.

## What changed
- Added `mcp_video/engine_overlay.py`.
- Kept `mcp_video.engine.overlay_video` as a compatibility re-export for client, server, CLI, and external callers.
- Moved overlay scale, opacity, position, and enable-expression construction into private helpers.
- Sanitized scale, opacity, and timing filter values before FFmpeg filter-complex interpolation.

## Verification
- `ruff check mcp_video/engine.py mcp_video/engine_overlay.py`
- `ruff format --check mcp_video/engine.py mcp_video/engine_overlay.py`
- `python3 -m pytest tests/test_engine_advanced.py -k 'overlay' -q --tb=short`
- `python3 -m pytest tests/test_cli.py -k 'overlay_video' tests/test_server.py -k 'overlay' tests/test_red_team.py -k 'overlay' -q --tb=short`
- `python3 -m pytest tests/test_engine.py tests/test_e2e.py tests/test_server.py -q --tb=short`

Not run: full slow/real-media suite.
