### PR TITLE
Add integration smoke workflow

### DIFF
--- a/.github/workflows/integration-smoke.yml
+++ b/.github/workflows/integration-smoke.yml
@@ -1,0 +1,159 @@
+name: Integration smoke
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [master]
+    paths:
+      - "mcp_video/**"
+      - "tests/**"
+      - "pyproject.toml"
+      - "uv.lock"
+      - ".github/workflows/integration-smoke.yml"
+  push:
+    branches: [master]
+    paths:
+      - "mcp_video/**"
+      - "tests/**"
+      - "pyproject.toml"
+      - "uv.lock"
+      - ".github/workflows/integration-smoke.yml"
+
+jobs:
+  base-cli-and-doctor:
+    name: Base CLI and doctor
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+      - name: Install base package
+        run: pip install -e .
+      - name: Import package and public facades
+        run: |
+          python - <<'PY'
+          import mcp_video
+          import mcp_video.engine
+          import mcp_video.server
+          from mcp_video.client import Client
+          from mcp_video.engine import convert, edit_timeline, video_batch
+          print(mcp_video.__version__, Client.__name__, convert.__name__, edit_timeline.__name__, video_batch.__name__)
+          PY
+      - name: CLI help and version
+        run: |
+          python -m mcp_video --version
+          python -m mcp_video --help
+          python -m mcp_video doctor --json | python -m json.tool >/tmp/mcp-video-doctor.json
+      - name: Validate doctor JSON
+        run: |
+          python - <<'PY'
+          import json
+          data = json.load(open("/tmp/mcp-video-doctor.json"))
+          assert data["success"] is True
+          assert "required_ok" in data["summary"]
+          assert any(check["name"] == "ffmpeg" for check in data["checks"])
+          PY
+
+  ffmpeg-smoke:
+    name: FFmpeg operation smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+      - name: Install FFmpeg
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends ffmpeg
+      - name: Install package
+        run: pip install -e .
+      - name: Create sample video
+        run: |
+          ffmpeg -y -f lavfi -i testsrc=size=160x120:rate=15 -f lavfi -i sine=frequency=440:sample_rate=44100 -t 1 -c:v libx264 -pix_fmt yuv420p -c:a aac sample.mp4
+      - name: Smoke core FFmpeg path
+        run: |
+          python -m mcp_video --format json info sample.mp4 | python -m json.tool >/tmp/info.json
+          python -m mcp_video --format json trim sample.mp4 --start 0 --duration 0.5 -o trimmed.mp4 | python -m json.tool >/tmp/trim.json
+          test -s trimmed.mp4
+
+  image-extra-smoke:
+    name: Image extra smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+      - name: Install image extra
+        run: pip install -e ".[image]"
+      - name: Import image dependencies and analyze tiny image
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+          from PIL import Image
+          import sklearn
+          import webcolors
+          from mcp_video.image_engine import extract_colors
+
+          path = Path("sample.png")
+          Image.new("RGB", (8, 8), (255, 0, 0)).save(path)
+          result = extract_colors(str(path), n_colors=1)
+          assert result.success is True
+          assert result.colors
+          print(sklearn.__version__, webcolors.__name__, result.colors[0].hex)
+          PY
+
+  remotion-command-smoke:
+    name: Remotion command smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "20"
+      - name: Install base package
+        run: pip install -e .
+      - name: Check Node/npm/npx and doctor reporting
+        run: |
+          node --version
+          npm --version
+          npx --version
+          python -m mcp_video doctor --json | python -m json.tool >/tmp/doctor.json
+          python - <<'PY'
+          import json
+          data = json.load(open("/tmp/doctor.json"))
+          remotion = [check for check in data["checks"] if check["category"] == "remotion"]
+          assert remotion
+          assert any(check["name"] == "node" and check["ok"] for check in remotion)
+          PY
+
+  ai-module-smoke:
+    name: AI module metadata smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+      - name: Install base package
+        run: pip install -e .
+      - name: Import AI module without heavyweight extras
+        run: |
+          python - <<'PY'
+          import mcp_video.ai_engine as ai_engine
+          from mcp_video.doctor import run_diagnostics
+
+          report = run_diagnostics()
+          ai_checks = [check for check in report["checks"] if check["category"] == "ai"]
+          assert ai_checks
+          assert all(check["required"] is False for check in ai_checks)
+          assert hasattr(ai_engine, "ai_transcribe")
+          PY

--- a/docs/repository-audit-checklist.md
+++ b/docs/repository-audit-checklist.md
@@ -51,6 +51,22 @@ This validates:
 - package metadata URLs exist
 - local tag visibility (release hygiene signal)
 
+## 3.5) Integration smoke (before releases)
+
+Run the dedicated smoke workflow after packaging or integration changes:
+
+```bash
+gh workflow run "Integration smoke"
+```
+
+This validates:
+- base install imports and CLI help/version
+- `mcp-video doctor --json`
+- a minimal FFmpeg trim path
+- image extra import and tiny image color extraction
+- Node/npm/npx availability reporting for Remotion
+- AI module import and optional dependency reporting without installing heavyweight AI stacks
+
 ## 4) Documentation quality (weekly)
 
 - README: accurate tool counts, install instructions, and quick-start snippets.


### PR DESCRIPTION
The main CI suite is broad but does not isolate integration assumptions. This workflow adds lightweight smoke lanes for base import/CLI/doctor, FFmpeg operation execution, image extras, Remotion command availability, and AI optional-dependency metadata without installing heavyweight AI stacks.

Constraint: Keep this separate from required CI until the workflow proves stable.

Rejected: Install full AI extras in smoke CI | torch/realesrgan/demucs stacks are expensive and platform-sensitive; doctor metadata validates optional reporting without making base CI brittle.

Confidence: high

Scope-risk: narrow

Directive: Integration smoke should stay diagnostic and cheap; promote checks to required CI only after repeated green runs.

Tested: PyYAML parsed .github/workflows/integration-smoke.yml; git diff --check; python3 -c public import smoke; python3 -m mcp_video --version/--help/doctor --json; local FFmpeg trim smoke; local image extra color extraction smoke; local AI module/doctor metadata smoke; ./scripts/repo-readiness-audit.py

Not-tested: GitHub-hosted workflow execution for the new workflow.

## Why

<!-- Explain the user problem, bug, or maintenance risk this PR addresses. -->

## What changed

<!-- Keep this concrete and reviewable. -->

## Verification

<!-- Paste commands and outcomes. Prefer focused tests plus the relevant broader suite. -->

- [ ] `python3 -m pytest tests/ -x -q --tb=short`
- [ ] `python3 -c "import mcp_video"`
- [ ] `./scripts/git-professional-audit.sh`
- [ ] Other:

## Maintainer checklist

- [ ] Public MCP tool signatures are unchanged, or the compatibility impact is explained.
- [ ] New or changed FFmpeg filter strings escape user-controlled values with `_escape_ffmpeg_filter_value()`.
- [ ] Subprocess calls include a timeout and route FFmpeg failures through `ProcessingError`.
- [ ] New defaults live in `defaults.py`; validation constants live in `validation.py` or `limits.py`.
- [ ] No generated media, logs, caches, local research dumps, or build artifacts were committed.
- [ ] Documentation, README counts, or roadmap entries were updated when the public surface changed.
