### PR TITLE
Split AI extras into focused install groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,16 @@ mcp-video template tiktok video.mp4 --caption "Check this out!"
 | `video_ai_color_grade` | Auto color grading with style presets or reference matching | FFmpeg |
 | `video_audio_spatial` | 3D spatial audio positioning (azimuth + elevation) | FFmpeg |
 
+Install only the AI dependencies you need:
+
+```bash
+pip install "mcp-video[transcribe]"  # Whisper transcription
+pip install "mcp-video[ai-scene]"    # perceptual scene hashing
+pip install "mcp-video[stems]"       # Demucs stem separation
+pip install "mcp-video[upscale]"     # Real-ESRGAN/OpenCV upscaling
+pip install "mcp-video[ai]"          # all AI extras, kept for compatibility
+```
+
 ### Remotion & Motion Graphics (8 tools)
 
 Create videos programmatically using [Remotion](https://www.remotion.dev/) — a React framework for video. Scaffold projects, render compositions, then post-process with mcp-video.

--- a/mcp_video/doctor.py
+++ b/mcp_video/doctor.py
@@ -64,14 +64,15 @@ PACKAGE_CHECKS = (
     ("scikit-learn", "sklearn", "image", False, 'Install image extras: pip install "mcp-video[image]"'),
     ("webcolors", "webcolors", "image", False, 'Install image extras: pip install "mcp-video[image]"'),
     ("anthropic", "anthropic", "image-ai", False, 'Install image AI extras: pip install "mcp-video[image-ai]"'),
-    ("openai-whisper", "whisper", "ai", False, 'Install AI extras: pip install "mcp-video[ai]"'),
-    ("demucs", "demucs", "ai", False, 'Install AI extras: pip install "mcp-video[ai]"'),
-    ("realesrgan", "realesrgan", "ai", False, 'Install AI extras: pip install "mcp-video[ai]"'),
-    ("basicsr", "basicsr", "ai", False, 'Install AI extras: pip install "mcp-video[ai]"'),
-    ("opencv-contrib-python", "cv2", "ai", False, 'Install AI extras: pip install "mcp-video[ai]"'),
-    ("torch", "torch", "ai", False, 'Install AI extras: pip install "mcp-video[ai]"'),
-    ("torchaudio", "torchaudio", "ai", False, 'Install AI extras: pip install "mcp-video[ai]"'),
-    ("imagehash", "imagehash", "ai", False, 'Install AI extras: pip install "mcp-video[ai]"'),
+    ("openai-whisper", "whisper", "ai", False, 'Install transcription extras: pip install "mcp-video[transcribe]"'),
+    ("demucs", "demucs", "ai", False, 'Install stem-separation extras: pip install "mcp-video[stems]"'),
+    ("realesrgan", "realesrgan", "ai", False, 'Install upscale extras: pip install "mcp-video[upscale]"'),
+    ("basicsr", "basicsr", "ai", False, 'Install upscale extras: pip install "mcp-video[upscale]"'),
+    ("numpy", "numpy", "ai", False, 'Install upscale extras: pip install "mcp-video[upscale]"'),
+    ("opencv-contrib-python", "cv2", "ai", False, 'Install upscale extras: pip install "mcp-video[upscale]"'),
+    ("torch", "torch", "ai", False, 'Install stem/upscale extras: pip install "mcp-video[stems]" or "mcp-video[upscale]"'),
+    ("torchaudio", "torchaudio", "ai", False, 'Install stem-separation extras: pip install "mcp-video[stems]"'),
+    ("imagehash", "imagehash", "ai", False, 'Install AI scene extras: pip install "mcp-video[ai-scene]"'),
 )
 
 

--- a/mcp_video/doctor.py
+++ b/mcp_video/doctor.py
@@ -70,7 +70,13 @@ PACKAGE_CHECKS = (
     ("basicsr", "basicsr", "ai", False, 'Install upscale extras: pip install "mcp-video[upscale]"'),
     ("numpy", "numpy", "ai", False, 'Install upscale extras: pip install "mcp-video[upscale]"'),
     ("opencv-contrib-python", "cv2", "ai", False, 'Install upscale extras: pip install "mcp-video[upscale]"'),
-    ("torch", "torch", "ai", False, 'Install stem/upscale extras: pip install "mcp-video[stems]" or "mcp-video[upscale]"'),
+    (
+        "torch",
+        "torch",
+        "ai",
+        False,
+        'Install stem/upscale extras: pip install "mcp-video[stems]" or "mcp-video[upscale]"',
+    ),
     ("torchaudio", "torchaudio", "ai", False, 'Install stem-separation extras: pip install "mcp-video[stems]"'),
     ("imagehash", "imagehash", "ai", False, 'Install AI scene extras: pip install "mcp-video[ai-scene]"'),
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,30 @@ client = ["pillow>=10.0"]
 image = ["pillow>=10.0", "scikit-learn>=1.3", "webcolors>=1.13"]
 image-ai = ["pillow>=10.0", "scikit-learn>=1.3", "webcolors>=1.13", "anthropic>=0.96.0"]
 remotion = []  # External: Node.js + Remotion CLI (npx remotion)
+transcribe = ["openai-whisper>=20231117"]
+ai-scene = ["imagehash>=4.3", "Pillow>=10.0"]
+stems = ["demucs>=4.0", "torch>=2.0", "torchaudio>=2.0"]
+upscale = [
+    "realesrgan>=0.3",
+    "basicsr>=1.4",
+    "numpy>=2.4.4",
+    "opencv-contrib-python>=4.10",
+    "torch>=2.0",
+    "Pillow>=10.0",
+]
 ai = [
+    "openai-whisper>=20231117",
+    "demucs>=4.0",
+    "realesrgan>=0.3",
+    "basicsr>=1.4",
+    "numpy>=2.4.4",
+    "opencv-contrib-python>=4.10",
+    "torch>=2.0",
+    "torchaudio>=2.0",
+    "imagehash>=4.3",
+    "Pillow>=10.0",
+]
+all-ai = [
     "openai-whisper>=20231117",
     "demucs>=4.0",
     "realesrgan>=0.3",

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -89,6 +89,10 @@ def test_run_diagnostics_checks_optional_packages_without_importing_them():
     assert checks["scikit-learn"]["ok"] is True
     assert checks["openai-whisper"]["ok"] is False
     assert checks["openai-whisper"]["required"] is False
+    assert 'mcp-video[transcribe]' in checks["openai-whisper"]["install_hint"]
+    assert 'mcp-video[stems]' in checks["demucs"]["install_hint"]
+    assert 'mcp-video[upscale]' in checks["opencv-contrib-python"]["install_hint"]
+    assert 'mcp-video[ai-scene]' in checks["imagehash"]["install_hint"]
 
 
 def test_run_diagnostics_requires_matching_distribution_for_package_checks():
@@ -142,4 +146,4 @@ def test_cli_doctor_text_outputs_summary():
     assert result.returncode == 0
     assert "mcp-video doctor" in result.stdout
     assert "ffmpeg" in result.stdout
-    assert "mcp-video[ai]" in result.stdout
+    assert "openai-whisper" in result.stdout


### PR DESCRIPTION
## Why
The audit plan calls out optional dependency install risk: `mcp-video[ai]` is heavy and platform-sensitive. Users should be able to install only the AI feature family they need, while existing `mcp-video[ai]` instructions keep working.

## What changed
- Added focused extras:
  - `transcribe` for Whisper transcription
  - `ai-scene` for perceptual scene hashing
  - `stems` for Demucs stem separation
  - `upscale` for Real-ESRGAN/OpenCV upscaling
  - `all-ai` as an explicit aggregate alias
- Kept `ai` as the existing aggregate for compatibility.
- Updated `mcp-video doctor` hints to name the smallest relevant extra.
- Added README install examples for the focused AI extras.

## Verification
- pyproject TOML parse and `all-ai` equals `ai`
- `python3 -m pytest tests/test_doctor.py -q --tb=short`
- `ruff check pyproject.toml mcp_video/doctor.py tests/test_doctor.py README.md`
- `python3 -m mcp_video doctor --json`
- `python3 -m pytest tests/test_public_surface.py tests/test_adversarial_audit.py -q --tb=short`
- `./scripts/repo-readiness-audit.py`
- `python3 -m build --sdist --wheel --outdir /tmp/mcp-video-ai-extras-dist`
- `python3 .github/scripts/check-built-artifacts.py /tmp/mcp-video-ai-extras-dist`

Not run: installing every new optional extra group in a clean environment.
