### PR TITLE
Extract engine filter operations

### DIFF
--- a/mcp_video/engine.py
+++ b/mcp_video/engine.py
@@ -5,16 +5,13 @@ from __future__ import annotations
 import os
 import shutil
 import tempfile
-from typing import Any
 from collections.abc import Callable
 
 from .errors import MCPVideoError
 from .models import (
     QUALITY_PRESETS,
-    ColorPreset,
     EditResult,
     ExportFormat,
-    FilterType,
     NamedPosition,
     QualityLevel,
     Timeline,
@@ -33,6 +30,9 @@ from .engine_edit import trim as trim
 from .engine_export import export_video as export_video
 from .engine_extract_audio import extract_audio as extract_audio
 from .engine_frames import export_frames as export_frames
+from .engine_filters import _build_pitch_shift_filter as _build_pitch_shift_filter
+from .engine_filters import _get_color_preset_filter as _get_color_preset_filter
+from .engine_filters import apply_filter as _apply_filter
 from .engine_images import create_from_images as create_from_images
 from .engine_mask import apply_mask as _apply_mask
 from .engine_merge import merge as merge
@@ -85,6 +85,7 @@ from .engine_transcode import normalize as normalize
 from .engine_watermark import watermark as watermark
 
 apply_mask = _apply_mask
+apply_filter = _apply_filter
 overlay_video = _overlay_video
 split_screen = _split_screen
 video_batch = _video_batch
@@ -604,192 +605,6 @@ def _apply_composite_overlays(
                 output_path,
             ]
         )
-
-
-# ---------------------------------------------------------------------------
-# Video filters & effects
-# ---------------------------------------------------------------------------
-
-
-def _get_color_preset_filter(preset: ColorPreset) -> str:
-    """Return FFmpeg eq filter string for a named color preset."""
-    preset_filters: dict[ColorPreset, str] = {
-        "warm": "eq=brightness=0.05:saturation=1.3:contrast=1.05",
-        "cool": "eq=brightness=0.02:saturation=0.9:contrast=1.05",
-        "vintage": "eq=contrast=1.1:brightness=-0.02:saturation=0.7",
-        "cinematic": "eq=contrast=1.15:brightness=-0.03:saturation=0.85",
-        "noir": "eq=contrast=1.3:brightness=-0.05:saturation=0.0",
-    }
-    if preset not in preset_filters:
-        valid = ", ".join(sorted(preset_filters))
-        raise MCPVideoError(
-            f"Unknown color preset '{preset}'. Valid presets: {valid}",
-            error_type="validation_error",
-            code="invalid_color_preset",
-        )
-    return preset_filters[preset]
-
-
-def _build_pitch_shift_filter(semitones: float = 0) -> str:
-    """Build FFmpeg audio filter string for pitch shifting.
-
-    Args:
-        semitones: Number of semitones to shift. Positive = higher, negative = lower.
-            Each semitone is a 2^(1/12) ~ 1.0595x multiplier on sample rate.
-    """
-    rate_mult = 2 ** (semitones / 12)
-    new_rate = 44100 * rate_mult
-    # atempo compensates for the tempo change caused by sample rate shift,
-    # restoring original playback speed (avoids A/V desync)
-    tempo = 1.0 / rate_mult
-    # atempo supports 0.5-100.0; chain if needed
-    if tempo < 0.5:
-        chain_count = 2
-        while tempo ** (1 / chain_count) < 0.5:
-            chain_count += 1
-        tempo_val = tempo ** (1 / chain_count)
-        atempo_str = ",".join([f"atempo={tempo_val}"] * chain_count)
-    elif tempo > 100:
-        chain_count = 2
-        while tempo ** (1 / chain_count) > 100:
-            chain_count += 1
-        tempo_val = tempo ** (1 / chain_count)
-        atempo_str = ",".join([f"atempo={tempo_val}"] * chain_count)
-    else:
-        atempo_str = f"atempo={tempo}"
-    return f"asetrate={new_rate},aresample=44100,{atempo_str}"
-
-
-def apply_filter(
-    input_path: str,
-    filter_type: FilterType,
-    params: dict[str, Any] | None = None,
-    output_path: str | None = None,
-    crf: int | None = None,
-    preset: str | None = None,
-) -> EditResult:
-    """Apply a visual filter to a video.
-
-    Args:
-        input_path: Path to the input video.
-        filter_type: One of the supported filter types.
-        params: Optional parameters for the filter.
-        output_path: Where to save the output.
-    """
-    _validate_input(input_path)
-    params = params or {}
-    output = output_path or _auto_output(input_path, f"filter_{filter_type}")
-
-    # Sanitize numeric params to prevent injection via non-numeric input.
-    # Skip known string params (e.g. "preset" for color_preset filter).
-    _STRING_PARAMS = {"preset"}
-    for key in params:
-        if key not in _STRING_PARAMS:
-            params[key] = _sanitize_ffmpeg_number(params[key], key)
-
-    # Probe video dimensions for ken_burns filter
-    info = probe(input_path)
-
-    # Build the -vf filter string
-    # Audio filters use -af; video filters use -vf.
-    # filter_map entries: (filter_name, filter_string, is_audio)
-    filter_map: dict[FilterType, tuple[str, str, bool]] = {
-        "blur": ("boxblur", f"boxblur={params.get('radius', 5)}:{params.get('strength', 1)}", False),
-        "sharpen": ("unsharp", f"unsharp=5:5:{params.get('amount', 1.0)}:5:5:0.0", False),
-        "brightness": ("eq", f"eq=brightness={params.get('level', 0.1)}", False),
-        "contrast": ("eq", f"eq=contrast={params.get('level', 1.5)}", False),
-        "saturation": ("eq", f"eq=saturation={params.get('level', 1.5)}", False),
-        "grayscale": ("hue", "hue=s=0", False),
-        "sepia": ("colorchannelmixer", "colorchannelmixer=.393:.769:.189:0:.349:.686:.168:0:.272:.534:.131", False),
-        "invert": ("negate", "negate", False),
-        "vignette": ("vignette", f"vignette=angle={params.get('angle', 'PI/4')}", False),
-        "color_preset": ("eq", _get_color_preset_filter(params.get("preset", "warm")), False),
-        "denoise": (
-            "hqdn3d",
-            f"hqdn3d={params.get('luma_spatial', 4)}:{params.get('chroma_spatial', 3)}:{params.get('luma_tmp', 6)}:{params.get('chroma_tmp', 4.5)}",
-            False,
-        ),
-        "deinterlace": ("yadif", "yadif=0:-1:0", False),
-        "ken_burns": (
-            "zoompan",
-            f"zoompan=z='min(zoom+{params.get('zoom_speed', 0.0015)},1.5)':d={params.get('duration', 150)}:x='iw/2-(iw/zoom)/2':y='ih/2-(ih/zoom)/2':s={info.width}x{info.height}",
-            False,
-        ),
-        "reverb": (
-            "aecho",
-            f"aecho={params.get('in_gain', 0.8)}:{params.get('out_gain', 0.9)}:{params.get('delays', 60)}:{params.get('decay', 0.2)}",
-            True,
-        ),
-        "compressor": (
-            "acompressor",
-            f"acompressor=threshold={params.get('threshold_db', -20)}dB:ratio={params.get('ratio', 4)}:attack={params.get('attack', 5)}:release={params.get('release', 50)}",
-            True,
-        ),
-        "pitch_shift": ("asetrate", _build_pitch_shift_filter(params.get("semitones", 0)), True),
-        "noise_reduction": ("afftdn", f"afftdn=nf={params.get('noise_level', -25)}", True),
-    }
-
-    if filter_type not in filter_map:
-        valid = ", ".join(sorted(filter_map))
-        raise MCPVideoError(
-            f"Unknown filter type '{filter_type}'. Valid types: {valid}",
-            error_type="validation_error",
-            code="invalid_filter_type",
-        )
-    filter_name, filter_string, is_audio = filter_map[filter_type]
-    _require_filter(filter_name, f"Filter '{filter_type}'")
-
-    # Audio filters require an audio stream and use -af instead of -vf
-    if is_audio:
-        input_info = probe(input_path)
-        if input_info.audio_codec is None:
-            raise MCPVideoError(
-                f"Audio filter '{filter_type}' requires an audio stream, but this video has none",
-                error_type="validation_error",
-                code="audio_filter_no_audio",
-            )
-        _run_ffmpeg(
-            [
-                "-i",
-                input_path,
-                "-af",
-                filter_string,
-                "-c:v",
-                "copy",
-                "-c:a",
-                "aac",
-                "-b:a",
-                "128k",
-                *_movflags_args(output),
-                output,
-            ]
-        )
-    else:
-        _run_ffmpeg(
-            [
-                "-i",
-                input_path,
-                "-vf",
-                filter_string,
-                "-c:v",
-                "libx264",
-                *_quality_args(crf=crf, preset=preset),
-                "-c:a",
-                "copy",
-                *_movflags_args(output),
-                output,
-            ]
-        )
-
-    info = probe(output)
-    return EditResult(
-        output_path=output,
-        duration=info.duration,
-        resolution=info.resolution,
-        size_mb=info.size_mb,
-        format="mp4",
-        operation=f"filter_{filter_type}",
-    )
 
 
 # ---------------------------------------------------------------------------

--- a/mcp_video/engine_filters.py
+++ b/mcp_video/engine_filters.py
@@ -14,7 +14,7 @@ from .engine_runtime_utils import (
     _sanitize_ffmpeg_number,
 )
 from .errors import MCPVideoError
-from .ffmpeg_helpers import _escape_ffmpeg_filter_value, _run_ffmpeg, _validate_input_path
+from .ffmpeg_helpers import _escape_ffmpeg_filter_value, _run_ffmpeg as _run_ffmpeg_cmd, _validate_input_path
 from .models import ColorPreset, EditResult, FilterType
 
 
@@ -169,10 +169,8 @@ def _run_audio_filter(input_path: str, filter_type: FilterType, filter_string: s
             error_type="validation_error",
             code="audio_filter_no_audio",
         )
-    _run_ffmpeg(
+    _run_filter_ffmpeg(
         [
-            _ffmpeg(),
-            "-y",
             "-i",
             input_path,
             "-af",
@@ -190,10 +188,8 @@ def _run_audio_filter(input_path: str, filter_type: FilterType, filter_string: s
 
 
 def _run_video_filter(input_path: str, filter_string: str, output: str, crf: int | None, preset: str | None) -> None:
-    _run_ffmpeg(
+    _run_filter_ffmpeg(
         [
-            _ffmpeg(),
-            "-y",
             "-i",
             input_path,
             "-vf",
@@ -207,3 +203,8 @@ def _run_video_filter(input_path: str, filter_string: str, output: str, crf: int
             output,
         ]
     )
+
+
+def _run_filter_ffmpeg(args: list[str]) -> None:
+    """Run an FFmpeg filter command through the canonical subprocess helper."""
+    _run_ffmpeg_cmd([_ffmpeg(), "-y", *args])

--- a/mcp_video/engine_filters.py
+++ b/mcp_video/engine_filters.py
@@ -7,15 +7,14 @@ from typing import Any
 from .engine_probe import probe
 from .engine_runtime_utils import (
     _auto_output,
+    _ffmpeg,
     _movflags_args,
     _quality_args,
     _require_filter,
-    _run_ffmpeg,
     _sanitize_ffmpeg_number,
-    _validate_input,
 )
 from .errors import MCPVideoError
-from .ffmpeg_helpers import _escape_ffmpeg_filter_value
+from .ffmpeg_helpers import _escape_ffmpeg_filter_value, _run_ffmpeg, _validate_input_path
 from .models import ColorPreset, EditResult, FilterType
 
 
@@ -70,7 +69,7 @@ def apply_filter(
     preset: str | None = None,
 ) -> EditResult:
     """Apply a visual or audio filter to a video."""
-    _validate_input(input_path)
+    _validate_input_path(input_path)
     params = _sanitize_params(params or {})
     output = output_path or _auto_output(input_path, f"filter_{filter_type}")
     info = probe(input_path)
@@ -172,6 +171,8 @@ def _run_audio_filter(input_path: str, filter_type: FilterType, filter_string: s
         )
     _run_ffmpeg(
         [
+            _ffmpeg(),
+            "-y",
             "-i",
             input_path,
             "-af",
@@ -191,6 +192,8 @@ def _run_audio_filter(input_path: str, filter_type: FilterType, filter_string: s
 def _run_video_filter(input_path: str, filter_string: str, output: str, crf: int | None, preset: str | None) -> None:
     _run_ffmpeg(
         [
+            _ffmpeg(),
+            "-y",
             "-i",
             input_path,
             "-vf",

--- a/mcp_video/engine_filters.py
+++ b/mcp_video/engine_filters.py
@@ -7,14 +7,14 @@ from typing import Any
 from .engine_probe import probe
 from .engine_runtime_utils import (
     _auto_output,
-    _ffmpeg,
     _movflags_args,
     _quality_args,
     _require_filter,
+    _run_ffmpeg,
     _sanitize_ffmpeg_number,
 )
 from .errors import MCPVideoError
-from .ffmpeg_helpers import _escape_ffmpeg_filter_value, _run_ffmpeg as _run_ffmpeg_cmd, _validate_input_path
+from .ffmpeg_helpers import _escape_ffmpeg_filter_value, _validate_input_path
 from .models import ColorPreset, EditResult, FilterType
 
 
@@ -206,5 +206,5 @@ def _run_video_filter(input_path: str, filter_string: str, output: str, crf: int
 
 
 def _run_filter_ffmpeg(args: list[str]) -> None:
-    """Run an FFmpeg filter command through the canonical subprocess helper."""
-    _run_ffmpeg_cmd([_ffmpeg(), "-y", *args])
+    """Run an FFmpeg filter command while preserving engine error parsing."""
+    _run_ffmpeg(args)

--- a/mcp_video/engine_filters.py
+++ b/mcp_video/engine_filters.py
@@ -1,0 +1,206 @@
+"""Video and audio filter operations for the FFmpeg engine."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .engine_probe import probe
+from .engine_runtime_utils import (
+    _auto_output,
+    _movflags_args,
+    _quality_args,
+    _require_filter,
+    _run_ffmpeg,
+    _sanitize_ffmpeg_number,
+    _validate_input,
+)
+from .errors import MCPVideoError
+from .ffmpeg_helpers import _escape_ffmpeg_filter_value
+from .models import ColorPreset, EditResult, FilterType
+
+
+def _get_color_preset_filter(preset: ColorPreset) -> str:
+    """Return FFmpeg eq filter string for a named color preset."""
+    preset_filters: dict[ColorPreset, str] = {
+        "warm": "eq=brightness=0.05:saturation=1.3:contrast=1.05",
+        "cool": "eq=brightness=0.02:saturation=0.9:contrast=1.05",
+        "vintage": "eq=contrast=1.1:brightness=-0.02:saturation=0.7",
+        "cinematic": "eq=contrast=1.15:brightness=-0.03:saturation=0.85",
+        "noir": "eq=contrast=1.3:brightness=-0.05:saturation=0.0",
+    }
+    if preset not in preset_filters:
+        valid = ", ".join(sorted(preset_filters))
+        raise MCPVideoError(
+            f"Unknown color preset '{preset}'. Valid presets: {valid}",
+            error_type="validation_error",
+            code="invalid_color_preset",
+        )
+    return preset_filters[preset]
+
+
+def _build_pitch_shift_filter(semitones: float = 0) -> str:
+    """Build FFmpeg audio filter string for pitch shifting."""
+    safe_semitones = _sanitize_ffmpeg_number(semitones, "semitones")
+    rate_mult = 2 ** (safe_semitones / 12)
+    new_rate = 44100 * rate_mult
+    tempo = 1.0 / rate_mult
+    if tempo < 0.5:
+        chain_count = 2
+        while tempo ** (1 / chain_count) < 0.5:
+            chain_count += 1
+        tempo_val = tempo ** (1 / chain_count)
+        atempo_str = ",".join([f"atempo={_safe_filter_number(tempo_val, 'atempo')}"] * chain_count)
+    elif tempo > 100:
+        chain_count = 2
+        while tempo ** (1 / chain_count) > 100:
+            chain_count += 1
+        tempo_val = tempo ** (1 / chain_count)
+        atempo_str = ",".join([f"atempo={_safe_filter_number(tempo_val, 'atempo')}"] * chain_count)
+    else:
+        atempo_str = f"atempo={_safe_filter_number(tempo, 'atempo')}"
+    return f"asetrate={_safe_filter_number(new_rate, 'sample_rate')},aresample=44100,{atempo_str}"
+
+
+def apply_filter(
+    input_path: str,
+    filter_type: FilterType,
+    params: dict[str, Any] | None = None,
+    output_path: str | None = None,
+    crf: int | None = None,
+    preset: str | None = None,
+) -> EditResult:
+    """Apply a visual or audio filter to a video."""
+    _validate_input(input_path)
+    params = _sanitize_params(params or {})
+    output = output_path or _auto_output(input_path, f"filter_{filter_type}")
+    info = probe(input_path)
+
+    filter_map = _filter_map(params, info.width, info.height)
+    if filter_type not in filter_map:
+        valid = ", ".join(sorted(filter_map))
+        raise MCPVideoError(
+            f"Unknown filter type '{filter_type}'. Valid types: {valid}",
+            error_type="validation_error",
+            code="invalid_filter_type",
+        )
+    filter_name, filter_string, is_audio = filter_map[filter_type]
+    _require_filter(filter_name, f"Filter '{filter_type}'")
+
+    if is_audio:
+        _run_audio_filter(input_path, filter_type, filter_string, output)
+    else:
+        _run_video_filter(input_path, filter_string, output, crf, preset)
+
+    result_info = probe(output)
+    return EditResult(
+        output_path=output,
+        duration=result_info.duration,
+        resolution=result_info.resolution,
+        size_mb=result_info.size_mb,
+        format="mp4",
+        operation=f"filter_{filter_type}",
+    )
+
+
+def _sanitize_params(params: dict[str, Any]) -> dict[str, Any]:
+    sanitized = dict(params)
+    for key in sanitized:
+        if key != "preset":
+            sanitized[key] = _sanitize_ffmpeg_number(sanitized[key], key)
+    return sanitized
+
+
+def _filter_map(params: dict[str, Any], width: int, height: int) -> dict[FilterType, tuple[str, str, bool]]:
+    return {
+        "blur": ("boxblur", f"boxblur={_param(params, 'radius', 5)}:{_param(params, 'strength', 1)}", False),
+        "sharpen": ("unsharp", f"unsharp=5:5:{_param(params, 'amount', 1.0)}:5:5:0.0", False),
+        "brightness": ("eq", f"eq=brightness={_param(params, 'level', 0.1)}", False),
+        "contrast": ("eq", f"eq=contrast={_param(params, 'level', 1.5)}", False),
+        "saturation": ("eq", f"eq=saturation={_param(params, 'level', 1.5)}", False),
+        "grayscale": ("hue", "hue=s=0", False),
+        "sepia": ("colorchannelmixer", "colorchannelmixer=.393:.769:.189:0:.349:.686:.168:0:.272:.534:.131", False),
+        "invert": ("negate", "negate", False),
+        "vignette": ("vignette", f"vignette=angle={_param(params, 'angle', 'PI/4')}", False),
+        "color_preset": ("eq", _get_color_preset_filter(params.get("preset", "warm")), False),
+        "denoise": (
+            "hqdn3d",
+            f"hqdn3d={_param(params, 'luma_spatial', 4)}:{_param(params, 'chroma_spatial', 3)}:{_param(params, 'luma_tmp', 6)}:{_param(params, 'chroma_tmp', 4.5)}",
+            False,
+        ),
+        "deinterlace": ("yadif", "yadif=0:-1:0", False),
+        "ken_burns": (
+            "zoompan",
+            f"zoompan=z='min(zoom+{_param(params, 'zoom_speed', 0.0015)},1.5)':d={_param(params, 'duration', 150)}:x='iw/2-(iw/zoom)/2':y='ih/2-(ih/zoom)/2':s={_safe_filter_int(width, 'width')}x{_safe_filter_int(height, 'height')}",
+            False,
+        ),
+        "reverb": (
+            "aecho",
+            f"aecho={_param(params, 'in_gain', 0.8)}:{_param(params, 'out_gain', 0.9)}:{_param(params, 'delays', 60)}:{_param(params, 'decay', 0.2)}",
+            True,
+        ),
+        "compressor": (
+            "acompressor",
+            f"acompressor=threshold={_param(params, 'threshold_db', -20)}dB:ratio={_param(params, 'ratio', 4)}:attack={_param(params, 'attack', 5)}:release={_param(params, 'release', 50)}",
+            True,
+        ),
+        "pitch_shift": ("asetrate", _build_pitch_shift_filter(params.get("semitones", 0)), True),
+        "noise_reduction": ("afftdn", f"afftdn=nf={_param(params, 'noise_level', -25)}", True),
+    }
+
+
+def _param(params: dict[str, Any], key: str, default: Any) -> str:
+    if key not in params and isinstance(default, str):
+        return _escape_ffmpeg_filter_value(default)
+    return _safe_filter_number(params.get(key, default), key)
+
+
+def _safe_filter_number(value: Any, name: str) -> str:
+    return _escape_ffmpeg_filter_value(str(_sanitize_ffmpeg_number(value, name)))
+
+
+def _safe_filter_int(value: Any, name: str) -> str:
+    return _escape_ffmpeg_filter_value(str(int(_sanitize_ffmpeg_number(value, name))))
+
+
+def _run_audio_filter(input_path: str, filter_type: FilterType, filter_string: str, output: str) -> None:
+    input_info = probe(input_path)
+    if input_info.audio_codec is None:
+        raise MCPVideoError(
+            f"Audio filter '{filter_type}' requires an audio stream, but this video has none",
+            error_type="validation_error",
+            code="audio_filter_no_audio",
+        )
+    _run_ffmpeg(
+        [
+            "-i",
+            input_path,
+            "-af",
+            filter_string,
+            "-c:v",
+            "copy",
+            "-c:a",
+            "aac",
+            "-b:a",
+            "128k",
+            *_movflags_args(output),
+            output,
+        ]
+    )
+
+
+def _run_video_filter(input_path: str, filter_string: str, output: str, crf: int | None, preset: str | None) -> None:
+    _run_ffmpeg(
+        [
+            "-i",
+            input_path,
+            "-vf",
+            filter_string,
+            "-c:v",
+            "libx264",
+            *_quality_args(crf=crf, preset=preset),
+            "-c:a",
+            "copy",
+            *_movflags_args(output),
+            output,
+        ]
+    )

--- a/mcp_video/engine_runtime_utils.py
+++ b/mcp_video/engine_runtime_utils.py
@@ -18,7 +18,7 @@ from .errors import (
     MCPVideoError,
     parse_ffmpeg_error,
 )
-from .limits import DEFAULT_CRF, DEFAULT_PRESET
+from .limits import DEFAULT_CRF, DEFAULT_FFMPEG_TIMEOUT, DEFAULT_PRESET
 from .models import NamedPosition, Position
 
 # ---------------------------------------------------------------------------
@@ -307,7 +307,7 @@ def _run_ffmpeg(args: list[str]) -> subprocess.CompletedProcess[str]:
         cmd,
         capture_output=True,
         text=True,
-        timeout=600,  # 10-minute max
+        timeout=DEFAULT_FFMPEG_TIMEOUT,
     )
     if proc.returncode != 0:
         raise parse_ffmpeg_error(proc.stderr)

--- a/mcp_video/engine_runtime_utils.py
+++ b/mcp_video/engine_runtime_utils.py
@@ -18,6 +18,7 @@ from .errors import (
     MCPVideoError,
     parse_ffmpeg_error,
 )
+from .limits import DEFAULT_CRF, DEFAULT_PRESET
 from .models import NamedPosition, Position
 
 # ---------------------------------------------------------------------------
@@ -427,8 +428,8 @@ def _movflags_args(output_path: str) -> list[str]:
 def _quality_args(
     crf: int | None = None,
     preset: str | None = None,
-    default_crf: int = 23,
-    default_preset: str = "fast",
+    default_crf: int = DEFAULT_CRF,
+    default_preset: str = DEFAULT_PRESET,
 ) -> list[str]:
     """Build FFmpeg quality args [-preset, X, -crf, Y].
 

--- a/mcp_video/limits.py
+++ b/mcp_video/limits.py
@@ -27,6 +27,8 @@ MAX_SPEED_FACTOR = 100.0
 # Encoding parameter bounds
 MAX_CRF = 51
 MIN_CRF = 0
+DEFAULT_CRF = 23
+DEFAULT_PRESET = "fast"
 
 # Network / concurrency bounds
 MAX_PORT = 65535


### PR DESCRIPTION
## Why
`apply_filter` is the next major engine island after the composition/batch extractions. It is broader than prior slices, but it has focused coverage across visual filters, audio filters, validation, CLI, server, and red-team tests.

## What changed
- Added `mcp_video/engine_filters.py`.
- Kept `mcp_video.engine.apply_filter`, `_get_color_preset_filter`, and `_build_pitch_shift_filter` as compatibility exports.
- Moved filter map construction and audio/video filter execution into focused helpers.
- Preserved existing filter behavior while escaping sanitized numeric values before FFmpeg filter-string interpolation.
- Kept `convert` and timeline/composite operations untouched.

## Verification
- `ruff check mcp_video/engine.py mcp_video/engine_filters.py`
- `ruff format --check mcp_video/engine.py mcp_video/engine_filters.py`
- `python3 -m pytest tests/test_engine_advanced.py -k 'ApplyFilter or ColorPresetFilter or FilterValidation or AudioEffects or KenBurns' -q --tb=short`
- `python3 -m pytest tests/test_cli.py -k 'filter or blur' tests/test_server.py -k 'filter or blur' tests/test_red_team.py -k 'apply_filter' -q --tb=short`
- `python3 -m pytest tests/test_engine.py tests/test_e2e.py tests/test_server.py -q --tb=short`

Not run: full slow/real-media suite.
