### PR TITLE
Extract engine batch dispatcher

### DIFF
--- a/mcp_video/engine.py
+++ b/mcp_video/engine.py
@@ -24,6 +24,7 @@ from .ffmpeg_helpers import _escape_ffmpeg_filter_value
 from .engine_audio_waveform import audio_waveform as audio_waveform
 from .engine_audio_ops import add_audio as add_audio
 from .engine_audio_normalize import normalize_audio as normalize_audio
+from .engine_batch import video_batch as _video_batch
 from .engine_chroma_key import chroma_key as chroma_key
 from .engine_compare_quality import compare_quality as compare_quality
 from .engine_crop import crop as crop
@@ -86,6 +87,7 @@ from .engine_watermark import watermark as watermark
 apply_mask = _apply_mask
 overlay_video = _overlay_video
 split_screen = _split_screen
+video_batch = _video_batch
 
 
 # ---------------------------------------------------------------------------
@@ -798,125 +800,3 @@ def apply_filter(
 # ---------------------------------------------------------------------------
 # Batch processing
 # ---------------------------------------------------------------------------
-
-
-def video_batch(
-    inputs: list[str],
-    operation: str,
-    params: dict[str, Any] | None = None,
-    output_dir: str | None = None,
-) -> dict[str, Any]:
-    """Apply the same operation to multiple video files.
-
-    Args:
-        inputs: List of absolute paths to input video files.
-        operation: Operation (trim, resize, convert, filter, blur, color_grade, watermark, speed, fade, normalize_audio).
-        params: Parameters for the operation.
-        output_dir: Directory for output files. Auto-generated if omitted.
-    """
-    if not inputs:
-        return {
-            "success": False,
-            "error": {"type": "input_error", "code": "empty_inputs", "message": "No input files provided"},
-        }
-
-    params = params or {}
-    results = []
-    succeeded = 0
-    failed = 0
-
-    for input_path in inputs:
-        try:
-            if output_dir:
-                os.makedirs(output_dir, exist_ok=True)
-
-            def _batch_output(ext: str | None = None, _input_path: str = input_path) -> str:
-                """Generate output path in output_dir, or auto-generate."""
-                if output_dir:
-                    name = os.path.splitext(os.path.basename(_input_path))[0]
-                    ext = ext or ".mp4"
-                    return os.path.join(output_dir, f"{name}_{operation}{ext}")
-                return None  # let the engine auto-generate
-
-            if operation == "trim":
-                result = trim(
-                    input_path,
-                    start=params.get("start", "0"),
-                    duration=params.get("duration"),
-                    end=params.get("end"),
-                    output_path=_batch_output(),
-                )
-            elif operation == "resize":
-                result = resize(
-                    input_path,
-                    width=params.get("width"),
-                    height=params.get("height"),
-                    aspect_ratio=params.get("aspect_ratio"),
-                    quality=params.get("quality", "high"),
-                    output_path=_batch_output(),
-                )
-            elif operation == "convert":
-                out_ext = f".{params.get('format', 'mp4')}"
-                result = convert(
-                    input_path,
-                    format=params.get("format", "mp4"),
-                    quality=params.get("quality", "high"),
-                    output_path=_batch_output(out_ext),
-                )
-            elif operation == "filter":
-                result = apply_filter(
-                    input_path,
-                    filter_type=params.get("filter_type", "blur"),
-                    params=params.get("filter_params", {}),
-                    output_path=_batch_output(),
-                )
-            elif operation == "blur":
-                result = apply_filter(
-                    input_path, filter_type="blur", params=params.get("filter_params", {}), output_path=_batch_output()
-                )
-            elif operation == "color_grade":
-                result = apply_filter(
-                    input_path,
-                    filter_type="color_preset",
-                    params={"preset": params.get("preset", "warm")},
-                    output_path=_batch_output(),
-                )
-            elif operation == "watermark":
-                result = watermark(
-                    input_path,
-                    image_path=params.get("image_path", ""),
-                    position=params.get("position", "bottom-right"),
-                    opacity=params.get("opacity", 0.7),
-                    output_path=_batch_output(),
-                )
-            elif operation == "speed":
-                result = speed(input_path, factor=params.get("factor", 1.0), output_path=_batch_output())
-            elif operation == "fade":
-                result = fade(
-                    input_path,
-                    fade_in=params.get("fade_in", 0.5),
-                    fade_out=params.get("fade_out", 0.5),
-                    output_path=_batch_output(),
-                )
-            elif operation == "normalize_audio":
-                result = normalize_audio(
-                    input_path, target_lufs=params.get("target_lufs", -16.0), output_path=_batch_output()
-                )
-            else:
-                results.append({"input": input_path, "success": False, "error": f"Unknown operation: {operation}"})
-                failed += 1
-                continue
-
-            results.append({"input": input_path, "success": True, "output_path": result.output_path})
-            succeeded += 1
-        except Exception as e:
-            results.append({"input": input_path, "success": False, "error": str(e)})
-            failed += 1
-
-    return {
-        "success": failed == 0,
-        "total": len(inputs),
-        "succeeded": succeeded,
-        "failed": failed,
-        "results": results,
-    }

--- a/mcp_video/engine_batch.py
+++ b/mcp_video/engine_batch.py
@@ -1,0 +1,138 @@
+"""Batch operation dispatcher for the FFmpeg engine."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from .engine_audio_normalize import normalize_audio
+from .engine_edit import trim
+from .engine_fade import fade
+from .engine_resize import resize
+from .engine_speed import speed
+from .engine_watermark import watermark
+
+
+def video_batch(
+    inputs: list[str],
+    operation: str,
+    params: dict[str, Any] | None = None,
+    output_dir: str | None = None,
+) -> dict[str, Any]:
+    """Apply the same operation to multiple video files."""
+    if not inputs:
+        return {
+            "success": False,
+            "error": {"type": "input_error", "code": "empty_inputs", "message": "No input files provided"},
+        }
+
+    params = params or {}
+    results = []
+    succeeded = 0
+    failed = 0
+
+    for input_path in inputs:
+        try:
+            if output_dir:
+                os.makedirs(output_dir, exist_ok=True)
+
+            result = _run_batch_operation(input_path, operation, params, output_dir)
+            if result is None:
+                results.append({"input": input_path, "success": False, "error": f"Unknown operation: {operation}"})
+                failed += 1
+                continue
+
+            results.append({"input": input_path, "success": True, "output_path": result.output_path})
+            succeeded += 1
+        except Exception as e:
+            results.append({"input": input_path, "success": False, "error": str(e)})
+            failed += 1
+
+    return {
+        "success": failed == 0,
+        "total": len(inputs),
+        "succeeded": succeeded,
+        "failed": failed,
+        "results": results,
+    }
+
+
+def _run_batch_operation(input_path: str, operation: str, params: dict[str, Any], output_dir: str | None):
+    def _batch_output(ext: str | None = None) -> str | None:
+        if output_dir:
+            name = os.path.splitext(os.path.basename(input_path))[0]
+            ext = ext or ".mp4"
+            return os.path.join(output_dir, f"{name}_{operation}{ext}")
+        return None
+
+    if operation == "trim":
+        return trim(
+            input_path,
+            start=params.get("start", "0"),
+            duration=params.get("duration"),
+            end=params.get("end"),
+            output_path=_batch_output(),
+        )
+    if operation == "resize":
+        return resize(
+            input_path,
+            width=params.get("width"),
+            height=params.get("height"),
+            aspect_ratio=params.get("aspect_ratio"),
+            quality=params.get("quality", "high"),
+            output_path=_batch_output(),
+        )
+    if operation == "convert":
+        from .engine import convert
+
+        out_ext = f".{params.get('format', 'mp4')}"
+        return convert(
+            input_path,
+            format=params.get("format", "mp4"),
+            quality=params.get("quality", "high"),
+            output_path=_batch_output(out_ext),
+        )
+    if operation == "filter":
+        from .engine import apply_filter
+
+        return apply_filter(
+            input_path,
+            filter_type=params.get("filter_type", "blur"),
+            params=params.get("filter_params", {}),
+            output_path=_batch_output(),
+        )
+    if operation == "blur":
+        from .engine import apply_filter
+
+        return apply_filter(
+            input_path, filter_type="blur", params=params.get("filter_params", {}), output_path=_batch_output()
+        )
+    if operation == "color_grade":
+        from .engine import apply_filter
+
+        return apply_filter(
+            input_path,
+            filter_type="color_preset",
+            params={"preset": params.get("preset", "warm")},
+            output_path=_batch_output(),
+        )
+    if operation == "watermark":
+        return watermark(
+            input_path,
+            image_path=params.get("image_path", ""),
+            position=params.get("position", "bottom-right"),
+            opacity=params.get("opacity", 0.7),
+            output_path=_batch_output(),
+        )
+    if operation == "speed":
+        return speed(input_path, factor=params.get("factor", 1.0), output_path=_batch_output())
+    if operation == "fade":
+        return fade(
+            input_path,
+            fade_in=params.get("fade_in", 0.5),
+            fade_out=params.get("fade_out", 0.5),
+            output_path=_batch_output(),
+        )
+    if operation == "normalize_audio":
+        return normalize_audio(input_path, target_lufs=params.get("target_lufs", -16.0), output_path=_batch_output())
+    return None

--- a/mcp_video/engine_batch.py
+++ b/mcp_video/engine_batch.py
@@ -11,6 +11,7 @@ from .engine_fade import fade
 from .engine_resize import resize
 from .engine_speed import speed
 from .engine_watermark import watermark
+from .models import EditResult
 
 
 def video_batch(
@@ -57,7 +58,12 @@ def video_batch(
     }
 
 
-def _run_batch_operation(input_path: str, operation: str, params: dict[str, Any], output_dir: str | None):
+def _run_batch_operation(
+    input_path: str,
+    operation: str,
+    params: dict[str, Any],
+    output_dir: str | None,
+) -> EditResult | None:
     def _batch_output(ext: str | None = None) -> str | None:
         if output_dir:
             name = os.path.splitext(os.path.basename(input_path))[0]


### PR DESCRIPTION
## Why
The remaining engine surface is high-risk, but `video_batch` is orchestration glue rather than direct FFmpeg filter graph construction. Extracting it reduces `engine.py` further while keeping the harder `convert` and `apply_filter` changes separate.

## What changed
- Added `mcp_video/engine_batch.py`.
- Kept `mcp_video.engine.video_batch` as a compatibility re-export for client, server, CLI, and external callers.
- Preserved output directory naming, partial-failure accounting, and result shape.
- Uses lazy imports for `convert` and `apply_filter` while those operations remain in the facade.

## Verification
- `ruff check mcp_video/engine.py mcp_video/engine_batch.py`
- `ruff format --check mcp_video/engine.py mcp_video/engine_batch.py`
- `python3 -m pytest tests/test_server.py::TestVideoBatchTool -q --tb=short`
- `python3 -m pytest tests/test_client.py -k 'batch' tests/test_red_team.py -k 'video_batch' -q --tb=short`
- `python3 -m pytest tests/test_engine.py tests/test_e2e.py tests/test_server.py -q --tb=short`

Not run: full slow/real-media suite.
