### PR TITLE
Format test suite with Ruff

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,13 +36,26 @@ def sample_video(tmp_path_factory) -> str:
     # Generate a test video: 3 seconds, 640x480, color bars + sine audio
     subprocess.run(
         [
-            "ffmpeg", "-y",
-            "-f", "lavfi",
-            "-i", "smptehdbars=size=640x480:duration=3:rate=30",
-            "-f", "lavfi",
-            "-i", "sine=frequency=440:duration=3",
-            "-c:v", "libx264", "-preset", "ultrafast", "-crf", "23",
-            "-c:a", "aac", "-b:a", "128k",
+            "ffmpeg",
+            "-y",
+            "-f",
+            "lavfi",
+            "-i",
+            "smptehdbars=size=640x480:duration=3:rate=30",
+            "-f",
+            "lavfi",
+            "-i",
+            "sine=frequency=440:duration=3",
+            "-c:v",
+            "libx264",
+            "-preset",
+            "ultrafast",
+            "-crf",
+            "23",
+            "-c:a",
+            "aac",
+            "-b:a",
+            "128k",
             "-shortest",
             video_path,
         ],
@@ -66,10 +79,16 @@ def sample_audio(tmp_path_factory) -> str:
 
     subprocess.run(
         [
-            "ffmpeg", "-y",
-            "-f", "lavfi",
-            "-i", "sine=frequency=880:duration=5",
-            "-c:a", "libmp3lame", "-b:a", "192k",
+            "ffmpeg",
+            "-y",
+            "-f",
+            "lavfi",
+            "-i",
+            "sine=frequency=880:duration=5",
+            "-c:a",
+            "libmp3lame",
+            "-b:a",
+            "192k",
             audio_path,
         ],
         capture_output=True,
@@ -88,13 +107,7 @@ def sample_srt(tmp_path_factory) -> str:
     srt_dir = tmp_path_factory.mktemp("subs")
     srt_path = srt_dir / "test.srt"
     srt_path.write_text(
-        "1\n"
-        "00:00:00,000 --> 00:00:02,000\n"
-        "Hello World\n"
-        "\n"
-        "2\n"
-        "00:00:02,000 --> 00:00:04,000\n"
-        "This is a test\n"
+        "1\n00:00:00,000 --> 00:00:02,000\nHello World\n\n2\n00:00:02,000 --> 00:00:04,000\nThis is a test\n"
     )
     return str(srt_path)
 
@@ -105,13 +118,7 @@ def sample_vtt(tmp_path_factory) -> str:
     vtt_dir = tmp_path_factory.mktemp("subs")
     vtt_path = vtt_dir / "test.vtt"
     vtt_path.write_text(
-        "WEBVTT\n"
-        "\n"
-        "00:00:00.000 --> 00:00:02.000\n"
-        "Hello World\n"
-        "\n"
-        "00:00:02.000 --> 00:00:04.000\n"
-        "This is a test\n"
+        "WEBVTT\n\n00:00:00.000 --> 00:00:02.000\nHello World\n\n00:00:02.000 --> 00:00:04.000\nThis is a test\n"
     )
     return str(vtt_path)
 
@@ -128,10 +135,14 @@ def sample_watermark_png(tmp_path_factory) -> str:
     # Generate a 100x100 semi-transparent red square
     subprocess.run(
         [
-            "ffmpeg", "-y",
-            "-f", "lavfi",
-            "-i", "color=c=red@0.5:s=100x100:d=0.1",
-            "-frames:v", "1",
+            "ffmpeg",
+            "-y",
+            "-f",
+            "lavfi",
+            "-i",
+            "color=c=red@0.5:s=100x100:d=0.1",
+            "-frames:v",
+            "1",
             img_path,
         ],
         capture_output=True,
@@ -154,13 +165,22 @@ def sample_video_webm(tmp_path_factory) -> str:
 
     subprocess.run(
         [
-            "ffmpeg", "-y",
-            "-f", "lavfi",
-            "-i", "smptehdbars=size=640x480:duration=2:rate=30",
-            "-f", "lavfi",
-            "-i", "sine=frequency=440:duration=2",
-            "-c:v", "libvpx-vp9", "-crf", "35",
-            "-c:a", "libopus",
+            "ffmpeg",
+            "-y",
+            "-f",
+            "lavfi",
+            "-i",
+            "smptehdbars=size=640x480:duration=2:rate=30",
+            "-f",
+            "lavfi",
+            "-i",
+            "sine=frequency=440:duration=2",
+            "-c:v",
+            "libvpx-vp9",
+            "-crf",
+            "35",
+            "-c:a",
+            "libopus",
             "-shortest",
             video_path,
         ],
@@ -184,10 +204,18 @@ def sample_video_no_audio(tmp_path_factory) -> str:
 
     subprocess.run(
         [
-            "ffmpeg", "-y",
-            "-f", "lavfi",
-            "-i", "smptehdbars=size=640x480:duration=2:rate=30",
-            "-c:v", "libx264", "-preset", "ultrafast", "-crf", "23",
+            "ffmpeg",
+            "-y",
+            "-f",
+            "lavfi",
+            "-i",
+            "smptehdbars=size=640x480:duration=2:rate=30",
+            "-c:v",
+            "libx264",
+            "-preset",
+            "ultrafast",
+            "-crf",
+            "23",
             "-an",
             video_path,
         ],
@@ -212,13 +240,26 @@ def sample_video_2(tmp_path_factory) -> str:
     # Generate a test video: 3 seconds, 320x240, solid blue + sine audio
     subprocess.run(
         [
-            "ffmpeg", "-y",
-            "-f", "lavfi",
-            "-i", "color=c=blue:size=320x240:duration=3:rate=30",
-            "-f", "lavfi",
-            "-i", "sine=frequency=880:duration=3",
-            "-c:v", "libx264", "-preset", "ultrafast", "-crf", "23",
-            "-c:a", "aac", "-b:a", "128k",
+            "ffmpeg",
+            "-y",
+            "-f",
+            "lavfi",
+            "-i",
+            "color=c=blue:size=320x240:duration=3:rate=30",
+            "-f",
+            "lavfi",
+            "-i",
+            "sine=frequency=880:duration=3",
+            "-c:v",
+            "libx264",
+            "-preset",
+            "ultrafast",
+            "-crf",
+            "23",
+            "-c:a",
+            "aac",
+            "-b:a",
+            "128k",
             "-shortest",
             video_path,
         ],
@@ -263,7 +304,7 @@ def sample_remotion_project(tmp_path):
         "export const RemotionRoot: React.FC = () => {\n"
         "  return (\n"
         "    <>\n"
-        "      <Composition id=\"Test\" component={() => null} "
+        '      <Composition id="Test" component={() => null} '
         "durationInFrames={90} fps={30} compositionWidth={1920} "
         "compositionHeight={1080} />\n"
         "    </>\n"

--- a/tests/test_adversarial_audit.py
+++ b/tests/test_adversarial_audit.py
@@ -53,6 +53,7 @@ class TestErrorHandlingRobustness:
     def test_server_error_result_mcpvideoerror(self) -> None:
         """_error_result handles MCPVideoError correctly."""
         from mcp_video.server import _error_result
+
         err = InputFileError("/tmp/nonexistent.mp4")
         result = _error_result(err)
         assert result["success"] is False
@@ -62,6 +63,7 @@ class TestErrorHandlingRobustness:
     def test_server_error_result_generic_exception(self) -> None:
         """_error_result handles generic Exception without crash — sanitized for no detail leak."""
         from mcp_video.server import _error_result
+
         err = RuntimeError("unexpected failure")
         result = _error_result(err)
         assert result["success"] is False
@@ -171,12 +173,14 @@ class TestErrorTypeConsistency:
     def test_effects_engine_raises_processing_error(self) -> None:
         """effects_engine raises MCPVideoError (InputFileError), not RuntimeError."""
         from mcp_video.effects_engine import effect_vignette
+
         with pytest.raises(MCPVideoError):
             effect_vignette("/nonexistent/video.mp4", "/tmp/out.mp4")
 
     def test_transitions_engine_raises_processing_error(self) -> None:
         """transitions_engine raises MCPVideoError (InputFileError), not RuntimeError."""
         from mcp_video.transitions_engine import transition_pixelate
+
         with pytest.raises(MCPVideoError):
             transition_pixelate(
                 "/nonexistent/clip1.mp4",
@@ -199,6 +203,7 @@ class TestTimeoutProtection:
         """effects_engine subprocess.run calls include timeout parameter."""
         import inspect
         from mcp_video import ffmpeg_helpers
+
         # Timeout lives in the shared ffmpeg_helpers module used by effects_engine
         source = inspect.getsource(ffmpeg_helpers)
         assert "timeout=" in source or "timeout =" in source
@@ -207,6 +212,7 @@ class TestTimeoutProtection:
         """transitions_engine subprocess.run calls include timeout parameter."""
         import inspect
         from mcp_video import ffmpeg_helpers
+
         # Timeout lives in the shared ffmpeg_helpers module used by transitions_engine
         source = inspect.getsource(ffmpeg_helpers)
         assert "timeout=" in source or "timeout =" in source
@@ -248,42 +254,49 @@ class TestParameterBounds:
     def test_audio_frequency_too_low(self) -> None:
         """Frequency below 20 Hz is rejected."""
         from mcp_video.audio_engine import audio_synthesize
+
         with pytest.raises(MCPVideoError, match=r"[Ff]requency"):
             audio_synthesize("/tmp/test.wav", frequency=5)
 
     def test_audio_frequency_too_high(self) -> None:
         """Frequency above 20000 Hz is rejected."""
         from mcp_video.audio_engine import audio_synthesize
+
         with pytest.raises(MCPVideoError, match=r"[Ff]requency"):
             audio_synthesize("/tmp/test.wav", frequency=50000)
 
     def test_audio_frequency_zero(self) -> None:
         """Frequency of 0 Hz is rejected."""
         from mcp_video.audio_engine import audio_synthesize
+
         with pytest.raises(MCPVideoError, match=r"[Ff]requency"):
             audio_synthesize("/tmp/test.wav", frequency=0)
 
     def test_audio_duration_too_short(self) -> None:
         """Duration below 0.01s is rejected."""
         from mcp_video.audio_engine import audio_synthesize
+
         with pytest.raises(MCPVideoError, match=r"[Dd]uration"):
             audio_synthesize("/tmp/test.wav", duration=0.001)
 
     def test_audio_duration_too_long(self) -> None:
         """Duration above MAX_AUDIO_DURATION is rejected."""
         from mcp_video.audio_engine import audio_synthesize
+
         with pytest.raises(MCPVideoError, match=r"[Dd]uration"):
             audio_synthesize("/tmp/test.wav", duration=100000)
 
     def test_audio_volume_negative(self) -> None:
         """Negative volume is rejected."""
         from mcp_video.audio_engine import audio_synthesize
+
         with pytest.raises(MCPVideoError, match=r"[Vv]olume"):
             audio_synthesize("/tmp/test.wav", volume=-0.5)
 
     def test_audio_volume_over_one(self) -> None:
         """Volume > 1.0 is rejected."""
         from mcp_video.audio_engine import audio_synthesize
+
         with pytest.raises(MCPVideoError, match=r"[Vv]olume"):
             audio_synthesize("/tmp/test.wav", volume=1.5)
 
@@ -291,6 +304,7 @@ class TestParameterBounds:
         """Valid bounds at edges are accepted."""
         from mcp_video.audio_engine import audio_synthesize
         from mcp_video.limits import MIN_FREQUENCY
+
         # These should NOT raise - just validate params, don't actually run
         # We can't easily test without creating a file, so just test validation
         # by checking the function doesn't raise at boundary values
@@ -314,6 +328,7 @@ class TestLimitsModule:
     def test_limits_importable(self) -> None:
         """Limits module can be imported."""
         from mcp_video import limits
+
         assert hasattr(limits, "MAX_VIDEO_DURATION")
         assert hasattr(limits, "MAX_RESOLUTION")
         assert hasattr(limits, "MAX_FILE_SIZE_MB")
@@ -330,6 +345,7 @@ class TestLimitsModule:
             MAX_BATCH_SIZE,
             MAX_AUDIO_DURATION,
         )
+
         assert MAX_VIDEO_DURATION > 0
         assert MAX_RESOLUTION > 0
         assert MAX_FILE_SIZE_MB > 0
@@ -377,5 +393,6 @@ class TestEscapingConsistency:
         """quality_guardrails uses escaped paths for movie= filter."""
         import inspect
         from mcp_video import quality_guardrails
+
         source = inspect.getsource(quality_guardrails)
         assert "_escape_lavfi_path" in source

--- a/tests/test_ai_features.py
+++ b/tests/test_ai_features.py
@@ -28,13 +28,9 @@ def has_ffprobe() -> bool:
     return shutil.which("ffprobe") is not None
 
 
-requires_ffmpeg = pytest.mark.skipif(
-    not has_ffmpeg(), reason="FFmpeg not installed"
-)
+requires_ffmpeg = pytest.mark.skipif(not has_ffmpeg(), reason="FFmpeg not installed")
 
-requires_ffprobe = pytest.mark.skipif(
-    not has_ffprobe(), reason="FFprobe not installed"
-)
+requires_ffprobe = pytest.mark.skipif(not has_ffprobe(), reason="FFprobe not installed")
 
 
 # ---------------------------------------------------------------------------
@@ -51,15 +47,34 @@ def create_video_with_silence(output_path: str, duration: float = 5) -> str:
     - 2 seconds of sine wave audio
     """
     cmd = [
-        "ffmpeg", "-y",
-        "-f", "lavfi", "-i", f"color=c=blue:s=320x240:d={duration}",
-        "-f", "lavfi", "-i", "sine=frequency=1000:duration=2",
-        "-f", "lavfi", "-i", "anullsrc=r=44100:cl=mono",  # silence
-        "-f", "lavfi", "-i", "sine=frequency=1000:duration=2",
-        "-filter_complex", "[1:a][2:a][3:a]concat=n=3:v=0:a=1[a]",
-        "-map", "0:v", "-map", "[a]",
-        "-pix_fmt", "yuv420p", "-shortest",
-        output_path
+        "ffmpeg",
+        "-y",
+        "-f",
+        "lavfi",
+        "-i",
+        f"color=c=blue:s=320x240:d={duration}",
+        "-f",
+        "lavfi",
+        "-i",
+        "sine=frequency=1000:duration=2",
+        "-f",
+        "lavfi",
+        "-i",
+        "anullsrc=r=44100:cl=mono",  # silence
+        "-f",
+        "lavfi",
+        "-i",
+        "sine=frequency=1000:duration=2",
+        "-filter_complex",
+        "[1:a][2:a][3:a]concat=n=3:v=0:a=1[a]",
+        "-map",
+        "0:v",
+        "-map",
+        "[a]",
+        "-pix_fmt",
+        "yuv420p",
+        "-shortest",
+        output_path,
     ]
     subprocess.run(cmd, capture_output=True, check=True)
     return output_path
@@ -68,10 +83,14 @@ def create_video_with_silence(output_path: str, duration: float = 5) -> str:
 def get_video_duration(video_path: str) -> float:
     """Get video duration using ffprobe."""
     probe_cmd = [
-        "ffprobe", "-v", "error",
-        "-show_entries", "format=duration",
-        "-of", "default=noprint_wrappers=1:nokey=1",
-        video_path
+        "ffprobe",
+        "-v",
+        "error",
+        "-show_entries",
+        "format=duration",
+        "-of",
+        "default=noprint_wrappers=1:nokey=1",
+        video_path,
     ]
     result = subprocess.run(probe_cmd, capture_output=True, text=True, check=True)
     return float(result.stdout.strip())
@@ -92,12 +111,7 @@ def test_remove_silence():
         # Get input duration
         input_duration = get_video_duration(input_video)
 
-        result = ai_remove_silence(
-            input_video,
-            output_video,
-            silence_threshold=-50,
-            min_silence_duration=0.3
-        )
+        result = ai_remove_silence(input_video, output_video, silence_threshold=-50, min_silence_duration=0.3)
 
         assert os.path.exists(result), "Output not created"
 
@@ -124,11 +138,20 @@ def test_remove_silence_no_silence():
 
         # Create video with continuous audio (no silence)
         cmd = [
-            "ffmpeg", "-y",
-            "-f", "lavfi", "-i", "color=c=red:s=320x240:d=3",
-            "-f", "lavfi", "-i", "sine=frequency=500:duration=3",
-            "-pix_fmt", "yuv420p", "-shortest",
-            input_video
+            "ffmpeg",
+            "-y",
+            "-f",
+            "lavfi",
+            "-i",
+            "color=c=red:s=320x240:d=3",
+            "-f",
+            "lavfi",
+            "-i",
+            "sine=frequency=500:duration=3",
+            "-pix_fmt",
+            "yuv420p",
+            "-shortest",
+            input_video,
         ]
         subprocess.run(cmd, capture_output=True, check=True)
 
@@ -141,8 +164,7 @@ def test_remove_silence_no_silence():
         output_duration = get_video_duration(result)
 
         # Duration should be approximately the same
-        assert abs(output_duration - input_duration) < 0.5, \
-            "Duration should remain similar when no silence to remove"
+        assert abs(output_duration - input_duration) < 0.5, "Duration should remain similar when no silence to remove"
 
 
 @requires_ffmpeg
@@ -158,12 +180,7 @@ def test_remove_silence_custom_threshold():
         create_video_with_silence(input_video)
 
         # Use stricter threshold (more negative = quieter sounds considered silence)
-        result = ai_remove_silence(
-            input_video,
-            output_video,
-            silence_threshold=-60,
-            min_silence_duration=0.3
-        )
+        result = ai_remove_silence(input_video, output_video, silence_threshold=-60, min_silence_duration=0.3)
 
         assert os.path.exists(result), "Output not created"
 
@@ -191,7 +208,7 @@ def test_remove_silence_with_margin():
             output_video,
             silence_threshold=-50,
             min_silence_duration=0.3,
-            keep_margin=0.5  # Larger margin
+            keep_margin=0.5,  # Larger margin
         )
 
         assert os.path.exists(result), "Output not created"
@@ -225,10 +242,19 @@ def create_video_with_speech(output_path: str) -> str:
     """Create test video with synthetic speech audio."""
     # Create a simple video with sine wave that simulates speech
     cmd = [
-        "ffmpeg", "-y",
-        "-f", "lavfi", "-i", "color=c=green:s=320x240:d=3",
-        "-f", "lavfi", "-i", "sine=frequency=440:duration=3",
-        "-pix_fmt", "yuv420p", "-shortest",
+        "ffmpeg",
+        "-y",
+        "-f",
+        "lavfi",
+        "-i",
+        "color=c=green:s=320x240:d=3",
+        "-f",
+        "lavfi",
+        "-i",
+        "sine=frequency=440:duration=3",
+        "-pix_fmt",
+        "yuv420p",
+        "-shortest",
         output_path,
     ]
     subprocess.run(cmd, capture_output=True, check=True)
@@ -287,7 +313,9 @@ class TestTranscription:
         from mcp_video.ai_engine import ai_transcribe
         from mcp_video.errors import ProcessingError
 
-        monkeypatch.setattr("mcp_video.ai_engine.subprocess.run", lambda *a, **k: type("R", (), {"returncode": 1, "stderr": "boom"})())
+        monkeypatch.setattr(
+            "mcp_video.ai_engine.subprocess.run", lambda *a, **k: type("R", (), {"returncode": 1, "stderr": "boom"})()
+        )
 
         with pytest.raises(ProcessingError, match="FFmpeg processing failed"):
             ai_transcribe(sample_video)
@@ -454,16 +482,26 @@ class TestColorGrade:
 
             # Create test video with blue color
             cmd = [
-                "ffmpeg", "-y",
-                "-f", "lavfi", "-i", "color=c=blue:s=320x240:d=2",
-                "-f", "lavfi", "-i", "sine=frequency=1000:duration=2",
-                "-pix_fmt", "yuv420p", "-shortest",
+                "ffmpeg",
+                "-y",
+                "-f",
+                "lavfi",
+                "-i",
+                "color=c=blue:s=320x240:d=2",
+                "-f",
+                "lavfi",
+                "-i",
+                "sine=frequency=1000:duration=2",
+                "-pix_fmt",
+                "yuv420p",
+                "-shortest",
                 input_video,
             ]
             subprocess.run(cmd, capture_output=True, check=True)
 
             # Test cinematic style
             from mcp_video.ai_engine import ai_color_grade
+
             result = ai_color_grade(input_video, output_video, style="cinematic")
             assert os.path.exists(result), "Output video should be created"
             assert result == output_video
@@ -478,10 +516,19 @@ class TestColorGrade:
 
             # Create test video
             cmd = [
-                "ffmpeg", "-y",
-                "-f", "lavfi", "-i", "color=c=green:s=320x240:d=1",
-                "-f", "lavfi", "-i", "sine=frequency=1000:duration=1",
-                "-pix_fmt", "yuv420p", "-shortest",
+                "ffmpeg",
+                "-y",
+                "-f",
+                "lavfi",
+                "-i",
+                "color=c=green:s=320x240:d=1",
+                "-f",
+                "lavfi",
+                "-i",
+                "sine=frequency=1000:duration=1",
+                "-pix_fmt",
+                "yuv420p",
+                "-shortest",
                 input_video,
             ]
             subprocess.run(cmd, capture_output=True, check=True)
@@ -505,20 +552,38 @@ class TestColorGrade:
 
             # Create input video (blue)
             cmd = [
-                "ffmpeg", "-y",
-                "-f", "lavfi", "-i", "color=c=blue:s=320x240:d=1",
-                "-f", "lavfi", "-i", "sine=frequency=1000:duration=1",
-                "-pix_fmt", "yuv420p", "-shortest",
+                "ffmpeg",
+                "-y",
+                "-f",
+                "lavfi",
+                "-i",
+                "color=c=blue:s=320x240:d=1",
+                "-f",
+                "lavfi",
+                "-i",
+                "sine=frequency=1000:duration=1",
+                "-pix_fmt",
+                "yuv420p",
+                "-shortest",
                 input_video,
             ]
             subprocess.run(cmd, capture_output=True, check=True)
 
             # Create reference video (red)
             cmd = [
-                "ffmpeg", "-y",
-                "-f", "lavfi", "-i", "color=c=red:s=320x240:d=1",
-                "-f", "lavfi", "-i", "sine=frequency=1000:duration=1",
-                "-pix_fmt", "yuv420p", "-shortest",
+                "ffmpeg",
+                "-y",
+                "-f",
+                "lavfi",
+                "-i",
+                "color=c=red:s=320x240:d=1",
+                "-f",
+                "lavfi",
+                "-i",
+                "sine=frequency=1000:duration=1",
+                "-pix_fmt",
+                "yuv420p",
+                "-shortest",
                 reference_video,
             ]
             subprocess.run(cmd, capture_output=True, check=True)
@@ -537,10 +602,19 @@ class TestColorGrade:
 
             # Create test video
             cmd = [
-                "ffmpeg", "-y",
-                "-f", "lavfi", "-i", "color=c=gray:s=320x240:d=1",
-                "-f", "lavfi", "-i", "sine=frequency=1000:duration=1",
-                "-pix_fmt", "yuv420p", "-shortest",
+                "ffmpeg",
+                "-y",
+                "-f",
+                "lavfi",
+                "-i",
+                "color=c=gray:s=320x240:d=1",
+                "-f",
+                "lavfi",
+                "-i",
+                "sine=frequency=1000:duration=1",
+                "-pix_fmt",
+                "yuv420p",
+                "-shortest",
                 input_video,
             ]
             subprocess.run(cmd, capture_output=True, check=True)
@@ -643,12 +717,22 @@ if __name__ == "__main__":
 def create_stereo_video(output_path):
     """Create video with stereo audio."""
     cmd = [
-        "ffmpeg", "-y",
-        "-f", "lavfi", "-i", "color=c=orange:s=320x240:d=5",
-        "-f", "lavfi", "-i", "sine=frequency=1000:duration=5",
-        "-ac", "2",  # stereo
-        "-pix_fmt", "yuv420p", "-shortest",
-        output_path
+        "ffmpeg",
+        "-y",
+        "-f",
+        "lavfi",
+        "-i",
+        "color=c=orange:s=320x240:d=5",
+        "-f",
+        "lavfi",
+        "-i",
+        "sine=frequency=1000:duration=5",
+        "-ac",
+        "2",  # stereo
+        "-pix_fmt",
+        "yuv420p",
+        "-shortest",
+        output_path,
     ]
     subprocess.run(cmd, capture_output=True, check=True)
     return output_path
@@ -657,11 +741,16 @@ def create_stereo_video(output_path):
 def get_audio_channels(video_path):
     """Get audio channel count."""
     cmd = [
-        "ffprobe", "-v", "error",
-        "-select_streams", "a:0",
-        "-show_entries", "stream=channels",
-        "-of", "default=noprint_wrappers=1:nokey=1",
-        video_path
+        "ffprobe",
+        "-v",
+        "error",
+        "-select_streams",
+        "a:0",
+        "-show_entries",
+        "stream=channels",
+        "-of",
+        "default=noprint_wrappers=1:nokey=1",
+        video_path,
     ]
     result = subprocess.run(cmd, capture_output=True, text=True)
     return int(result.stdout.strip())
@@ -681,9 +770,9 @@ def test_spatial_audio():
 
         # Test simple spatial positioning
         positions = [
-            {"time": 0, "azimuth": -45, "elevation": 0},   # left
+            {"time": 0, "azimuth": -45, "elevation": 0},  # left
             {"time": 2.5, "azimuth": 0, "elevation": 30},  # center, up
-            {"time": 5, "azimuth": 45, "elevation": 0},    # right
+            {"time": 5, "azimuth": 45, "elevation": 0},  # right
         ]
 
         result = audio_spatial(input_video, output_video, positions, method="simple")
@@ -812,11 +901,20 @@ if __name__ == "__main__":
 def create_low_res_video(output_path, resolution="160x120"):
     """Create low-res test video."""
     cmd = [
-        "ffmpeg", "-y",
-        "-f", "lavfi", "-i", f"color=c=red:s={resolution}:d=2",
-        "-f", "lavfi", "-i", "sine=frequency=1000:duration=2",
-        "-pix_fmt", "yuv420p", "-shortest",
-        output_path
+        "ffmpeg",
+        "-y",
+        "-f",
+        "lavfi",
+        "-i",
+        f"color=c=red:s={resolution}:d=2",
+        "-f",
+        "lavfi",
+        "-i",
+        "sine=frequency=1000:duration=2",
+        "-pix_fmt",
+        "yuv420p",
+        "-shortest",
+        output_path,
     ]
     subprocess.run(cmd, capture_output=True)
     return output_path
@@ -825,11 +923,16 @@ def create_low_res_video(output_path, resolution="160x120"):
 def get_video_resolution(video_path):
     """Get video resolution."""
     cmd = [
-        "ffprobe", "-v", "error",
-        "-select_streams", "v:0",
-        "-show_entries", "stream=width,height",
-        "-of", "csv=s=x:p=0",
-        video_path
+        "ffprobe",
+        "-v",
+        "error",
+        "-select_streams",
+        "v:0",
+        "-show_entries",
+        "stream=width,height",
+        "-of",
+        "csv=s=x:p=0",
+        video_path,
     ]
     result = subprocess.run(cmd, capture_output=True, text=True)
     return result.stdout.strip()
@@ -840,9 +943,7 @@ def realesrgan_installed():
     return importlib.util.find_spec("realesrgan") is not None
 
 
-requires_realesrgan = pytest.mark.skipif(
-    not realesrgan_installed(), reason="Real-ESRGAN not installed"
-)
+requires_realesrgan = pytest.mark.skipif(not realesrgan_installed(), reason="Real-ESRGAN not installed")
 
 
 @requires_ffmpeg
@@ -997,11 +1098,23 @@ def test_ai_upscale_missing_file():
 def create_simple_video(output_path: str, duration: float = 3) -> str:
     """Create a minimal test video with audio."""
     cmd = [
-        "ffmpeg", "-y",
-        "-f", "lavfi", "-i", f"color=c=red:s=320x240:d={duration}",
-        "-f", "lavfi", "-i", f"sine=frequency=440:duration={duration}",
-        "-map", "0:v", "-map", "1:a",
-        "-pix_fmt", "yuv420p", "-shortest",
+        "ffmpeg",
+        "-y",
+        "-f",
+        "lavfi",
+        "-i",
+        f"color=c=red:s=320x240:d={duration}",
+        "-f",
+        "lavfi",
+        "-i",
+        f"sine=frequency=440:duration={duration}",
+        "-map",
+        "0:v",
+        "-map",
+        "1:a",
+        "-pix_fmt",
+        "yuv420p",
+        "-shortest",
         output_path,
     ]
     subprocess.run(cmd, capture_output=True, check=True)
@@ -1163,12 +1276,14 @@ def test_analyze_video_writes_txt_output():
 
 def test_is_url_detects_http():
     from mcp_video.ai_engine import _is_url
+
     assert _is_url("http://example.com/video.mp4") is True
     assert _is_url("https://example.com/video.mp4") is True
 
 
 def test_is_url_rejects_local_path():
     from mcp_video.ai_engine import _is_url
+
     assert _is_url("/local/path/video.mp4") is False
     assert _is_url("relative/path.mp4") is False
     assert _is_url("C:\\Windows\\video.mp4") is False
@@ -1176,6 +1291,7 @@ def test_is_url_rejects_local_path():
 
 def test_url_host_extraction():
     from mcp_video.ai_engine import _url_host
+
     assert _url_host("https://www.youtube.com/watch?v=abc") == "www.youtube.com"
     assert _url_host("https://example.com/path/video.mp4") == "example.com"
     assert _url_host("http://cdn.example.com:8080/v.mp4") == "cdn.example.com:8080"

--- a/tests/test_audio_presets.py
+++ b/tests/test_audio_presets.py
@@ -2,6 +2,7 @@ import tempfile
 import os
 from mcp_video import audio_preset
 
+
 def test_drone_ominous_preset():
     with tempfile.TemporaryDirectory() as tmpdir:
         output = os.path.join(tmpdir, "drone.wav")
@@ -9,6 +10,7 @@ def test_drone_ominous_preset():
         assert os.path.exists(result)
         assert os.path.getsize(result) > 0
         print(f"✓ drone-ominous created: {os.path.getsize(result)} bytes")
+
 
 if __name__ == "__main__":
     test_drone_ominous_preset()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -113,7 +113,7 @@ class TestCLIFilter:
         assert data["operation"] == "filter_blur"
 
     def test_filter_color_preset_outputs_json(self, sample_video):
-        result = run_cli_json("filter", sample_video, "-t", "color_preset", '--params', '{"preset": "warm"}')
+        result = run_cli_json("filter", sample_video, "-t", "color_preset", "--params", '{"preset": "warm"}')
         data = json.loads(result.stdout)
         assert data["success"] is True
 
@@ -159,13 +159,15 @@ class TestCLISplitScreen:
 
 class TestCLIBatch:
     def test_batch_outputs_json(self, sample_video):
-        result = run_cli_json("batch", sample_video, "--operation", "trim", '--params', '{"start": "0", "duration": "1"}')
+        result = run_cli_json(
+            "batch", sample_video, "--operation", "trim", "--params", '{"start": "0", "duration": "1"}'
+        )
         data = json.loads(result.stdout)
         assert data["success"] is True
         assert data["succeeded"] == 1
 
     def test_batch_outputs_text(self, sample_video):
-        result = run_cli("batch", sample_video, "--operation", "trim", '--params', '{"start": "0", "duration": "1"}')
+        result = run_cli("batch", sample_video, "--operation", "trim", "--params", '{"start": "0", "duration": "1"}')
         assert "Batch Results" in result.stdout
 
 
@@ -378,14 +380,7 @@ class TestCLIExtractAudio:
 class TestCLIEdit:
     def test_edit_outputs_json(self, sample_video, tmp_path):
         # Create a timeline JSON file
-        timeline = {
-            "tracks": [
-                {
-                    "type": "video",
-                    "clips": [{"source": sample_video, "start": 0, "end": 1}]
-                }
-            ]
-        }
+        timeline = {"tracks": [{"type": "video", "clips": [{"source": sample_video, "start": 0, "end": 1}]}]}
         timeline_path = tmp_path / "timeline.json"
         timeline_path.write_text(json.dumps(timeline))
 
@@ -395,14 +390,7 @@ class TestCLIEdit:
 
     def test_edit_outputs_text(self, sample_video, tmp_path):
         # Create a timeline JSON file
-        timeline = {
-            "tracks": [
-                {
-                    "type": "video",
-                    "clips": [{"source": sample_video, "start": 0, "end": 1}]
-                }
-            ]
-        }
+        timeline = {"tracks": [{"type": "video", "clips": [{"source": sample_video, "start": 0, "end": 1}]}]}
         timeline_path = tmp_path / "timeline.json"
         timeline_path.write_text(json.dumps(timeline))
 
@@ -448,7 +436,9 @@ class TestCLIAudioWaveform:
 
 class TestCLIGenerateSubtitles:
     def test_generate_subtitles_outputs_json(self, sample_video):
-        result = run_cli_json("generate-subtitles", sample_video, "--entries", '[{"start": 0, "end": 1, "text": "Hello"}]')
+        result = run_cli_json(
+            "generate-subtitles", sample_video, "--entries", '[{"start": 0, "end": 1, "text": "Hello"}]'
+        )
         data = json.loads(result.stdout)
         assert data["success"] is True
         assert "srt_path" in data or "entry_count" in data
@@ -626,7 +616,9 @@ class TestCLICompositionHandlers:
             ),
         ],
     )
-    def test_composition_handler_outputs_json(self, command, output_name, label, extra_args, tmp_path, monkeypatch, capsys):
+    def test_composition_handler_outputs_json(
+        self, command, output_name, label, extra_args, tmp_path, monkeypatch, capsys
+    ):
         output = tmp_path / output_name
         from mcp_video.cli import handlers_composition
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -37,6 +37,7 @@ class TestClientInfo:
 
     def test_info_nonexistent_file(self, editor):
         from mcp_video.errors import InputFileError
+
         with pytest.raises(InputFileError):
             editor.info("/nonexistent/video.mp4")
 
@@ -84,9 +85,13 @@ class TestClientAddText:
     @requires_filter("drawtext", "Text overlay")
     def test_add_text_passes_params(self, editor, sample_video):
         result = editor.add_text(
-            sample_video, text="Test",
-            position="bottom-center", font=None, size=36,
-            color="yellow", shadow=False,
+            sample_video,
+            text="Test",
+            position="bottom-center",
+            font=None,
+            size=36,
+            color="yellow",
+            shadow=False,
         )
         assert isinstance(result, EditResult)
 
@@ -103,8 +108,11 @@ class TestClientAddAudio:
 
     def test_add_audio_with_fade(self, editor, sample_video, sample_audio):
         result = editor.add_audio(
-            sample_video, sample_audio,
-            volume=0.8, fade_in=0.5, fade_out=0.5,
+            sample_video,
+            sample_audio,
+            volume=0.8,
+            fade_in=0.5,
+            fade_out=0.5,
         )
         assert isinstance(result, EditResult)
 

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -89,10 +89,10 @@ def test_run_diagnostics_checks_optional_packages_without_importing_them():
     assert checks["scikit-learn"]["ok"] is True
     assert checks["openai-whisper"]["ok"] is False
     assert checks["openai-whisper"]["required"] is False
-    assert 'mcp-video[transcribe]' in checks["openai-whisper"]["install_hint"]
-    assert 'mcp-video[stems]' in checks["demucs"]["install_hint"]
-    assert 'mcp-video[upscale]' in checks["opencv-contrib-python"]["install_hint"]
-    assert 'mcp-video[ai-scene]' in checks["imagehash"]["install_hint"]
+    assert "mcp-video[transcribe]" in checks["openai-whisper"]["install_hint"]
+    assert "mcp-video[stems]" in checks["demucs"]["install_hint"]
+    assert "mcp-video[upscale]" in checks["opencv-contrib-python"]["install_hint"]
+    assert "mcp-video[ai-scene]" in checks["imagehash"]["install_hint"]
 
 
 def test_run_diagnostics_requires_matching_distribution_for_package_checks():

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -36,8 +36,10 @@ class TestTikTokWorkflow:
 
         # 2. Add text
         titled = editor.add_text(
-            trimmed.output_path, text="Follow for more!",
-            position="bottom-center", size=36,
+            trimmed.output_path,
+            text="Follow for more!",
+            position="bottom-center",
+            size=36,
         )
         assert os.path.isfile(titled.output_path)
 
@@ -68,9 +70,12 @@ class TestYouTubeWorkflow:
 
         # 2. Add title text
         titled = editor.add_text(
-            merged.output_path, text="EPISODE 1",
-            position="top-center", size=48,
-            start_time=0, duration=2,
+            merged.output_path,
+            text="EPISODE 1",
+            position="top-center",
+            size=48,
+            start_time=0,
+            duration=2,
         )
         assert os.path.isfile(titled.output_path)
 

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -112,8 +112,10 @@ class TestAddText:
     @requires_filter("drawtext", "Text overlay")
     def test_add_text_with_timing(self, sample_video):
         result = add_text(
-            sample_video, text="Timed",
-            start_time=0.5, duration=1.0,
+            sample_video,
+            text="Timed",
+            start_time=0.5,
+            duration=1.0,
         )
         assert os.path.isfile(result.output_path)
 
@@ -130,8 +132,10 @@ class TestAddAudio:
 
     def test_audio_with_fade(self, sample_video, sample_audio):
         result = add_audio(
-            sample_video, sample_audio,
-            fade_in=0.5, fade_out=0.5,
+            sample_video,
+            sample_audio,
+            fade_in=0.5,
+            fade_out=0.5,
         )
         assert os.path.isfile(result.output_path)
 
@@ -139,6 +143,7 @@ class TestAddAudio:
 class TestResize:
     def test_resize_by_dimensions(self, sample_video):
         from mcp_video.engine import resize
+
         result = resize(sample_video, width=320, height=240)
         assert os.path.isfile(result.output_path)
         info = probe(result.output_path)
@@ -147,6 +152,7 @@ class TestResize:
 
     def test_resize_by_aspect_ratio(self, sample_video):
         from mcp_video.engine import resize
+
         result = resize(sample_video, aspect_ratio="1:1")
         assert os.path.isfile(result.output_path)
         info = probe(result.output_path)
@@ -210,9 +216,7 @@ class TestSubtitles:
     @requires_filter("subtitles", "Subtitle burn-in")
     def test_burn_subtitles(self, sample_video, tmp_path):
         srt_path = tmp_path / "subs.srt"
-        srt_path.write_text(
-            "1\n00:00:00,000 --> 00:00:02,000\nTest subtitle\n"
-        )
+        srt_path.write_text("1\n00:00:00,000 --> 00:00:02,000\nTest subtitle\n")
         result = subtitles(input_path=str(sample_video), subtitle_path=str(srt_path))
         assert os.path.isfile(result.output_path)
 
@@ -243,14 +247,18 @@ class TestProgressCallbacks:
         # Create a simple FFmpeg command
         output = str(tmp_path / "output.mp4")
         args = [
-            "-i", sample_video,
-            "-t", "1",
-            "-c", "copy",
+            "-i",
+            sample_video,
+            "-t",
+            "1",
+            "-c",
+            "copy",
             output,
         ]
 
         # With estimated_duration=None, on_progress should not be called
         progress_calls = []
+
         def mock_on_progress(pct):
             progress_calls.append(pct)
 
@@ -335,6 +343,7 @@ class TestChromaKey:
     def test_chroma_key_preserves_alpha_with_mov(self, sample_video):
         """MOV output should use prores_ks with alpha channel support."""
         import tempfile
+
         with tempfile.NamedTemporaryFile(suffix=".mov", delete=False) as tmp:
             result = chroma_key(sample_video, output_path=tmp.name)
             assert result.success is True

--- a/tests/test_engine_advanced.py
+++ b/tests/test_engine_advanced.py
@@ -81,12 +81,14 @@ class TestWatermark:
 class TestExportVideo:
     def test_wrapper_for_convert(self, sample_video):
         from mcp_video.engine import export_video
+
         result = export_video(sample_video)
         assert os.path.isfile(result.output_path)
         assert result.operation == "export"
 
     def test_with_quality(self, sample_video):
         from mcp_video.engine import export_video
+
         result = export_video(sample_video, quality="low")
         assert os.path.isfile(result.output_path)
 
@@ -94,7 +96,8 @@ class TestExportVideo:
 class TestEditTimeline:
     def test_single_clip_no_transitions(self, sample_video):
         tl = Timeline(
-            width=640, height=480,
+            width=640,
+            height=480,
             tracks=[
                 TimelineTrack(
                     type="video",
@@ -109,7 +112,8 @@ class TestEditTimeline:
     @requires_filter("drawtext", "Text overlay")
     def test_multiple_clips_with_text(self, sample_video):
         tl = Timeline(
-            width=640, height=480,
+            width=640,
+            height=480,
             tracks=[
                 TimelineTrack(
                     type="video",
@@ -120,13 +124,15 @@ class TestEditTimeline:
                 ),
                 TimelineTrack(
                     type="text",
-                    elements=[{
-                        "text": "Test Title",
-                        "start": 0,
-                        "duration": 2,
-                        "position": "center",
-                        "style": {"size": 36, "color": "white", "shadow": True},
-                    }],
+                    elements=[
+                        {
+                            "text": "Test Title",
+                            "start": 0,
+                            "duration": 2,
+                            "position": "center",
+                            "style": {"size": 36, "color": "white", "shadow": True},
+                        }
+                    ],
                 ),
             ],
         )
@@ -136,7 +142,8 @@ class TestEditTimeline:
     def test_timeline_with_audio(self, sample_video, sample_audio, tmp_path):
         out = str(tmp_path / "timeline_audio.mp4")
         tl = Timeline(
-            width=640, height=480,
+            width=640,
+            height=480,
             tracks=[
                 TimelineTrack(
                     type="video",
@@ -275,7 +282,8 @@ class TestExtractAudioAdvanced:
 class TestAddAudioAdvanced:
     def test_with_start_time(self, sample_video, sample_audio):
         result = add_audio(
-            sample_video, sample_audio,
+            sample_video,
+            sample_audio,
             start_time=0.5,
         )
         assert os.path.isfile(result.output_path)
@@ -396,6 +404,7 @@ class TestMergePerTransition:
 # ---------------------------------------------------------------------------
 # v0.3.0 features: filters, compositing, audio normalization
 # ---------------------------------------------------------------------------
+
 
 class TestColorPresetFilter:
     def test_warm_preset(self):
@@ -581,9 +590,16 @@ class TestAudioEffects:
 
     @requires_filter("aecho", "Reverb filter")
     def test_reverb_with_params(self, sample_video):
-        result = apply_filter(sample_video, filter_type="reverb", params={
-            "in_gain": 0.6, "out_gain": 0.8, "delays": 80, "decay": 0.3,
-        })
+        result = apply_filter(
+            sample_video,
+            filter_type="reverb",
+            params={
+                "in_gain": 0.6,
+                "out_gain": 0.8,
+                "delays": 80,
+                "decay": 0.3,
+            },
+        )
         assert os.path.isfile(result.output_path)
 
     @requires_filter("acompressor", "Compressor filter")
@@ -594,9 +610,16 @@ class TestAudioEffects:
 
     @requires_filter("acompressor", "Compressor filter")
     def test_compressor_with_params(self, sample_video):
-        result = apply_filter(sample_video, filter_type="compressor", params={
-            "threshold_db": -15, "ratio": 6, "attack": 3, "release": 100,
-        })
+        result = apply_filter(
+            sample_video,
+            filter_type="compressor",
+            params={
+                "threshold_db": -15,
+                "ratio": 6,
+                "attack": 3,
+                "release": 100,
+            },
+        )
         assert os.path.isfile(result.output_path)
 
     @requires_filter("asetrate", "Pitch shift filter")
@@ -634,6 +657,7 @@ class TestLoudnormTruePeak:
     def test_broadcast_tp_is_fixed(self, sample_video, tmp_path):
         """TP should be -1.5 regardless of target_lufs, not target_lufs + 14.5."""
         from mcp_video.engine import normalize_audio
+
         out = str(tmp_path / "norm_broadcast.mp4")
         result = normalize_audio(sample_video, target_lufs=-23.0, output_path=out)
         assert os.path.isfile(result.output_path)
@@ -650,9 +674,14 @@ class TestKenBurns:
 
     @requires_filter("zoompan", "Zoom pan filter")
     def test_ken_burns_with_params(self, sample_video):
-        result = apply_filter(sample_video, filter_type="ken_burns", params={
-            "zoom_speed": 0.002, "duration": 100,
-        })
+        result = apply_filter(
+            sample_video,
+            filter_type="ken_burns",
+            params={
+                "zoom_speed": 0.002,
+                "duration": 100,
+            },
+        )
         assert os.path.isfile(result.output_path)
 
 
@@ -661,6 +690,7 @@ class TestGenerateSubtitles:
 
     def test_generate_srt_file(self, sample_video, tmp_path):
         from mcp_video.engine import generate_subtitles
+
         out = str(tmp_path / "subs")
         entries = [
             {"start": 0.0, "end": 1.5, "text": "Hello World"},
@@ -675,6 +705,7 @@ class TestGenerateSubtitles:
 
     def test_burn_subtitles_into_video(self, sample_video, tmp_path):
         from mcp_video.engine import generate_subtitles
+
         out = str(tmp_path / "burned")
         entries = [{"start": 0.0, "end": 2.0, "text": "Burned text"}]
         result = generate_subtitles(entries, sample_video, output_path=out, burn=True)
@@ -684,11 +715,13 @@ class TestGenerateSubtitles:
 
     def test_empty_entries_raises(self, sample_video):
         from mcp_video.engine import generate_subtitles
+
         with pytest.raises(MCPVideoError, match="entries"):
             generate_subtitles([], sample_video)
 
     def test_invalid_time_range_raises(self, sample_video):
         from mcp_video.engine import generate_subtitles
+
         entries = [{"start": 2.0, "end": 1.0, "text": "Bad range"}]
         with pytest.raises(MCPVideoError, match=r"start.*end"):
             generate_subtitles(entries, sample_video)
@@ -699,6 +732,7 @@ class TestAudioWaveform:
 
     def test_waveform_extraction(self, sample_video):
         from mcp_video.engine import audio_waveform
+
         result = audio_waveform(sample_video, bins=10)
         assert result.success is True
         assert result.duration > 0
@@ -710,16 +744,19 @@ class TestAudioWaveform:
 
     def test_waveform_no_audio_raises(self, sample_video_no_audio):
         from mcp_video.engine import audio_waveform
+
         with pytest.raises(MCPVideoError, match="audio"):
             audio_waveform(sample_video_no_audio)
 
     def test_waveform_custom_bins(self, sample_video):
         from mcp_video.engine import audio_waveform
+
         result = audio_waveform(sample_video, bins=20)
         assert len(result.peaks) == 20
 
     def test_waveform_rejects_excessive_bins(self, sample_video):
         from mcp_video.engine import audio_waveform
+
         with pytest.raises(MCPVideoError, match="bins"):
             audio_waveform(sample_video, bins=1001)
 
@@ -770,6 +807,7 @@ class TestTwoPassEncoding:
 
     def test_export_video_two_pass(self, sample_video, tmp_path):
         from mcp_video.engine import export_video
+
         out = str(tmp_path / "export_two_pass.mp4")
         result = export_video(sample_video, output_path=out, two_pass=True, target_bitrate=1500)
         assert os.path.isfile(result.output_path)
@@ -785,9 +823,11 @@ class TestTwoPassEncoding:
 # Wave 3: Scene Detection
 # ---------------------------------------------------------------------------
 
+
 class TestSceneDetection:
     def test_detect_scenes_returns_result(self, sample_video):
         from mcp_video.engine import detect_scenes
+
         result = detect_scenes(sample_video)
         assert result.success is True
         assert result.duration > 0
@@ -796,11 +836,13 @@ class TestSceneDetection:
 
     def test_detect_scenes_custom_threshold(self, sample_video):
         from mcp_video.engine import detect_scenes
+
         result = detect_scenes(sample_video, threshold=0.5)
         assert result.success is True
 
     def test_detect_scenes_min_duration(self, sample_video):
         from mcp_video.engine import detect_scenes
+
         result = detect_scenes(sample_video, min_scene_duration=0.5)
         assert result.success is True
         # Verify no scene is shorter than min_duration
@@ -809,6 +851,7 @@ class TestSceneDetection:
 
     def test_detect_scenes_nonexistent_file(self):
         from mcp_video.engine import detect_scenes
+
         with pytest.raises(InputFileError):
             detect_scenes("/nonexistent/video.mp4")
 
@@ -829,11 +872,14 @@ class TestSceneDetection:
 # Wave 3: Image Sequences
 # ---------------------------------------------------------------------------
 
+
 class TestImageSequences:
     def test_create_from_images(self, sample_video, tmp_path):
         from mcp_video.engine import create_from_images
+
         # First export frames, then create video from them
         from mcp_video.engine import export_frames
+
         frames_dir = str(tmp_path / "frames")
         frames_result = export_frames(sample_video, output_dir=frames_dir, fps=1.0)
         assert len(frames_result.frame_paths) > 0
@@ -845,16 +891,19 @@ class TestImageSequences:
 
     def test_create_from_images_empty_raises(self):
         from mcp_video.engine import create_from_images
+
         with pytest.raises(MCPVideoError, match="No images"):
             create_from_images([])
 
     def test_create_from_images_invalid_file_raises(self):
         from mcp_video.engine import create_from_images
+
         with pytest.raises(InputFileError):
             create_from_images(["/nonexistent/image.jpg"])
 
     def test_export_frames(self, sample_video, tmp_path):
         from mcp_video.engine import export_frames
+
         out_dir = str(tmp_path / "exported")
         result = export_frames(sample_video, output_dir=out_dir, fps=1.0)
         assert result.success is True
@@ -865,6 +914,7 @@ class TestImageSequences:
 
     def test_export_frames_png(self, sample_video, tmp_path):
         from mcp_video.engine import export_frames
+
         out_dir = str(tmp_path / "exported_png")
         result = export_frames(sample_video, output_dir=out_dir, fps=1.0, format="png")
         assert result.frame_count > 0
@@ -876,10 +926,12 @@ class TestImageSequences:
 # Wave 3: Quality Metrics
 # ---------------------------------------------------------------------------
 
+
 class TestQualityMetrics:
     def test_compare_quality_same_file(self, sample_video):
         """Comparing a file to itself should yield high quality."""
         from mcp_video.engine import compare_quality
+
         result = compare_quality(sample_video, sample_video)
         assert result.success is True
         assert isinstance(result.metrics, dict)
@@ -888,6 +940,7 @@ class TestQualityMetrics:
     def test_compare_quality_psnr_parsed(self, sample_video):
         """PSNR should be parsed from average: summary line."""
         from mcp_video.engine import compare_quality
+
         result = compare_quality(sample_video, sample_video, metrics=["psnr"])
         assert result.success is True
         if "psnr" in result.metrics:
@@ -896,6 +949,7 @@ class TestQualityMetrics:
     def test_compare_quality_ssim_parsed(self, sample_video):
         """SSIM should be parsed from All: summary line."""
         from mcp_video.engine import compare_quality
+
         result = compare_quality(sample_video, sample_video, metrics=["ssim"])
         assert result.success is True
         if "ssim" in result.metrics:
@@ -903,6 +957,7 @@ class TestQualityMetrics:
 
     def test_compare_quality_default_metrics(self, sample_video):
         from mcp_video.engine import compare_quality
+
         result = compare_quality(sample_video, sample_video, metrics=["psnr", "ssim"])
         assert "psnr" in result.metrics or "ssim" in result.metrics
 
@@ -921,6 +976,7 @@ class TestQualityMetrics:
 
     def test_compare_quality_nonexistent_original(self, sample_video):
         from mcp_video.engine import compare_quality
+
         with pytest.raises(InputFileError):
             compare_quality("/nonexistent/original.mp4", sample_video)
 
@@ -929,20 +985,24 @@ class TestQualityMetrics:
 # Wave 3: Metadata Editing
 # ---------------------------------------------------------------------------
 
+
 class TestMetadataEditing:
     def test_read_metadata(self, sample_video):
         from mcp_video.engine import read_metadata
+
         result = read_metadata(sample_video)
         assert result.success is True
         assert isinstance(result.tags, dict)
 
     def test_read_metadata_nonexistent(self):
         from mcp_video.engine import read_metadata
+
         with pytest.raises(InputFileError):
             read_metadata("/nonexistent/video.mp4")
 
     def test_write_and_read_metadata(self, sample_video, tmp_path):
         from mcp_video.engine import read_metadata, write_metadata
+
         out = str(tmp_path / "tagged.mp4")
         tags = {"title": "Test Video", "artist": "Test Artist"}
         result = write_metadata(sample_video, metadata=tags, output_path=out)
@@ -956,6 +1016,7 @@ class TestMetadataEditing:
 
     def test_write_metadata_empty_raises(self, sample_video):
         from mcp_video.engine import write_metadata
+
         with pytest.raises(MCPVideoError, match="No metadata"):
             write_metadata(sample_video, metadata={})
 
@@ -964,9 +1025,11 @@ class TestMetadataEditing:
 # Wave 4: Video Stabilization
 # ---------------------------------------------------------------------------
 
+
 class TestStabilize:
     def test_stabilize(self, sample_video, tmp_path):
         from mcp_video.engine import stabilize
+
         out = str(tmp_path / "stabilized.mp4")
         if _check_filter_available("vidstabdetect"):
             result = stabilize(sample_video, output_path=out)
@@ -979,6 +1042,7 @@ class TestStabilize:
 
     def test_stabilize_with_params(self, sample_video, tmp_path):
         from mcp_video.engine import stabilize
+
         out = str(tmp_path / "stabilized_zoom.mp4")
         if _check_filter_available("vidstabdetect"):
             result = stabilize(sample_video, smoothing=20, zooming=5, output_path=out)
@@ -990,6 +1054,7 @@ class TestStabilize:
 
     def test_stabilize_nonexistent_file(self):
         from mcp_video.engine import stabilize
+
         with pytest.raises(InputFileError):
             stabilize("/nonexistent/video.mp4")
 
@@ -998,9 +1063,11 @@ class TestStabilize:
 # Wave 4: Advanced Masking
 # ---------------------------------------------------------------------------
 
+
 class TestApplyMask:
     def test_apply_mask(self, sample_video, sample_watermark_png, tmp_path):
         from mcp_video.engine import apply_mask
+
         if not _check_filter_available("alphamerge"):
             pytest.skip("alphamerge filter not available")
         out = str(tmp_path / "masked.mp4")
@@ -1011,6 +1078,7 @@ class TestApplyMask:
     def test_apply_mask_preserves_audio(self, sample_video, sample_watermark_png, tmp_path):
         """Masked video should retain the original audio track."""
         from mcp_video.engine import apply_mask
+
         if not _check_filter_available("alphamerge"):
             pytest.skip("alphamerge filter not available")
         out = str(tmp_path / "masked_audio.mp4")
@@ -1020,6 +1088,7 @@ class TestApplyMask:
 
     def test_apply_mask_with_feather(self, sample_video, sample_watermark_png, tmp_path):
         from mcp_video.engine import apply_mask
+
         if not _check_filter_available("alphamerge"):
             pytest.skip("alphamerge filter not available")
         out = str(tmp_path / "masked_feather.mp4")
@@ -1028,5 +1097,6 @@ class TestApplyMask:
 
     def test_apply_mask_nonexistent_input(self, sample_watermark_png):
         from mcp_video.engine import apply_mask
+
         with pytest.raises(InputFileError):
             apply_mask("/nonexistent/video.mp4", mask_path=sample_watermark_png)

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -128,7 +128,6 @@ class TestCodecError:
         assert "documentation_url" in d
 
 
-
 class TestProcessingError:
     def test_message_includes_returncode(self):
         err = ProcessingError("ffmpeg -i in.mp4 out.mp4", 1, "some error output")
@@ -160,7 +159,6 @@ class TestProcessingError:
         err = ProcessingError("ffmpeg -i a.mp4 b.mp4", 1, "err")
         assert err.command == "ffmpeg -i a.mp4 b.mp4"
         assert err.returncode == 1
-
 
 
 class TestResourceError:

--- a/tests/test_image_engine.py
+++ b/tests/test_image_engine.py
@@ -15,27 +15,33 @@ from mcp_video.errors import MCPVideoError
 # Unit tests — no image deps needed (mocked)
 # ---------------------------------------------------------------------------
 
+
 class TestRgbToHex:
     def test_basic(self):
         from mcp_video.image_engine import _rgb_to_hex
+
         assert _rgb_to_hex(139, 69, 19) == "#8B4513"
 
     def test_black(self):
         from mcp_video.image_engine import _rgb_to_hex
+
         assert _rgb_to_hex(0, 0, 0) == "#000000"
 
     def test_white(self):
         from mcp_video.image_engine import _rgb_to_hex
+
         assert _rgb_to_hex(255, 255, 255) == "#FFFFFF"
 
     def test_red(self):
         from mcp_video.image_engine import _rgb_to_hex
+
         assert _rgb_to_hex(255, 0, 0) == "#FF0000"
 
 
 class TestRgbToHsl:
     def test_red(self):
         from mcp_video.image_engine import _rgb_to_hsl
+
         h, lightness, s = _rgb_to_hsl(255, 0, 0)
         assert h == pytest.approx(0.0, abs=0.01)
         assert s == pytest.approx(1.0, abs=0.01)
@@ -43,11 +49,13 @@ class TestRgbToHsl:
 
     def test_white(self):
         from mcp_video.image_engine import _rgb_to_hsl
+
         _, lightness, _ = _rgb_to_hsl(255, 255, 255)
         assert lightness == pytest.approx(1.0, abs=0.01)
 
     def test_black(self):
         from mcp_video.image_engine import _rgb_to_hsl
+
         _, lightness, _ = _rgb_to_hsl(0, 0, 0)
         assert lightness == pytest.approx(0.0, abs=0.01)
 
@@ -55,12 +63,14 @@ class TestRgbToHsl:
 class TestHslToRgb:
     def test_roundtrip_red(self):
         from mcp_video.image_engine import _hsl_to_rgb, _rgb_to_hsl
+
         h, lightness, s = _rgb_to_hsl(255, 0, 0)
         r, g, b = _hsl_to_rgb(h, s, lightness)
         assert (r, g, b) == (255, 0, 0)
 
     def test_roundtrip_blue(self):
         from mcp_video.image_engine import _hsl_to_rgb, _rgb_to_hsl
+
         h, lightness, s = _rgb_to_hsl(0, 0, 255)
         r, g, b = _hsl_to_rgb(h, s, lightness)
         assert (r, g, b) == (0, 0, 255)
@@ -69,12 +79,14 @@ class TestHslToRgb:
 class TestModelsValidate:
     def test_dominant_color(self):
         from mcp_video.image_models import DominantColor
+
         c = DominantColor(hex="#FF0000", rgb=(255, 0, 0), name="red", percentage=50.0)
         assert c.hex == "#FF0000"
         assert c.percentage == 50.0
 
     def test_color_extraction_result(self):
         from mcp_video.image_models import ColorExtractionResult, DominantColor
+
         colors = [DominantColor(hex="#FF0000", rgb=(255, 0, 0), name="red", percentage=100.0)]
         result = ColorExtractionResult(image_path="/tmp/test.jpg", colors=colors, n_colors=1)
         assert result.success is True
@@ -82,13 +94,17 @@ class TestModelsValidate:
 
     def test_palette_result(self):
         from mcp_video.image_models import PaletteColor, PaletteResult, DominantColor
+
         source = DominantColor(hex="#FF0000", rgb=(255, 0, 0), name="red", percentage=50.0)
         palette = [PaletteColor(hex="#00FFFF", rgb=(0, 255, 255), role="complement")]
-        result = PaletteResult(image_path="/tmp/test.jpg", harmony="complementary", palette=palette, source_color=source)
+        result = PaletteResult(
+            image_path="/tmp/test.jpg", harmony="complementary", palette=palette, source_color=source
+        )
         assert result.harmony == "complementary"
 
     def test_product_analysis_result(self):
         from mcp_video.image_models import ProductAnalysisResult, DominantColor
+
         colors = [DominantColor(hex="#FF0000", rgb=(255, 0, 0), name="red", percentage=100.0)]
         result = ProductAnalysisResult(image_path="/tmp/test.jpg", colors=colors)
         assert result.ai_description is False
@@ -98,12 +114,14 @@ class TestModelsValidate:
 class TestValidateImage:
     def test_missing_file(self):
         from mcp_video.image_engine import _validate_image
+
         with pytest.raises(MCPVideoError) as exc_info:
             _validate_image("/nonexistent/path/image.jpg")
         assert exc_info.value.code == "file_not_found"
 
     def test_unsupported_format(self):
         from mcp_video.image_engine import _validate_image
+
         with tempfile.NamedTemporaryFile(suffix=".xyz", delete=False) as f:
             f.write(b"not an image")
             tmp_path = f.name
@@ -123,10 +141,7 @@ try:
     import PIL.Image
     import importlib.util
 
-    HAS_IMAGE_DEPS = all(
-        importlib.util.find_spec(module) is not None
-        for module in ("numpy", "sklearn")
-    )
+    HAS_IMAGE_DEPS = all(importlib.util.find_spec(module) is not None for module in ("numpy", "sklearn"))
 except ImportError:
     HAS_IMAGE_DEPS = False
 
@@ -161,6 +176,7 @@ def _create_two_color_image(
 class TestExtractColors:
     def test_solid_color_image(self):
         from mcp_video.image_engine import extract_colors
+
         path = _create_solid_image((255, 0, 0))
         try:
             result = extract_colors(path, n_colors=3)
@@ -175,6 +191,7 @@ class TestExtractColors:
 
     def test_two_color_image(self):
         from mcp_video.image_engine import extract_colors
+
         path = _create_two_color_image((255, 0, 0), (0, 0, 255))
         try:
             result = extract_colors(path, n_colors=2)
@@ -188,6 +205,7 @@ class TestExtractColors:
 
     def test_n_colors_validated(self):
         from mcp_video.image_engine import extract_colors
+
         path = _create_solid_image((0, 0, 0))
         try:
             with pytest.raises(MCPVideoError):
@@ -197,6 +215,7 @@ class TestExtractColors:
 
     def test_result_has_hex(self):
         from mcp_video.image_engine import extract_colors
+
         path = _create_solid_image((128, 64, 32))
         try:
             result = extract_colors(path, n_colors=1)
@@ -210,6 +229,7 @@ class TestExtractColors:
 class TestGeneratePalette:
     def test_complementary_from_red(self):
         from mcp_video.image_engine import generate_palette
+
         path = _create_solid_image((255, 0, 0))
         try:
             result = generate_palette(path, harmony="complementary")
@@ -225,6 +245,7 @@ class TestGeneratePalette:
 
     def test_triadic_from_red(self):
         from mcp_video.image_engine import generate_palette
+
         path = _create_solid_image((255, 0, 0))
         try:
             result = generate_palette(path, harmony="triadic")
@@ -235,6 +256,7 @@ class TestGeneratePalette:
 
     def test_invalid_harmony(self):
         from mcp_video.image_engine import generate_palette
+
         path = _create_solid_image((128, 128, 128))
         try:
             with pytest.raises(MCPVideoError) as exc_info:
@@ -247,6 +269,7 @@ class TestGeneratePalette:
 class TestAnalyzeProduct:
     def test_no_ai(self):
         from mcp_video.image_engine import analyze_product
+
         path = _create_solid_image((64, 128, 200))
         try:
             result = analyze_product(path, use_ai=False)
@@ -269,6 +292,7 @@ class TestGracefulError:
         with patch.dict("sys.modules", {"PIL": None, "PIL.Image": None}):
             # Force ImportError by patching the import
             import builtins
+
             real_import = builtins.__import__
 
             def mock_import(name, *args, **kwargs):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -24,8 +24,12 @@ from mcp_video.models import (
 class TestVideoInfo:
     def test_basic_creation(self):
         info = VideoInfo(
-            path="/tmp/video.mp4", duration=10.5,
-            width=1920, height=1080, fps=30.0, codec="h264",
+            path="/tmp/video.mp4",
+            duration=10.5,
+            width=1920,
+            height=1080,
+            fps=30.0,
+            codec="h264",
         )
         assert info.path == "/tmp/video.mp4"
         assert info.duration == 10.5
@@ -36,8 +40,12 @@ class TestVideoInfo:
 
     def test_optional_fields_default_none(self):
         info = VideoInfo(
-            path="/tmp/video.mp4", duration=5.0,
-            width=640, height=480, fps=24.0, codec="h264",
+            path="/tmp/video.mp4",
+            duration=5.0,
+            width=640,
+            height=480,
+            fps=24.0,
+            codec="h264",
         )
         assert info.audio_codec is None
         assert info.audio_sample_rate is None
@@ -47,10 +55,17 @@ class TestVideoInfo:
 
     def test_optional_fields_set(self):
         info = VideoInfo(
-            path="/tmp/video.mp4", duration=5.0,
-            width=640, height=480, fps=24.0, codec="h264",
-            audio_codec="aac", audio_sample_rate=44100,
-            bitrate=5000000, size_bytes=10485760, format="mp4",
+            path="/tmp/video.mp4",
+            duration=5.0,
+            width=640,
+            height=480,
+            fps=24.0,
+            codec="h264",
+            audio_codec="aac",
+            audio_sample_rate=44100,
+            bitrate=5000000,
+            size_bytes=10485760,
+            format="mp4",
         )
         assert info.audio_codec == "aac"
         assert info.audio_sample_rate == 44100
@@ -60,59 +75,91 @@ class TestVideoInfo:
 
     def test_resolution_property(self):
         info = VideoInfo(
-            path="/tmp/video.mp4", duration=5.0,
-            width=1920, height=1080, fps=30.0, codec="h264",
+            path="/tmp/video.mp4",
+            duration=5.0,
+            width=1920,
+            height=1080,
+            fps=30.0,
+            codec="h264",
         )
         assert info.resolution == "1920x1080"
 
     def test_aspect_ratio_property(self):
         info = VideoInfo(
-            path="/tmp/video.mp4", duration=5.0,
-            width=1920, height=1080, fps=30.0, codec="h264",
+            path="/tmp/video.mp4",
+            duration=5.0,
+            width=1920,
+            height=1080,
+            fps=30.0,
+            codec="h264",
         )
         assert info.aspect_ratio == "16:9"
 
     def test_aspect_ratio_4_3(self):
         info = VideoInfo(
-            path="/tmp/video.mp4", duration=5.0,
-            width=640, height=480, fps=30.0, codec="h264",
+            path="/tmp/video.mp4",
+            duration=5.0,
+            width=640,
+            height=480,
+            fps=30.0,
+            codec="h264",
         )
         assert info.aspect_ratio == "4:3"
 
     def test_aspect_ratio_9_16(self):
         info = VideoInfo(
-            path="/tmp/video.mp4", duration=5.0,
-            width=1080, height=1920, fps=30.0, codec="h264",
+            path="/tmp/video.mp4",
+            duration=5.0,
+            width=1080,
+            height=1920,
+            fps=30.0,
+            codec="h264",
         )
         assert info.aspect_ratio == "9:16"
 
     def test_size_mb_property(self):
         info = VideoInfo(
-            path="/tmp/video.mp4", duration=5.0,
-            width=640, height=480, fps=30.0, codec="h264",
+            path="/tmp/video.mp4",
+            duration=5.0,
+            width=640,
+            height=480,
+            fps=30.0,
+            codec="h264",
             size_bytes=10485760,  # 10 MB
         )
         assert info.size_mb == 10.0
 
     def test_size_mb_property_none(self):
         info = VideoInfo(
-            path="/tmp/video.mp4", duration=5.0,
-            width=640, height=480, fps=30.0, codec="h264",
+            path="/tmp/video.mp4",
+            duration=5.0,
+            width=640,
+            height=480,
+            fps=30.0,
+            codec="h264",
         )
         assert info.size_mb is None
 
     def test_size_mb_property_rounding(self):
         info = VideoInfo(
-            path="/tmp/video.mp4", duration=5.0,
-            width=640, height=480, fps=30.0, codec="h264",
+            path="/tmp/video.mp4",
+            duration=5.0,
+            width=640,
+            height=480,
+            fps=30.0,
+            codec="h264",
             size_bytes=1500000,  # ~1.43 MB
         )
         assert info.size_mb == 1.43
 
     def test_model_dump(self):
         info = VideoInfo(
-            path="/tmp/video.mp4", duration=5.0,
-            width=640, height=480, fps=30.0, codec="h264",
+            path="/tmp/video.mp4",
+            duration=5.0,
+            width=640,
+            height=480,
+            fps=30.0,
+            codec="h264",
         )
         d = info.model_dump()
         assert d["path"] == "/tmp/video.mp4"
@@ -256,7 +303,9 @@ class TestTimelineTextElement:
 
     def test_custom(self):
         elem = TimelineTextElement(
-            text="Title", start=1.0, duration=3.0,
+            text="Title",
+            start=1.0,
+            duration=3.0,
             position="bottom-center",
             style={"font": "Arial", "size": 36, "color": "yellow"},
         )
@@ -311,7 +360,8 @@ class TestTimeline:
 
     def test_with_tracks(self):
         tl = Timeline(
-            width=1080, height=1920,
+            width=1080,
+            height=1920,
             tracks=[
                 TimelineTrack(type="video", clips=[TimelineClip(source="v.mp4")]),
             ],
@@ -394,8 +444,12 @@ class TestInvalidInputs:
         # Pydantic doesn't enforce positive by default on int fields,
         # but validate that model accepts valid inputs
         info = VideoInfo(
-            path="/tmp/v.mp4", duration=1.0,
-            width=100, height=100, fps=30.0, codec="h264",
+            path="/tmp/v.mp4",
+            duration=1.0,
+            width=100,
+            height=100,
+            fps=30.0,
+            codec="h264",
         )
         assert info.width == 100
 
@@ -484,4 +538,7 @@ class TestEditResultNewFields:
         )
         d = result.model_dump()
         assert "thumbnail_base64" in d
-        assert d["thumbnail_base64"] == "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+        assert (
+            d["thumbnail_base64"]
+            == "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+        )

--- a/tests/test_quality_guardrails.py
+++ b/tests/test_quality_guardrails.py
@@ -39,11 +39,20 @@ def create_test_video(output_path: str, color: str = "gray", duration: float = 2
     ffmpeg_color = color_map.get(color, "gray")
 
     cmd = [
-        "ffmpeg", "-y",
-        "-f", "lavfi", "-i", f"color=c={ffmpeg_color}:s=320x240:d={duration}",
-        "-f", "lavfi", "-i", f"sine=frequency=1000:duration={duration}",
-        "-pix_fmt", "yuv420p", "-shortest",
-        output_path
+        "ffmpeg",
+        "-y",
+        "-f",
+        "lavfi",
+        "-i",
+        f"color=c={ffmpeg_color}:s=320x240:d={duration}",
+        "-f",
+        "lavfi",
+        "-i",
+        f"sine=frequency=1000:duration={duration}",
+        "-pix_fmt",
+        "yuv420p",
+        "-shortest",
+        output_path,
     ]
     result = subprocess.run(cmd, capture_output=True, text=True)
     if result.returncode != 0:
@@ -55,11 +64,16 @@ def create_video_no_audio(output_path: str, color: str = "gray", duration: float
     """Create a test video without audio."""
     ffmpeg_color = color
     cmd = [
-        "ffmpeg", "-y",
-        "-f", "lavfi", "-i", f"color=c={ffmpeg_color}:s=320x240:d={duration}",
-        "-pix_fmt", "yuv420p",
+        "ffmpeg",
+        "-y",
+        "-f",
+        "lavfi",
+        "-i",
+        f"color=c={ffmpeg_color}:s=320x240:d={duration}",
+        "-pix_fmt",
+        "yuv420p",
         "-an",  # No audio
-        output_path
+        output_path,
     ]
     result = subprocess.run(cmd, capture_output=True, text=True)
     if result.returncode != 0:
@@ -73,11 +87,7 @@ class TestQualityReport:
     def test_quality_report_creation(self):
         """Test creating a QualityReport."""
         report = QualityReport(
-            check_name="brightness",
-            passed=True,
-            score=85.0,
-            message="Brightness is good",
-            details={"y_avg": 128.0}
+            check_name="brightness", passed=True, score=85.0, message="Brightness is good", details={"y_avg": 128.0}
         )
         assert report.check_name == "brightness"
         assert report.passed is True
@@ -201,27 +211,30 @@ class TestVisualQualityGuardrails:
 
     def test_run_ffprobe_logs_nonzero_exit(self, guardrails):
         fake = Mock(return_value=Mock(returncode=1, stdout="", stderr="ffprobe failed"))
-        with patch("mcp_video.quality_guardrails.subprocess.run", fake), patch(
-            "mcp_video.quality_guardrails.logger.warning"
-        ) as mock_warning:
+        with (
+            patch("mcp_video.quality_guardrails.subprocess.run", fake),
+            patch("mcp_video.quality_guardrails.logger.warning") as mock_warning,
+        ):
             result = guardrails._run_ffprobe("/tmp/test.mp4", "lavfi.signalstats.YAVG")
             assert result["_error"]["stage"] == "ffprobe_signalstats"
         mock_warning.assert_called()
 
     def test_get_rgb_means_logs_nonzero_exit(self, guardrails):
         fake = Mock(return_value=Mock(returncode=1, stdout="", stderr="ffprobe failed"))
-        with patch("mcp_video.quality_guardrails.subprocess.run", fake), patch(
-            "mcp_video.quality_guardrails.logger.warning"
-        ) as mock_warning:
+        with (
+            patch("mcp_video.quality_guardrails.subprocess.run", fake),
+            patch("mcp_video.quality_guardrails.logger.warning") as mock_warning,
+        ):
             result = guardrails._get_rgb_means("/tmp/test.mp4")
             assert result["_error"]["stage"] == "ffprobe_rgb_means"
         mock_warning.assert_called()
 
     def test_analyze_loudnorm_logs_missing_json(self, guardrails):
         fake = Mock(return_value=Mock(returncode=0, stdout="", stderr="no structured data"))
-        with patch("mcp_video.quality_guardrails.subprocess.run", fake), patch(
-            "mcp_video.quality_guardrails.logger.warning"
-        ) as mock_warning:
+        with (
+            patch("mcp_video.quality_guardrails.subprocess.run", fake),
+            patch("mcp_video.quality_guardrails.logger.warning") as mock_warning,
+        ):
             result = guardrails._analyze_loudnorm("/tmp/test.mp4")
             assert result["_error"]["stage"] == "ffmpeg_loudnorm"
         mock_warning.assert_called()
@@ -235,7 +248,9 @@ class TestVisualQualityGuardrails:
     def test_check_brightness_exposes_fallback_diagnostic_details(self, guardrails):
         with (
             patch.object(guardrails, "_run_ffprobe", return_value={"_error": {"stage": "ffprobe_signalstats"}}),
-            patch.object(guardrails, "_run_ffmpeg_signalstats", return_value={"_error": {"stage": "ffmpeg_signalstats"}}),
+            patch.object(
+                guardrails, "_run_ffmpeg_signalstats", return_value={"_error": {"stage": "ffmpeg_signalstats"}}
+            ),
         ):
             report = guardrails.check_brightness("/tmp/test.mp4")
         assert report.passed is False

--- a/tests/test_real_all_features.py
+++ b/tests/test_real_all_features.py
@@ -22,15 +22,12 @@ from mcp_video import Client
 
 # Test video files (real media)
 TEST_VIDEOS = {
-    'explainer': 'out/McpVideoExplainer-FINAL.mp4',
-    'original': 'out/McpVideoExplainerV1.mp4',
+    "explainer": "out/McpVideoExplainer-FINAL.mp4",
+    "original": "out/McpVideoExplainerV1.mp4",
 }
 
 # Skip if no test videos
-skip_no_video = pytest.mark.skipif(
-    not os.path.exists(TEST_VIDEOS['explainer']),
-    reason="Test video not found"
-)
+skip_no_video = pytest.mark.skipif(not os.path.exists(TEST_VIDEOS["explainer"]), reason="Test video not found")
 pytestmark = [skip_no_video]
 
 
@@ -49,6 +46,7 @@ def has_ai_upscale_backend() -> bool:
 # FIXTURES
 # =============================================================================
 
+
 @pytest.fixture
 def client():
     """Provide a fresh Client instance."""
@@ -58,7 +56,7 @@ def client():
 @pytest.fixture
 def test_video():
     """Provide the main test video path."""
-    return TEST_VIDEOS['explainer']
+    return TEST_VIDEOS["explainer"]
 
 
 @pytest.fixture
@@ -72,17 +70,33 @@ def output_dir():
 def sample_clips(output_dir):
     """Create sample video clips for testing."""
     clips = []
-    colors = ['red', 'blue', 'green', 'yellow']
+    colors = ["red", "blue", "green", "yellow"]
 
     for color in colors:
-        clip_path = os.path.join(output_dir, f'sample_{color}.mp4')
-        subprocess.run([
-            'ffmpeg', '-y', '-f', 'lavfi',
-            '-i', f'color=c={color}:s=640x480:d=2',
-            '-f', 'lavfi', '-i', 'sine=frequency=1000:duration=2',
-            '-c:v', 'libx264', '-c:a', 'aac', '-pix_fmt', 'yuv420p',
-            clip_path
-        ], capture_output=True, check=True)
+        clip_path = os.path.join(output_dir, f"sample_{color}.mp4")
+        subprocess.run(
+            [
+                "ffmpeg",
+                "-y",
+                "-f",
+                "lavfi",
+                "-i",
+                f"color=c={color}:s=640x480:d=2",
+                "-f",
+                "lavfi",
+                "-i",
+                "sine=frequency=1000:duration=2",
+                "-c:v",
+                "libx264",
+                "-c:a",
+                "aac",
+                "-pix_fmt",
+                "yuv420p",
+                clip_path,
+            ],
+            capture_output=True,
+            check=True,
+        )
         clips.append(clip_path)
 
     return clips
@@ -91,21 +105,39 @@ def sample_clips(output_dir):
 @pytest.fixture
 def short_test_clip(output_dir):
     """Create a short test clip (3s) for quality checks that would timeout on full video."""
-    clip_path = os.path.join(output_dir, 'short_test.mp4')
-    subprocess.run([
-        'ffmpeg', '-y', '-f', 'lavfi',
-        '-i', 'color=c=blue:s=640x480:d=3',
-        '-f', 'lavfi', '-i', 'sine=frequency=1000:duration=3',
-        '-c:v', 'libx264', '-c:a', 'aac', '-pix_fmt', 'yuv420p',
-        '-vf', 'drawtext=text=Test:fontsize=30:fontcolor=white:x=10:y=10',
-        clip_path
-    ], capture_output=True, check=True)
+    clip_path = os.path.join(output_dir, "short_test.mp4")
+    subprocess.run(
+        [
+            "ffmpeg",
+            "-y",
+            "-f",
+            "lavfi",
+            "-i",
+            "color=c=blue:s=640x480:d=3",
+            "-f",
+            "lavfi",
+            "-i",
+            "sine=frequency=1000:duration=3",
+            "-c:v",
+            "libx264",
+            "-c:a",
+            "aac",
+            "-pix_fmt",
+            "yuv420p",
+            "-vf",
+            "drawtext=text=Test:fontsize=30:fontcolor=white:x=10:y=10",
+            clip_path,
+        ],
+        capture_output=True,
+        check=True,
+    )
     return clip_path
 
 
 # =============================================================================
 # CATEGORY A: CORE VIDEO EDITING (Tests 01-18)
 # =============================================================================
+
 
 @pytest.mark.slow
 class TestCoreVideoEditing:
@@ -124,7 +156,7 @@ class TestCoreVideoEditing:
 
     def test_02_trim_video(self, client, test_video, output_dir):
         """Trim video to specific time range."""
-        output = os.path.join(output_dir, 'trimmed.mp4')
+        output = os.path.join(output_dir, "trimmed.mp4")
 
         result = client.trim(test_video, start=10, duration=5, output=output)
 
@@ -137,7 +169,7 @@ class TestCoreVideoEditing:
 
     def test_03_merge_videos(self, client, sample_clips, output_dir):
         """Merge multiple video clips."""
-        output = os.path.join(output_dir, 'merged.mp4')
+        output = os.path.join(output_dir, "merged.mp4")
 
         result = client.merge(sample_clips[:2], output=output)
 
@@ -150,7 +182,7 @@ class TestCoreVideoEditing:
 
     def test_04_resize_video(self, client, test_video, output_dir):
         """Resize video to different resolution."""
-        output = os.path.join(output_dir, 'resized_720p.mp4')
+        output = os.path.join(output_dir, "resized_720p.mp4")
 
         result = client.resize(test_video, width=1280, height=720, output=output)
 
@@ -162,7 +194,7 @@ class TestCoreVideoEditing:
 
     def test_05_change_speed(self, client, sample_clips, output_dir):
         """Change video playback speed."""
-        output = os.path.join(output_dir, '2x_speed.mp4')
+        output = os.path.join(output_dir, "2x_speed.mp4")
 
         result = client.speed(sample_clips[0], factor=2.0, output=output)
 
@@ -174,19 +206,19 @@ class TestCoreVideoEditing:
 
     def test_06_extract_frame(self, client, test_video, output_dir):
         """Extract a single frame as image."""
-        output = os.path.join(output_dir, 'frame.png')
+        output = os.path.join(output_dir, "frame.png")
 
         result = client.extract_frame(test_video, timestamp=5.0, output=output)
 
         # ThumbnailResult uses frame_path not output_path
-        frame_path = result.frame_path if hasattr(result, 'frame_path') else getattr(result, 'output_path', output)
+        frame_path = result.frame_path if hasattr(result, "frame_path") else getattr(result, "output_path", output)
         assert os.path.exists(frame_path)
-        assert frame_path.endswith('.png')
+        assert frame_path.endswith(".png")
         print(f"✓ Frame extracted: {frame_path}")
 
     def test_07_fade_video(self, client, sample_clips, output_dir):
         """Add fade in/out to video."""
-        output = os.path.join(output_dir, 'faded.mp4')
+        output = os.path.join(output_dir, "faded.mp4")
 
         result = client.fade(sample_clips[0], fade_in=0.5, fade_out=0.5, output=output)
 
@@ -196,7 +228,7 @@ class TestCoreVideoEditing:
 
     def test_08_crop_video(self, client, test_video, output_dir):
         """Crop video to region."""
-        output = os.path.join(output_dir, 'cropped.mp4')
+        output = os.path.join(output_dir, "cropped.mp4")
 
         result = client.crop(test_video, width=800, height=600, x=560, y=240, output=output)
 
@@ -208,7 +240,7 @@ class TestCoreVideoEditing:
 
     def test_09_rotate_video(self, client, sample_clips, output_dir):
         """Rotate video 90 degrees."""
-        output = os.path.join(output_dir, 'rotated.mp4')
+        output = os.path.join(output_dir, "rotated.mp4")
 
         result = client.rotate(sample_clips[0], angle=90, output=output)
 
@@ -221,7 +253,7 @@ class TestCoreVideoEditing:
 
     def test_10_flip_video(self, client, sample_clips, output_dir):
         """Flip video horizontally."""
-        output = os.path.join(output_dir, 'flipped.mp4')
+        output = os.path.join(output_dir, "flipped.mp4")
 
         result = client.rotate(sample_clips[0], flip_horizontal=True, output=output)
 
@@ -231,7 +263,7 @@ class TestCoreVideoEditing:
 
     def test_11_reverse_video(self, client, sample_clips, output_dir):
         """Reverse video playback."""
-        output = os.path.join(output_dir, 'reversed.mp4')
+        output = os.path.join(output_dir, "reversed.mp4")
 
         result = client.reverse(sample_clips[0], output=output)
 
@@ -240,16 +272,12 @@ class TestCoreVideoEditing:
         print("✓ Video reversed")
 
     @pytest.mark.skipif(
-        subprocess.run(
-            ["ffmpeg", "-filters"],
-            capture_output=True,
-            text=True
-        ).stdout.find("vidstabdetect") == -1,
-        reason="Requires FFmpeg with vidstabdetect filter"
+        subprocess.run(["ffmpeg", "-filters"], capture_output=True, text=True).stdout.find("vidstabdetect") == -1,
+        reason="Requires FFmpeg with vidstabdetect filter",
     )
     def test_12_stabilize_video(self, client, sample_clips, output_dir):
         """Stabilize shaky video."""
-        output = os.path.join(output_dir, 'stabilized.mp4')
+        output = os.path.join(output_dir, "stabilized.mp4")
 
         # Use a short clip for faster test
         result = client.stabilize(sample_clips[0], smoothing=10, output=output)
@@ -260,10 +288,10 @@ class TestCoreVideoEditing:
 
     def test_13_chroma_key(self, client, sample_clips, output_dir):
         """Remove green screen background."""
-        output = os.path.join(output_dir, 'keyed.mp4')
+        output = os.path.join(output_dir, "keyed.mp4")
 
         # Use green clip for chroma key
-        result = client.chroma_key(sample_clips[2], color='0x00FF00', similarity=0.1, output=output)
+        result = client.chroma_key(sample_clips[2], color="0x00FF00", similarity=0.1, output=output)
 
         assert result.success
         assert os.path.exists(result.output_path)
@@ -271,7 +299,7 @@ class TestCoreVideoEditing:
 
     def test_14_blur_video(self, client, sample_clips, output_dir):
         """Apply blur effect."""
-        output = os.path.join(output_dir, 'blurred.mp4')
+        output = os.path.join(output_dir, "blurred.mp4")
 
         result = client.blur(sample_clips[0], radius=5, output=output)
 
@@ -282,15 +310,26 @@ class TestCoreVideoEditing:
     def test_15_watermark_video(self, client, sample_clips, output_dir):
         """Add image watermark."""
         # Create a simple watermark image
-        watermark = os.path.join(output_dir, 'watermark.png')
-        subprocess.run([
-            'ffmpeg', '-y', '-f', 'lavfi',
-            '-i', 'color=c=white:s=100x50',
-            '-vf', 'drawtext=text=WM:fontsize=30:fontcolor=black',
-            '-frames:v', '1', watermark
-        ], capture_output=True, check=True)
+        watermark = os.path.join(output_dir, "watermark.png")
+        subprocess.run(
+            [
+                "ffmpeg",
+                "-y",
+                "-f",
+                "lavfi",
+                "-i",
+                "color=c=white:s=100x50",
+                "-vf",
+                "drawtext=text=WM:fontsize=30:fontcolor=black",
+                "-frames:v",
+                "1",
+                watermark,
+            ],
+            capture_output=True,
+            check=True,
+        )
 
-        output = os.path.join(output_dir, 'watermarked.mp4')
+        output = os.path.join(output_dir, "watermarked.mp4")
         result = client.watermark(sample_clips[0], image=watermark, output=output)
 
         assert result.success
@@ -299,15 +338,9 @@ class TestCoreVideoEditing:
 
     def test_16_add_text(self, client, sample_clips, output_dir):
         """Burn text overlay."""
-        output = os.path.join(output_dir, 'text_overlay.mp4')
+        output = os.path.join(output_dir, "text_overlay.mp4")
 
-        result = client.add_text(
-            sample_clips[0],
-            text="Hello World",
-            position="center",
-            size=48,
-            output=output
-        )
+        result = client.add_text(sample_clips[0], text="Hello World", position="center", size=48, output=output)
 
         assert result.success
         assert os.path.exists(result.output_path)
@@ -315,15 +348,10 @@ class TestCoreVideoEditing:
 
     def test_17_overlay_video(self, client, sample_clips, output_dir):
         """Picture-in-picture overlay."""
-        output = os.path.join(output_dir, 'overlay.mp4')
+        output = os.path.join(output_dir, "overlay.mp4")
 
         result = client.overlay_video(
-            sample_clips[0],
-            overlay=sample_clips[1],
-            position="top-right",
-            width=160,
-            height=120,
-            output=output
+            sample_clips[0], overlay=sample_clips[1], position="top-right", width=160, height=120, output=output
         )
 
         assert result.success
@@ -332,14 +360,9 @@ class TestCoreVideoEditing:
 
     def test_18_split_screen(self, client, sample_clips, output_dir):
         """Side-by-side split screen."""
-        output = os.path.join(output_dir, 'split.mp4')
+        output = os.path.join(output_dir, "split.mp4")
 
-        result = client.split_screen(
-            sample_clips[0],
-            sample_clips[1],
-            layout="side-by-side",
-            output=output
-        )
+        result = client.split_screen(sample_clips[0], sample_clips[1], layout="side-by-side", output=output)
 
         assert result.success
         assert os.path.exists(result.output_path)
@@ -350,24 +373,25 @@ class TestCoreVideoEditing:
 # CATEGORY B: AUDIO FEATURES (Tests 19-28)
 # =============================================================================
 
+
 @pytest.mark.slow
 class TestAudioFeatures:
     """Test audio processing features."""
 
     def test_19_extract_audio(self, client, sample_clips, output_dir):
         """Extract audio track from video."""
-        output = os.path.join(output_dir, 'audio.mp3')
+        output = os.path.join(output_dir, "audio.mp3")
 
-        result = client.extract_audio(sample_clips[0], output=output, format='mp3')
+        result = client.extract_audio(sample_clips[0], output=output, format="mp3")
 
         assert result.success
         assert os.path.exists(result.output_path)
-        assert result.output_path.endswith('.mp3')
+        assert result.output_path.endswith(".mp3")
         print(f"✓ Audio extracted: {result.output_path}")
 
     def test_20_normalize_audio(self, client, sample_clips, output_dir):
         """Normalize audio loudness."""
-        output = os.path.join(output_dir, 'normalized.mp4')
+        output = os.path.join(output_dir, "normalized.mp4")
 
         result = client.normalize_audio(sample_clips[0], target_lufs=-16.0, output=output)
 
@@ -377,36 +401,30 @@ class TestAudioFeatures:
 
     def test_21_audio_synthesize(self, client, output_dir):
         """Generate synthetic audio."""
-        output = os.path.join(output_dir, 'synth.wav')
+        output = os.path.join(output_dir, "synth.wav")
 
-        result = client.audio_synthesize(
-            output=output,
-            waveform='sine',
-            frequency=440.0,
-            duration=1.0,
-            volume=0.5
-        )
+        result = client.audio_synthesize(output=output, waveform="sine", frequency=440.0, duration=1.0, volume=0.5)
 
         assert os.path.exists(result)
         print("✓ Synthesized 1s sine wave at 440Hz")
 
     def test_22_audio_preset(self, client, output_dir):
         """Generate preset sound."""
-        output = os.path.join(output_dir, 'preset.wav')
+        output = os.path.join(output_dir, "preset.wav")
 
-        result = client.audio_preset('ui-blip', output=output)
+        result = client.audio_preset("ui-blip", output=output)
 
         assert os.path.exists(result)
         print("✓ Generated 'ui-blip' preset")
 
     def test_23_audio_sequence(self, client, output_dir):
         """Create timed audio sequence."""
-        output = os.path.join(output_dir, 'sequence.wav')
+        output = os.path.join(output_dir, "sequence.wav")
 
         sequence = [
-            {'type': 'tone', 'at': 0.0, 'duration': 0.2, 'frequency': 800},
-            {'type': 'tone', 'at': 0.3, 'duration': 0.2, 'frequency': 1000},
-            {'type': 'tone', 'at': 0.6, 'duration': 0.2, 'frequency': 1200},
+            {"type": "tone", "at": 0.0, "duration": 0.2, "frequency": 800},
+            {"type": "tone", "at": 0.3, "duration": 0.2, "frequency": 1000},
+            {"type": "tone", "at": 0.6, "duration": 0.2, "frequency": 1200},
         ]
 
         result = client.audio_sequence(sequence, output=output)
@@ -416,18 +434,18 @@ class TestAudioFeatures:
 
     def test_24_audio_compose(self, client, output_dir):
         """Layer multiple audio tracks."""
-        output = os.path.join(output_dir, 'composed.wav')
+        output = os.path.join(output_dir, "composed.wav")
 
         # Create two simple audio files
-        audio1 = os.path.join(output_dir, 'track1.wav')
-        audio2 = os.path.join(output_dir, 'track2.wav')
+        audio1 = os.path.join(output_dir, "track1.wav")
+        audio2 = os.path.join(output_dir, "track2.wav")
 
-        client.audio_synthesize(output=audio1, waveform='sine', frequency=440, duration=2.0)
-        client.audio_synthesize(output=audio2, waveform='sine', frequency=880, duration=2.0)
+        client.audio_synthesize(output=audio1, waveform="sine", frequency=440, duration=2.0)
+        client.audio_synthesize(output=audio2, waveform="sine", frequency=880, duration=2.0)
 
         tracks = [
-            {'file': audio1, 'volume': 0.5, 'start': 0},
-            {'file': audio2, 'volume': 0.3, 'start': 0.5},
+            {"file": audio1, "volume": 0.5, "start": 0},
+            {"file": audio2, "volume": 0.3, "start": 0.5},
         ]
 
         result = client.audio_compose(tracks, duration=2.5, output=output)
@@ -437,14 +455,14 @@ class TestAudioFeatures:
 
     def test_25_audio_effects(self, client, output_dir):
         """Apply audio effects chain."""
-        output = os.path.join(output_dir, 'effected.wav')
+        output = os.path.join(output_dir, "effected.wav")
 
         # Create input audio
-        input_audio = os.path.join(output_dir, 'input.wav')
-        client.audio_synthesize(output=input_audio, waveform='sine', frequency=1000, duration=1.0)
+        input_audio = os.path.join(output_dir, "input.wav")
+        client.audio_synthesize(output=input_audio, waveform="sine", frequency=1000, duration=1.0)
 
         effects = [
-            {'type': 'gain', 'params': {'db': -6}},
+            {"type": "gain", "params": {"db": -6}},
         ]
 
         result = client.audio_effects(input_audio, output=output, effects=effects)
@@ -454,11 +472,11 @@ class TestAudioFeatures:
 
     def test_26_add_audio(self, client, sample_clips, output_dir):
         """Add audio to video."""
-        output = os.path.join(output_dir, 'with_audio.mp4')
+        output = os.path.join(output_dir, "with_audio.mp4")
 
         # Create audio file
-        audio = os.path.join(output_dir, 'music.wav')
-        client.audio_synthesize(output=audio, waveform='sine', frequency=500, duration=2.0)
+        audio = os.path.join(output_dir, "music.wav")
+        client.audio_synthesize(output=audio, waveform="sine", frequency=500, duration=2.0)
 
         result = client.add_audio(sample_clips[0], audio=audio, mix=True, output=output)
 
@@ -476,12 +494,9 @@ class TestAudioFeatures:
 
     def test_28_add_generated_audio(self, client, sample_clips, output_dir):
         """Add procedural audio to video."""
-        output = os.path.join(output_dir, 'with_drone.mp4')
+        output = os.path.join(output_dir, "with_drone.mp4")
 
-        audio_config = {
-            'drone': {'frequency': 100, 'volume': 0.2},
-            'events': [{'type': 'blip', 'at': 0.5}]
-        }
+        audio_config = {"drone": {"frequency": 100, "volume": 0.2}, "events": [{"type": "blip", "at": 0.5}]}
 
         result = client.add_generated_audio(sample_clips[0], audio_config, output=output)
 
@@ -493,13 +508,14 @@ class TestAudioFeatures:
 # CATEGORY C: VISUAL EFFECTS (Tests 29-36)
 # =============================================================================
 
+
 @pytest.mark.slow
 class TestVisualEffects:
     """Test visual effect filters."""
 
     def test_29_effect_vignette(self, client, sample_clips, output_dir):
         """Apply vignette effect."""
-        output = os.path.join(output_dir, 'vignette.mp4')
+        output = os.path.join(output_dir, "vignette.mp4")
 
         result = client.effect_vignette(sample_clips[0], output, intensity=0.5)
 
@@ -508,7 +524,7 @@ class TestVisualEffects:
 
     def test_30_effect_chromatic_aberration(self, client, sample_clips, output_dir):
         """Apply RGB chromatic aberration."""
-        output = os.path.join(output_dir, 'chromatic.mp4')
+        output = os.path.join(output_dir, "chromatic.mp4")
 
         result = client.effect_chromatic_aberration(sample_clips[0], output, intensity=3.0)
 
@@ -517,7 +533,7 @@ class TestVisualEffects:
 
     def test_31_effect_scanlines(self, client, sample_clips, output_dir):
         """Apply CRT scanlines."""
-        output = os.path.join(output_dir, 'scanlines.mp4')
+        output = os.path.join(output_dir, "scanlines.mp4")
 
         result = client.effect_scanlines(sample_clips[0], output, line_height=2, opacity=0.5)
 
@@ -526,16 +542,16 @@ class TestVisualEffects:
 
     def test_32_effect_noise(self, client, sample_clips, output_dir):
         """Apply film grain noise."""
-        output = os.path.join(output_dir, 'noise.mp4')
+        output = os.path.join(output_dir, "noise.mp4")
 
-        result = client.effect_noise(sample_clips[0], output, intensity=0.05, mode='film')
+        result = client.effect_noise(sample_clips[0], output, intensity=0.05, mode="film")
 
         assert os.path.exists(result)
         print("✓ Film noise applied")
 
     def test_33_effect_glow(self, client, sample_clips, output_dir):
         """Apply bloom/glow effect."""
-        output = os.path.join(output_dir, 'glow.mp4')
+        output = os.path.join(output_dir, "glow.mp4")
 
         result = client.effect_glow(sample_clips[0], output, intensity=0.6, radius=15)
 
@@ -544,9 +560,9 @@ class TestVisualEffects:
 
     def test_34_color_grade(self, client, sample_clips, output_dir):
         """Apply color grading preset."""
-        output = os.path.join(output_dir, 'graded.mp4')
+        output = os.path.join(output_dir, "graded.mp4")
 
-        result = client.color_grade(sample_clips[0], preset='warm', output=output)
+        result = client.color_grade(sample_clips[0], preset="warm", output=output)
 
         assert result.success
         assert os.path.exists(result.output_path)
@@ -554,13 +570,9 @@ class TestVisualEffects:
 
     def test_35_apply_filter(self, client, sample_clips, output_dir):
         """Apply custom FFmpeg filter."""
-        output = os.path.join(output_dir, 'filtered.mp4')
+        output = os.path.join(output_dir, "filtered.mp4")
 
-        result = client.filter(
-            sample_clips[0],
-            filter_type='grayscale',
-            output=output
-        )
+        result = client.filter(sample_clips[0], filter_type="grayscale", output=output)
 
         assert result.success
         assert os.path.exists(result.output_path)
@@ -569,15 +581,26 @@ class TestVisualEffects:
     def test_36_apply_mask(self, client, sample_clips, output_dir):
         """Apply image mask."""
         # Create a simple mask
-        mask = os.path.join(output_dir, 'mask.png')
-        subprocess.run([
-            'ffmpeg', '-y', '-f', 'lavfi',
-            '-i', 'color=c=white:s=640x480',
-            '-vf', 'format=gray',
-            '-frames:v', '1', mask
-        ], capture_output=True, check=True)
+        mask = os.path.join(output_dir, "mask.png")
+        subprocess.run(
+            [
+                "ffmpeg",
+                "-y",
+                "-f",
+                "lavfi",
+                "-i",
+                "color=c=white:s=640x480",
+                "-vf",
+                "format=gray",
+                "-frames:v",
+                "1",
+                mask,
+            ],
+            capture_output=True,
+            check=True,
+        )
 
-        output = os.path.join(output_dir, 'masked.mp4')
+        output = os.path.join(output_dir, "masked.mp4")
         result = client.apply_mask(sample_clips[0], mask=mask, output=output)
 
         assert result.success
@@ -589,42 +612,34 @@ class TestVisualEffects:
 # CATEGORY D: TRANSITIONS (Tests 37-39)
 # =============================================================================
 
+
 @pytest.mark.slow
 class TestTransitions:
     """Test video transitions."""
 
     def test_37_transition_glitch(self, client, sample_clips, output_dir):
         """Apply glitch transition."""
-        output = os.path.join(output_dir, 'glitch_transition.mp4')
+        output = os.path.join(output_dir, "glitch_transition.mp4")
 
-        result = client.transition_glitch(
-            sample_clips[0], sample_clips[1],
-            output=output, duration=0.5
-        )
+        result = client.transition_glitch(sample_clips[0], sample_clips[1], output=output, duration=0.5)
 
         assert os.path.exists(result)
         print("✓ Glitch transition applied")
 
     def test_38_transition_pixelate(self, client, sample_clips, output_dir):
         """Apply pixelate transition."""
-        output = os.path.join(output_dir, 'pixelate_transition.mp4')
+        output = os.path.join(output_dir, "pixelate_transition.mp4")
 
-        result = client.transition_pixelate(
-            sample_clips[0], sample_clips[1],
-            output=output, duration=0.4
-        )
+        result = client.transition_pixelate(sample_clips[0], sample_clips[1], output=output, duration=0.4)
 
         assert os.path.exists(result)
         print("✓ Pixelate transition applied")
 
     def test_39_transition_morph(self, client, sample_clips, output_dir):
         """Apply morph transition."""
-        output = os.path.join(output_dir, 'morph_transition.mp4')
+        output = os.path.join(output_dir, "morph_transition.mp4")
 
-        result = client.transition_morph(
-            sample_clips[0], sample_clips[1],
-            output=output, duration=0.6
-        )
+        result = client.transition_morph(sample_clips[0], sample_clips[1], output=output, duration=0.6)
 
         assert os.path.exists(result)
         print("✓ Morph transition applied")
@@ -633,6 +648,7 @@ class TestTransitions:
 # =============================================================================
 # CATEGORY E: AI FEATURES (Tests 40-47)
 # =============================================================================
+
 
 @pytest.mark.slow
 class TestAIFeatures:
@@ -647,34 +663,24 @@ class TestAIFeatures:
 
     def test_41_ai_remove_silence(self, client, sample_clips, output_dir):
         """Remove silent sections."""
-        output = os.path.join(output_dir, 'no_silence.mp4')
+        output = os.path.join(output_dir, "no_silence.mp4")
 
-        result = client.ai_remove_silence(
-            sample_clips[0], output,
-            silence_threshold=-50,
-            min_silence_duration=0.3
-        )
+        result = client.ai_remove_silence(sample_clips[0], output, silence_threshold=-50, min_silence_duration=0.3)
 
         assert os.path.exists(result)
         print("✓ Silence removed")
 
-    @pytest.mark.skipif(
-        not importlib.util.find_spec("whisper"),
-        reason="Whisper not installed"
-    )
+    @pytest.mark.skipif(not importlib.util.find_spec("whisper"), reason="Whisper not installed")
     def test_42_ai_transcribe(self, client, test_video, output_dir):
         """Transcribe speech (requires Whisper)."""
-        output_srt = os.path.join(output_dir, 'transcript.srt')
+        output_srt = os.path.join(output_dir, "transcript.srt")
 
-        result = client.ai_transcribe(test_video, output_srt=output_srt, model='tiny')
+        result = client.ai_transcribe(test_video, output_srt=output_srt, model="tiny")
 
-        assert 'transcript' in result
+        assert "transcript" in result
         print("✓ Transcription complete")
 
-    @pytest.mark.skipif(
-        not importlib.util.find_spec("demucs"),
-        reason="Demucs not installed"
-    )
+    @pytest.mark.skipif(not importlib.util.find_spec("demucs"), reason="Demucs not installed")
     def test_43_ai_stem_separation(self, client, sample_clips, output_dir):
         """Separate audio into stems (requires Demucs)."""
         result = client.ai_stem_separation(sample_clips[0], output_dir)
@@ -688,7 +694,7 @@ class TestAIFeatures:
     )
     def test_44_ai_upscale(self, client, sample_clips, output_dir):
         """Upscale video using AI (OpenCV DNN fallback if Real-ESRGAN not available)."""
-        output = os.path.join(output_dir, 'upscaled.mp4')
+        output = os.path.join(output_dir, "upscaled.mp4")
 
         result = client.ai_upscale(sample_clips[0], output, scale=2)
 
@@ -701,20 +707,20 @@ class TestAIFeatures:
 
     def test_45_ai_color_grade(self, client, sample_clips, output_dir):
         """Auto color grade video."""
-        output = os.path.join(output_dir, 'ai_graded.mp4')
+        output = os.path.join(output_dir, "ai_graded.mp4")
 
-        result = client.ai_color_grade(sample_clips[0], output, style='cinematic')
+        result = client.ai_color_grade(sample_clips[0], output, style="cinematic")
 
         assert os.path.exists(result)
         print("✓ AI color grading applied")
 
     def test_46_audio_spatial(self, client, sample_clips, output_dir):
         """Apply 3D spatial audio."""
-        output = os.path.join(output_dir, 'spatial.mp4')
+        output = os.path.join(output_dir, "spatial.mp4")
 
         positions = [
-            {'time': 0, 'azimuth': -45, 'elevation': 0},
-            {'time': 1, 'azimuth': 45, 'elevation': 0},
+            {"time": 0, "azimuth": -45, "elevation": 0},
+            {"time": 1, "azimuth": 45, "elevation": 0},
         ]
 
         result = client.audio_spatial(sample_clips[0], output, positions)
@@ -725,13 +731,13 @@ class TestAIFeatures:
     def test_47_extract_colors(self, client, sample_clips, output_dir):
         """Extract dominant colors from frame."""
         # First extract a frame to a file path
-        frame_path = os.path.join(output_dir, 'frame_for_colors.png')
+        frame_path = os.path.join(output_dir, "frame_for_colors.png")
         frame_result = client.extract_frame(sample_clips[0], timestamp=1.0, output=frame_path)
-        actual_path = frame_result.frame_path if hasattr(frame_result, 'frame_path') else frame_path
+        actual_path = frame_result.frame_path if hasattr(frame_result, "frame_path") else frame_path
 
         result = client.extract_colors(actual_path, n_colors=5)
 
-        assert hasattr(result, 'colors') or isinstance(result, dict)
+        assert hasattr(result, "colors") or isinstance(result, dict)
         print("✓ Colors extracted")
 
 
@@ -739,49 +745,35 @@ class TestAIFeatures:
 # CATEGORY F: LAYOUT & COMPOSITION (Tests 48-55)
 # =============================================================================
 
+
 @pytest.mark.slow
 class TestLayoutComposition:
     """Test layout and composition features."""
 
     def test_48_layout_grid(self, client, sample_clips, output_dir):
         """Create grid layout."""
-        output = os.path.join(output_dir, 'grid.mp4')
+        output = os.path.join(output_dir, "grid.mp4")
 
-        result = client.layout_grid(
-            sample_clips[:4],
-            layout='2x2',
-            output=output
-        )
+        result = client.layout_grid(sample_clips[:4], layout="2x2", output=output)
 
         assert os.path.exists(result)
         print("✓ 2x2 grid layout created")
 
     def test_49_layout_pip(self, client, sample_clips, output_dir):
         """Picture-in-picture layout."""
-        output = os.path.join(output_dir, 'pip.mp4')
+        output = os.path.join(output_dir, "pip.mp4")
 
-        result = client.layout_pip(
-            sample_clips[0],
-            sample_clips[1],
-            output=output,
-            position='bottom-right',
-            size=0.25
-        )
+        result = client.layout_pip(sample_clips[0], sample_clips[1], output=output, position="bottom-right", size=0.25)
 
         assert os.path.exists(result)
         print("✓ PiP layout created")
 
     def test_50_text_animated(self, client, sample_clips, output_dir):
         """Add animated text."""
-        output = os.path.join(output_dir, 'animated_text.mp4')
+        output = os.path.join(output_dir, "animated_text.mp4")
 
         result = client.text_animated(
-            sample_clips[0],
-            text="Animated!",
-            output=output,
-            animation='fade',
-            start=0.5,
-            duration=1.0
+            sample_clips[0], text="Animated!", output=output, animation="fade", start=0.5, duration=1.0
         )
 
         assert os.path.exists(result)
@@ -790,8 +782,8 @@ class TestLayoutComposition:
     def test_51_text_subtitles(self, client, sample_clips, output_dir):
         """Burn SRT subtitles."""
         # Create SRT file
-        srt_path = os.path.join(output_dir, 'subs.srt')
-        with open(srt_path, 'w') as f:
+        srt_path = os.path.join(output_dir, "subs.srt")
+        with open(srt_path, "w") as f:
             f.write("""1
 00:00:00,000 --> 00:00:01,000
 Hello World
@@ -801,7 +793,7 @@ Hello World
 Test Subtitle
 """)
 
-        output = os.path.join(output_dir, 'with_subs.mp4')
+        output = os.path.join(output_dir, "with_subs.mp4")
         result = client.text_subtitles(sample_clips[0], srt_path, output)
 
         assert os.path.exists(result)
@@ -809,28 +801,18 @@ Test Subtitle
 
     def test_52_mograph_count(self, client, output_dir):
         """Generate animated counter."""
-        output = os.path.join(output_dir, 'counter.mp4')
+        output = os.path.join(output_dir, "counter.mp4")
 
-        result = client.mograph_count(
-            start=0,
-            end=100,
-            duration=2.0,
-            output=output
-        )
+        result = client.mograph_count(start=0, end=100, duration=2.0, output=output)
 
         assert os.path.exists(result)
         print("✓ Counter animation created")
 
     def test_53_mograph_progress(self, client, output_dir):
         """Generate progress bar."""
-        output = os.path.join(output_dir, 'progress.mp4')
+        output = os.path.join(output_dir, "progress.mp4")
 
-        result = client.mograph_progress(
-            duration=2.0,
-            output=output,
-            style='bar',
-            color='#CCFF00'
-        )
+        result = client.mograph_progress(duration=2.0, output=output, style="bar", color="#CCFF00")
 
         assert os.path.exists(result)
         print("✓ Progress bar animation created")
@@ -838,15 +820,15 @@ Test Subtitle
     def test_54_create_from_images(self, client, sample_clips, output_dir):
         """Create video from image sequence."""
         # Export frames first
-        frames_dir = os.path.join(output_dir, 'frames')
+        frames_dir = os.path.join(output_dir, "frames")
         os.makedirs(frames_dir, exist_ok=True)
 
         client.export_frames(sample_clips[0], output_dir=frames_dir, fps=5)
 
         # Get exported frames
-        images = sorted([os.path.join(frames_dir, f) for f in os.listdir(frames_dir) if f.endswith('.jpg')])
+        images = sorted([os.path.join(frames_dir, f) for f in os.listdir(frames_dir) if f.endswith(".jpg")])
 
-        output = os.path.join(output_dir, 'from_images.mp4')
+        output = os.path.join(output_dir, "from_images.mp4")
         result = client.create_from_images(images[:5], output=output, fps=5)
 
         assert result.success
@@ -855,13 +837,13 @@ Test Subtitle
 
     def test_55_export_frames(self, client, sample_clips, output_dir):
         """Export video frames as images."""
-        output_dir = os.path.join(output_dir, 'exported_frames')
+        output_dir = os.path.join(output_dir, "exported_frames")
         os.makedirs(output_dir, exist_ok=True)
 
         client.export_frames(sample_clips[0], output_dir=output_dir, fps=2)
 
         assert os.path.exists(output_dir)
-        frames = [f for f in os.listdir(output_dir) if f.endswith('.jpg')]
+        frames = [f for f in os.listdir(output_dir) if f.endswith(".jpg")]
         assert len(frames) > 0
         print(f"✓ {len(frames)} frames exported")
 
@@ -869,6 +851,7 @@ Test Subtitle
 # =============================================================================
 # CATEGORY G: QUALITY & METADATA (Tests 56-63)
 # =============================================================================
+
 
 @pytest.mark.slow
 class TestQualityMetadata:
@@ -880,10 +863,10 @@ class TestQualityMetadata:
 
         # Result can be dict or QualityReport object
         if isinstance(result, dict):
-            assert 'all_passed' in result or 'valid' in result
+            assert "all_passed" in result or "valid" in result
         else:
             # QualityReport object has all_passed attribute
-            assert hasattr(result, 'all_passed')
+            assert hasattr(result, "all_passed")
         print("✓ Quality check completed")
 
     def test_57_design_quality_check(self, client, short_test_clip):
@@ -892,17 +875,17 @@ class TestQualityMetadata:
 
         # Result can be dict or DesignQualityReport object
         if isinstance(result, dict):
-            assert 'overall_score' in result
-            score = result.get('overall_score', 0)
+            assert "overall_score" in result
+            score = result.get("overall_score", 0)
         else:
             # DesignQualityReport object
-            assert hasattr(result, 'overall_score')
+            assert hasattr(result, "overall_score")
             score = result.overall_score
         print(f"✓ Design quality score: {score}")
 
     def test_58_fix_design_issues(self, client, sample_clips, output_dir):
         """Auto-fix design issues."""
-        output = os.path.join(output_dir, 'design_fixed.mp4')
+        output = os.path.join(output_dir, "design_fixed.mp4")
 
         result = client.fix_design_issues(sample_clips[0], output=output)
 
@@ -912,16 +895,16 @@ class TestQualityMetadata:
     def test_59_compare_quality(self, client, short_test_clip, output_dir):
         """Compare video quality."""
         # Create a lower quality version for comparison
-        distorted = os.path.join(output_dir, 'distorted.mp4')
-        subprocess.run([
-            'ffmpeg', '-y', '-i', short_test_clip,
-            '-crf', '35', '-vf', 'scale=320:240',
-            distorted
-        ], capture_output=True, check=True)
+        distorted = os.path.join(output_dir, "distorted.mp4")
+        subprocess.run(
+            ["ffmpeg", "-y", "-i", short_test_clip, "-crf", "35", "-vf", "scale=320:240", distorted],
+            capture_output=True,
+            check=True,
+        )
 
         result = client.compare_quality(short_test_clip, distorted)
 
-        assert isinstance(result, dict) or hasattr(result, 'metrics')
+        assert isinstance(result, dict) or hasattr(result, "metrics")
         print("✓ Quality comparison complete")
 
     def test_60_auto_chapters(self, client, test_video):
@@ -936,7 +919,7 @@ class TestQualityMetadata:
         result = client.video_info_detailed(test_video)
 
         assert isinstance(result, dict)
-        assert 'duration' in result
+        assert "duration" in result
         print(f"✓ Detailed info: {len(result)} fields")
 
     def test_62_read_metadata(self, client, test_video):
@@ -944,19 +927,15 @@ class TestQualityMetadata:
         result = client.read_metadata(test_video)
 
         # MetadataResult object with tags dict
-        assert hasattr(result, 'tags')
+        assert hasattr(result, "tags")
         assert isinstance(result.tags, dict)
         print(f"✓ Metadata read: {len(result.tags)} tags")
 
     def test_63_write_metadata(self, client, sample_clips, output_dir):
         """Write video metadata."""
-        output = os.path.join(output_dir, 'with_metadata.mp4')
+        output = os.path.join(output_dir, "with_metadata.mp4")
 
-        metadata = {
-            'title': 'Test Video',
-            'author': 'mcp-video Test',
-            'comment': 'Generated by test suite'
-        }
+        metadata = {"title": "Test Video", "author": "mcp-video Test", "comment": "Generated by test suite"}
 
         result = client.write_metadata(sample_clips[0], metadata=metadata, output=output)
 
@@ -970,24 +949,25 @@ class TestQualityMetadata:
 # CATEGORY H: UTILITY (Tests 64-70)
 # =============================================================================
 
+
 @pytest.mark.slow
 class TestUtility:
     """Test utility operations."""
 
     def test_64_convert_format(self, client, sample_clips, output_dir):
         """Convert video format."""
-        output = os.path.join(output_dir, 'converted.webm')
+        output = os.path.join(output_dir, "converted.webm")
 
-        result = client.convert(sample_clips[0], format='webm', output=output)
+        result = client.convert(sample_clips[0], format="webm", output=output)
 
         assert result.success
         assert os.path.exists(result.output_path)
-        assert result.output_path.endswith('.webm')
+        assert result.output_path.endswith(".webm")
         print("✓ Converted to WebM")
 
     def test_65_preview(self, client, test_video, output_dir):
         """Generate low-res preview."""
-        output = os.path.join(output_dir, 'preview.mp4')
+        output = os.path.join(output_dir, "preview.mp4")
 
         result = client.preview(test_video, output=output, scale_factor=4)
 
@@ -999,49 +979,42 @@ class TestUtility:
 
     def test_66_storyboard(self, client, test_video, output_dir):
         """Extract key frames as storyboard."""
-        output_dir = os.path.join(output_dir, 'storyboard')
+        output_dir = os.path.join(output_dir, "storyboard")
         os.makedirs(output_dir, exist_ok=True)
 
         client.storyboard(test_video, output_dir=output_dir, frame_count=8)
 
         assert os.path.exists(output_dir)
-        frames = [f for f in os.listdir(output_dir) if f.endswith('.jpg')]
+        frames = [f for f in os.listdir(output_dir) if f.endswith(".jpg")]
         # 8 frame files + 1 storyboard_grid.jpg
         assert len(frames) >= 8
         print(f"✓ Storyboard: {len(frames)} files")
 
     def test_67_thumbnail(self, client, test_video, output_dir):
         """Extract thumbnail."""
-        output = os.path.join(output_dir, 'thumb.jpg')
+        output = os.path.join(output_dir, "thumb.jpg")
 
         result = client.thumbnail(test_video, timestamp=10.0, output=output)
 
         # ThumbnailResult uses frame_path not output_path
-        frame_path = result.frame_path if hasattr(result, 'frame_path') else output
+        frame_path = result.frame_path if hasattr(result, "frame_path") else output
         assert os.path.exists(frame_path)
         print("✓ Thumbnail extracted")
 
     def test_68_batch_process(self, client, sample_clips, output_dir):
         """Batch process multiple files."""
-        result = client.batch(
-            sample_clips[:2],
-            operation='resize',
-            params={'width': 320, 'height': 240}
-        )
+        result = client.batch(sample_clips[:2], operation="resize", params={"width": 320, "height": 240})
 
         assert isinstance(result, dict)
         print(f"✓ Batch processed: {len(result)} files")
 
     def test_69_timeline_edit(self, client, sample_clips, output_dir):
         """Execute timeline-based edit."""
-        output = os.path.join(output_dir, 'timeline_edit.mp4')
+        output = os.path.join(output_dir, "timeline_edit.mp4")
 
         timeline = {
-            'tracks': [{
-                'type': 'video',
-                'clips': [{'source': sample_clips[0], 'in': 0, 'out': 1}]
-            }],
-            'output': output
+            "tracks": [{"type": "video", "clips": [{"source": sample_clips[0], "in": 0, "out": 1}]}],
+            "output": output,
         }
 
         result = client.edit(timeline, output=output)
@@ -1053,15 +1026,15 @@ class TestUtility:
     def test_70_generate_subtitles(self, client, sample_clips, output_dir):
         """Generate subtitles from entries."""
         entries = [
-            {'start': 0.0, 'end': 1.0, 'text': 'First line'},
-            {'start': 1.0, 'end': 2.0, 'text': 'Second line'},
+            {"start": 0.0, "end": 1.0, "text": "First line"},
+            {"start": 1.0, "end": 2.0, "text": "Second line"},
         ]
 
         result = client.generate_subtitles(sample_clips[0], entries, burn=False)
 
         assert result.success
         # SubtitleResult uses srt_path not subtitle_path
-        srt_path = result.srt_path if hasattr(result, 'srt_path') else None
+        srt_path = result.srt_path if hasattr(result, "srt_path") else None
         assert srt_path and os.path.exists(srt_path)
         print("✓ Subtitles generated")
 
@@ -1069,6 +1042,7 @@ class TestUtility:
 # =============================================================================
 # MAIN
 # =============================================================================
+
 
 def run_all_tests():
     """Run the complete test suite."""
@@ -1081,8 +1055,8 @@ def run_all_tests():
         print(f"  {exists} {name}: {path}")
     print()
 
-    pytest.main([__file__, '-v', '--tb=short', '-s'])
+    pytest.main([__file__, "-v", "--tb=short", "-s"])
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     run_all_tests()

--- a/tests/test_real_exhaustive.py
+++ b/tests/test_real_exhaustive.py
@@ -18,16 +18,15 @@ from mcp_video import Client
 
 # Test video files (real media)
 TEST_VIDEOS = {
-    'explainer': 'out/McpVideoExplainer-FINAL.mp4',
-    'original': 'out/McpVideoExplainerV1.mp4',
-    'short': 'out/new-scenes-bright.mp4',
+    "explainer": "out/McpVideoExplainer-FINAL.mp4",
+    "original": "out/McpVideoExplainerV1.mp4",
+    "short": "out/new-scenes-bright.mp4",
 }
 
 # Skip if no test videos
 pytestmark = [
     pytest.mark.skipif(
-        not os.path.exists(TEST_VIDEOS['explainer']),
-        reason="Test video not found - run explainer render first"
+        not os.path.exists(TEST_VIDEOS["explainer"]), reason="Test video not found - run explainer render first"
     ),
     pytest.mark.slow,
 ]
@@ -42,7 +41,7 @@ class TestRealVideoEditing:
 
     @pytest.fixture
     def test_video(self):
-        return TEST_VIDEOS['explainer']
+        return TEST_VIDEOS["explainer"]
 
     @pytest.fixture
     def output_dir(self):
@@ -63,21 +62,19 @@ class TestRealVideoEditing:
     def test_02_trim_video(self, client, test_video, output_dir):
         """Trim real video."""
         print("\n[Test] Trim 10-20s from video...")
-        output = os.path.join(output_dir, 'trimmed.mp4')
+        output = os.path.join(output_dir, "trimmed.mp4")
 
-        result = client.edit({
-            'tracks': [{
-                'type': 'video',
-                'clips': [{
-                    'source': test_video,
-                    'in': 0,
-                    'out': 10,
-                    'trim_start': 10,
-                    'trim_end': 90
-                }]
-            }],
-            'output': output
-        })
+        result = client.edit(
+            {
+                "tracks": [
+                    {
+                        "type": "video",
+                        "clips": [{"source": test_video, "in": 0, "out": 10, "trim_start": 10, "trim_end": 90}],
+                    }
+                ],
+                "output": output,
+            }
+        )
 
         # Check edit was successful
         assert result.success
@@ -87,15 +84,28 @@ class TestRealVideoEditing:
     def test_03_resize_video(self, client, test_video, output_dir):
         """Resize to 720p."""
         print("\n[Test] Resize to 720p...")
-        output = os.path.join(output_dir, '720p.mp4')
+        output = os.path.join(output_dir, "720p.mp4")
 
         # Use ffmpeg directly for resize test
-        subprocess.run([
-            'ffmpeg', '-y', '-i', test_video,
-            '-t', '5', '-vf', 'scale=1280:720',
-            '-c:v', 'libx264', '-c:a', 'aac',
-            output
-        ], capture_output=True, check=True)
+        subprocess.run(
+            [
+                "ffmpeg",
+                "-y",
+                "-i",
+                test_video,
+                "-t",
+                "5",
+                "-vf",
+                "scale=1280:720",
+                "-c:v",
+                "libx264",
+                "-c:a",
+                "aac",
+                output,
+            ],
+            capture_output=True,
+            check=True,
+        )
 
         assert os.path.exists(output)
         info = client.info(output)
@@ -114,7 +124,7 @@ class TestRealAIFeatures:
     def test_04_ai_scene_detect(self, client):
         """Detect scenes in video."""
         print("\n[Test] AI scene detection...")
-        test_video = TEST_VIDEOS.get('explainer')
+        test_video = TEST_VIDEOS.get("explainer")
         if not test_video or not os.path.exists(test_video):
             pytest.skip("No test video available")
 
@@ -139,20 +149,46 @@ class TestRealEffects:
     def test_05_transition_glitch(self, client, output_dir):
         """Apply glitch transition."""
         print("\n[Test] Glitch transition...")
-        clip1 = os.path.join(output_dir, 'clip1.mp4')
-        clip2 = os.path.join(output_dir, 'clip2.mp4')
+        clip1 = os.path.join(output_dir, "clip1.mp4")
+        clip2 = os.path.join(output_dir, "clip2.mp4")
 
-        subprocess.run([
-            'ffmpeg', '-y', '-f', 'lavfi', '-i', 'color=c=red:s=320x240:d=2',
-            '-c:v', 'libx264', '-pix_fmt', 'yuv420p', clip1
-        ], capture_output=True, check=True)
+        subprocess.run(
+            [
+                "ffmpeg",
+                "-y",
+                "-f",
+                "lavfi",
+                "-i",
+                "color=c=red:s=320x240:d=2",
+                "-c:v",
+                "libx264",
+                "-pix_fmt",
+                "yuv420p",
+                clip1,
+            ],
+            capture_output=True,
+            check=True,
+        )
 
-        subprocess.run([
-            'ffmpeg', '-y', '-f', 'lavfi', '-i', 'color=c=blue:s=320x240:d=2',
-            '-c:v', 'libx264', '-pix_fmt', 'yuv420p', clip2
-        ], capture_output=True, check=True)
+        subprocess.run(
+            [
+                "ffmpeg",
+                "-y",
+                "-f",
+                "lavfi",
+                "-i",
+                "color=c=blue:s=320x240:d=2",
+                "-c:v",
+                "libx264",
+                "-pix_fmt",
+                "yuv420p",
+                clip2,
+            ],
+            capture_output=True,
+            check=True,
+        )
 
-        output = os.path.join(output_dir, 'glitch.mp4')
+        output = os.path.join(output_dir, "glitch.mp4")
         result = client.transition_glitch(clip1, clip2, output, duration=0.5)
 
         assert os.path.exists(result)
@@ -161,19 +197,45 @@ class TestRealEffects:
     def test_06_transition_pixelate(self, client, output_dir):
         """Apply pixelate transition."""
         print("\n[Test] Pixelate transition...")
-        clip1 = os.path.join(output_dir, 'clip1.mp4')
-        clip2 = os.path.join(output_dir, 'clip2.mp4')
-        output = os.path.join(output_dir, 'pixelate.mp4')
+        clip1 = os.path.join(output_dir, "clip1.mp4")
+        clip2 = os.path.join(output_dir, "clip2.mp4")
+        output = os.path.join(output_dir, "pixelate.mp4")
 
         # Create fresh clips
-        subprocess.run([
-            'ffmpeg', '-y', '-f', 'lavfi', '-i', 'color=c=green:s=320x240:d=2',
-            '-c:v', 'libx264', '-pix_fmt', 'yuv420p', clip1
-        ], capture_output=True, check=True)
-        subprocess.run([
-            'ffmpeg', '-y', '-f', 'lavfi', '-i', 'color=c=yellow:s=320x240:d=2',
-            '-c:v', 'libx264', '-pix_fmt', 'yuv420p', clip2
-        ], capture_output=True, check=True)
+        subprocess.run(
+            [
+                "ffmpeg",
+                "-y",
+                "-f",
+                "lavfi",
+                "-i",
+                "color=c=green:s=320x240:d=2",
+                "-c:v",
+                "libx264",
+                "-pix_fmt",
+                "yuv420p",
+                clip1,
+            ],
+            capture_output=True,
+            check=True,
+        )
+        subprocess.run(
+            [
+                "ffmpeg",
+                "-y",
+                "-f",
+                "lavfi",
+                "-i",
+                "color=c=yellow:s=320x240:d=2",
+                "-c:v",
+                "libx264",
+                "-pix_fmt",
+                "yuv420p",
+                clip2,
+            ],
+            capture_output=True,
+            check=True,
+        )
 
         result = client.transition_pixelate(clip1, clip2, output, duration=0.4)
 
@@ -183,19 +245,45 @@ class TestRealEffects:
     def test_07_transition_morph(self, client, output_dir):
         """Apply morph transition."""
         print("\n[Test] Morph transition...")
-        clip1 = os.path.join(output_dir, 'clip1.mp4')
-        clip2 = os.path.join(output_dir, 'clip2.mp4')
-        output = os.path.join(output_dir, 'morph.mp4')
+        clip1 = os.path.join(output_dir, "clip1.mp4")
+        clip2 = os.path.join(output_dir, "clip2.mp4")
+        output = os.path.join(output_dir, "morph.mp4")
 
         # Create fresh clips
-        subprocess.run([
-            'ffmpeg', '-y', '-f', 'lavfi', '-i', 'color=c=purple:s=320x240:d=2',
-            '-c:v', 'libx264', '-pix_fmt', 'yuv420p', clip1
-        ], capture_output=True, check=True)
-        subprocess.run([
-            'ffmpeg', '-y', '-f', 'lavfi', '-i', 'color=c=orange:s=320x240:d=2',
-            '-c:v', 'libx264', '-pix_fmt', 'yuv420p', clip2
-        ], capture_output=True, check=True)
+        subprocess.run(
+            [
+                "ffmpeg",
+                "-y",
+                "-f",
+                "lavfi",
+                "-i",
+                "color=c=purple:s=320x240:d=2",
+                "-c:v",
+                "libx264",
+                "-pix_fmt",
+                "yuv420p",
+                clip1,
+            ],
+            capture_output=True,
+            check=True,
+        )
+        subprocess.run(
+            [
+                "ffmpeg",
+                "-y",
+                "-f",
+                "lavfi",
+                "-i",
+                "color=c=orange:s=320x240:d=2",
+                "-c:v",
+                "libx264",
+                "-pix_fmt",
+                "yuv420p",
+                clip2,
+            ],
+            capture_output=True,
+            check=True,
+        )
 
         result = client.transition_morph(clip1, clip2, output, duration=0.6)
 
@@ -212,7 +300,7 @@ class TestRealQualityGuardrails:
 
     @pytest.fixture
     def test_video(self):
-        return TEST_VIDEOS.get('explainer')
+        return TEST_VIDEOS.get("explainer")
 
     def test_08_video_info_detailed(self, client, test_video):
         """Get detailed video info."""
@@ -223,7 +311,7 @@ class TestRealQualityGuardrails:
         result = client.video_info_detailed(test_video)
 
         assert isinstance(result, dict)
-        assert 'duration' in result
+        assert "duration" in result
         print(f"  ✓ Detailed info: {len(result)} fields")
 
     def test_09_quality_check(self, client, test_video):
@@ -260,8 +348,8 @@ def run_all_tests():
         print(f"  {exists} {name}: {path}")
     print()
 
-    pytest.main([__file__, '-v', '--tb=short', '-s'])
+    pytest.main([__file__, "-v", "--tb=short", "-s"])
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     run_all_tests()

--- a/tests/test_real_media.py
+++ b/tests/test_real_media.py
@@ -268,7 +268,8 @@ class TestOverlayRealMedia:
         _require_ffmpeg()
         out = str(tmp_path / "pip.mov")
         result = overlay_video(
-            real_landscape, real_square,
+            real_landscape,
+            real_square,
             position="bottom-right",
             width=360,
             output_path=out,
@@ -285,7 +286,8 @@ class TestOverlayRealMedia:
         _require_ffmpeg()
         out = str(tmp_path / "pip_timed.mov")
         result = overlay_video(
-            real_landscape, real_portrait,
+            real_landscape,
+            real_portrait,
             position="top-left",
             width=480,
             start_time=0.0,
@@ -303,7 +305,8 @@ class TestOverlayRealMedia:
         _require_ffmpeg()
         out = str(tmp_path / "png_overlay.mov")
         result = overlay_video(
-            real_landscape, real_png,
+            real_landscape,
+            real_png,
             position="center",
             width=400,
             opacity=0.9,
@@ -320,7 +323,8 @@ class TestOverlayRealMedia:
         _require_ffmpeg()
         out = str(tmp_path / "crop_overlay.mp4")
         result = overlay_video(
-            real_mp4, real_crop,
+            real_mp4,
+            real_crop,
             position="top-right",
             width=320,
             height=240,
@@ -480,8 +484,10 @@ class TestCrossFeatureRealMedia:
         # Step 2: overlay square on filtered video
         out = str(tmp_path / "filtered_pip.mov")
         r2 = overlay_video(
-            r1.output_path, real_square,
-            position="bottom-right", width=320,
+            r1.output_path,
+            real_square,
+            position="bottom-right",
+            width=320,
             output_path=out,
         )
         assert r2.success

--- a/tests/test_red_team.py
+++ b/tests/test_red_team.py
@@ -1,16 +1,40 @@
 """Red team: adversarial edge-case tests for mcp-video."""
+
 import os
 import subprocess
 
 import pytest
 
 from mcp_video.engine import (
-    add_text, apply_filter, audio_waveform, chroma_key, compare_quality,
-    convert, crop, create_from_images, detect_scenes, edit_timeline,
-    export_frames, extract_audio, fade, generate_subtitles, merge,
-    normalize_audio, overlay_video, probe, reverse,
-    rotate, speed, split_screen, stabilize, storyboard, thumbnail,
-    trim, watermark, write_metadata, apply_mask
+    add_text,
+    apply_filter,
+    audio_waveform,
+    chroma_key,
+    compare_quality,
+    convert,
+    crop,
+    create_from_images,
+    detect_scenes,
+    edit_timeline,
+    export_frames,
+    extract_audio,
+    fade,
+    generate_subtitles,
+    merge,
+    normalize_audio,
+    overlay_video,
+    probe,
+    reverse,
+    rotate,
+    speed,
+    split_screen,
+    stabilize,
+    storyboard,
+    thumbnail,
+    trim,
+    watermark,
+    write_metadata,
+    apply_mask,
 )
 from mcp_video.errors import InputFileError, ProcessingError, MCPVideoError
 
@@ -26,15 +50,21 @@ def unicode_video(tmp_path):
     video_path = tmp_path / "测试视频🎬.mp4"
     subprocess.run(
         [
-            "ffmpeg", "-y",
-            "-f", "lavfi",
-            "-i", "smptehdbars=size=320x240:duration=1:rate=30",
-            "-c:v", "libx264", "-preset", "ultrafast",
+            "ffmpeg",
+            "-y",
+            "-f",
+            "lavfi",
+            "-i",
+            "smptehdbars=size=320x240:duration=1:rate=30",
+            "-c:v",
+            "libx264",
+            "-preset",
+            "ultrafast",
             "-an",
-            str(video_path)
+            str(video_path),
         ],
         capture_output=True,
-        timeout=15
+        timeout=15,
     )
     if not video_path.exists():
         pytest.skip("Could not create unicode video")
@@ -47,15 +77,21 @@ def tiny_video(tmp_path):
     video_path = tmp_path / "tiny.mp4"
     subprocess.run(
         [
-            "ffmpeg", "-y",
-            "-f", "lavfi",
-            "-i", "color=c=black:size=1x1:duration=1:rate=30",
-            "-c:v", "libx264", "-preset", "ultrafast",
+            "ffmpeg",
+            "-y",
+            "-f",
+            "lavfi",
+            "-i",
+            "color=c=black:size=1x1:duration=1:rate=30",
+            "-c:v",
+            "libx264",
+            "-preset",
+            "ultrafast",
             "-an",
-            str(video_path)
+            str(video_path),
         ],
         capture_output=True,
-        timeout=15
+        timeout=15,
     )
     if not video_path.exists():
         pytest.skip("Could not create tiny video")
@@ -192,7 +228,9 @@ class TestMissingDependencies:
             # If it fails due to missing filter, that's acceptable
             # Just verify it's a dependency error, not a crash
             error_str = str(e).lower()
-            assert "vidstab" in error_str or "filter" in error_str or "not found" in error_str or "available" in error_str
+            assert (
+                "vidstab" in error_str or "filter" in error_str or "not found" in error_str or "available" in error_str
+            )
 
     def test_apply_filter_unsupported(self, sample_video):
         """Applying an unsupported filter should fail gracefully."""
@@ -210,7 +248,7 @@ class TestLargeBatch:
         result = video_batch(
             ["/nonexistent1.mp4", sample_video, "/nonexistent2.mp4"],
             operation="trim",
-            params={"start": "0", "duration": "1"}
+            params={"start": "0", "duration": "1"},
         )
 
         # Should have partial success

--- a/tests/test_remotion_engine.py
+++ b/tests/test_remotion_engine.py
@@ -30,6 +30,7 @@ from mcp_video.errors import (
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def _make_completed_process(
     returncode: int = 0,
     stdout: str = "",
@@ -46,22 +47,24 @@ def _make_completed_process(
 
 def _mock_deps_ok():
     """Return a patcher that makes shutil.which find node and npx."""
+
     def _which(name: str):
         if name in ("node", "npx", "npm"):
             return f"/usr/bin/{name}"
         return None
+
     return patch("mcp_video.remotion_engine.shutil.which", side_effect=_which)
 
 
 def _mock_project_ok(project_dir: str):
     """Return a patcher that makes _validate_project succeed."""
-    return patch.object(Path, "is_dir", return_value=True), \
-           patch.object(Path, "is_file", return_value=True)
+    return patch.object(Path, "is_dir", return_value=True), patch.object(Path, "is_file", return_value=True)
 
 
 # ---------------------------------------------------------------------------
 # Test: _require_remotion_deps
 # ---------------------------------------------------------------------------
+
 
 class TestRequireRemotionDeps:
     """Tests for _require_remotion_deps()."""
@@ -76,10 +79,12 @@ class TestRequireRemotionDeps:
     @patch("mcp_video.remotion_engine.shutil.which")
     def test_raises_when_npx_missing(self, mock_which):
         """Should raise RemotionNotFoundError when npx is not on PATH."""
+
         def _which(name: str):
             if name == "node":
                 return "/usr/bin/node"
             return None
+
         mock_which.side_effect = _which
 
         with pytest.raises(RemotionNotFoundError, match="npx not found"):
@@ -88,8 +93,10 @@ class TestRequireRemotionDeps:
     @patch("mcp_video.remotion_engine.shutil.which")
     def test_passes_when_both_found(self, mock_which):
         """Should not raise when both node and npx are available."""
+
         def _which(name: str):
             return f"/usr/bin/{name}"
+
         mock_which.side_effect = _which
 
         _require_remotion_deps()  # should not raise
@@ -106,6 +113,7 @@ class TestRequireRemotionDeps:
 # ---------------------------------------------------------------------------
 # Test: _validate_project
 # ---------------------------------------------------------------------------
+
 
 class TestValidateProject:
     """Tests for _validate_project()."""
@@ -132,9 +140,7 @@ class TestValidateProject:
         (tmp_path / "package.json").write_text("{}")
         src_dir = tmp_path / "src"
         src_dir.mkdir()
-        (src_dir / "Root.tsx").write_text(
-            'import { registerRoot } from "remotion";\nregisterRoot();'
-        )
+        (src_dir / "Root.tsx").write_text('import { registerRoot } from "remotion";\nregisterRoot();')
 
         project_dir, _entry_point = _validate_project(str(tmp_path))
         assert project_dir == tmp_path.resolve()
@@ -145,6 +151,7 @@ class TestValidateProject:
 # Test: render
 # ---------------------------------------------------------------------------
 
+
 class TestRender:
     """Tests for render()."""
 
@@ -153,11 +160,12 @@ class TestRender:
         project = str(sample_remotion_project)
         fake_cp = _make_completed_process(stdout="Rendered.")
 
-        with _mock_deps_ok(), \
-             patch("mcp_video.remotion_engine.subprocess.run", return_value=fake_cp) as mock_run, \
-             patch("os.path.isfile", return_value=True), \
-             patch("os.path.getsize", return_value=1024 * 1024):
-
+        with (
+            _mock_deps_ok(),
+            patch("mcp_video.remotion_engine.subprocess.run", return_value=fake_cp) as mock_run,
+            patch("os.path.isfile", return_value=True),
+            patch("os.path.getsize", return_value=1024 * 1024),
+        ):
             render(
                 project,
                 composition_id="MyComp",
@@ -181,11 +189,12 @@ class TestRender:
         project = str(sample_remotion_project)
         fake_cp = _make_completed_process(stdout="done")
 
-        with _mock_deps_ok(), \
-             patch("mcp_video.remotion_engine.subprocess.run", return_value=fake_cp), \
-             patch("os.path.isfile", return_value=True), \
-             patch("os.path.getsize", return_value=2 * 1024 * 1024):
-
+        with (
+            _mock_deps_ok(),
+            patch("mcp_video.remotion_engine.subprocess.run", return_value=fake_cp),
+            patch("os.path.isfile", return_value=True),
+            patch("os.path.getsize", return_value=2 * 1024 * 1024),
+        ):
             result = render(
                 project,
                 composition_id="Comp",
@@ -225,11 +234,12 @@ class TestRender:
         project = str(sample_remotion_project)
         fake_cp = _make_completed_process(stdout="ok")
 
-        with _mock_deps_ok(), \
-             patch("mcp_video.remotion_engine.subprocess.run", return_value=fake_cp), \
-             patch("os.path.isfile", return_value=True), \
-             patch("os.path.getsize", return_value=1024):
-
+        with (
+            _mock_deps_ok(),
+            patch("mcp_video.remotion_engine.subprocess.run", return_value=fake_cp),
+            patch("os.path.isfile", return_value=True),
+            patch("os.path.getsize", return_value=1024),
+        ):
             result = render(
                 project,
                 composition_id="Comp",
@@ -244,11 +254,12 @@ class TestRender:
         project = str(sample_remotion_project)
         fake_cp = _make_completed_process(stdout="ok")
 
-        with _mock_deps_ok(), \
-             patch("mcp_video.remotion_engine.subprocess.run", return_value=fake_cp), \
-             patch("os.path.isfile", return_value=True), \
-             patch("os.path.getsize", return_value=1024):
-
+        with (
+            _mock_deps_ok(),
+            patch("mcp_video.remotion_engine.subprocess.run", return_value=fake_cp),
+            patch("os.path.isfile", return_value=True),
+            patch("os.path.getsize", return_value=1024),
+        ):
             result = render(
                 project,
                 composition_id="Comp",
@@ -261,34 +272,35 @@ class TestRender:
 # Test: compositions
 # ---------------------------------------------------------------------------
 
+
 class TestCompositions:
     """Tests for compositions()."""
 
     def test_parses_json_output(self, sample_remotion_project):
         """compositions() should parse JSON output from Remotion CLI."""
         project = str(sample_remotion_project)
-        comp_json = json.dumps([
-            {
-                "id": "Main",
-                "width": 1920,
-                "height": 1080,
-                "fps": 30,
-                "durationInFrames": 150,
-                "defaultProps": {"title": "Hello"},
-            },
-            {
-                "id": "Second",
-                "width": 1280,
-                "height": 720,
-                "fps": 60,
-                "durationInFrames": 300,
-            },
-        ])
+        comp_json = json.dumps(
+            [
+                {
+                    "id": "Main",
+                    "width": 1920,
+                    "height": 1080,
+                    "fps": 30,
+                    "durationInFrames": 150,
+                    "defaultProps": {"title": "Hello"},
+                },
+                {
+                    "id": "Second",
+                    "width": 1280,
+                    "height": 720,
+                    "fps": 60,
+                    "durationInFrames": 300,
+                },
+            ]
+        )
         fake_cp = _make_completed_process(stdout=comp_json)
 
-        with _mock_deps_ok(), \
-             patch("mcp_video.remotion_engine.subprocess.run", return_value=fake_cp):
-
+        with _mock_deps_ok(), patch("mcp_video.remotion_engine.subprocess.run", return_value=fake_cp):
             result = compositions(project)
             assert len(result.compositions) == 2
             assert result.compositions[0].id == "Main"
@@ -299,18 +311,18 @@ class TestCompositions:
     def test_parses_single_composition_dict(self, sample_remotion_project):
         """compositions() should handle a single composition dict (not wrapped in a list)."""
         project = str(sample_remotion_project)
-        comp_json = json.dumps({
-            "id": "Solo",
-            "width": 1920,
-            "height": 1080,
-            "fps": 30,
-            "durationInFrames": 90,
-        })
+        comp_json = json.dumps(
+            {
+                "id": "Solo",
+                "width": 1920,
+                "height": 1080,
+                "fps": 30,
+                "durationInFrames": 90,
+            }
+        )
         fake_cp = _make_completed_process(stdout=comp_json)
 
-        with _mock_deps_ok(), \
-             patch("mcp_video.remotion_engine.subprocess.run", return_value=fake_cp):
-
+        with _mock_deps_ok(), patch("mcp_video.remotion_engine.subprocess.run", return_value=fake_cp):
             result = compositions(project)
             assert len(result.compositions) == 1
             assert result.compositions[0].id == "Solo"
@@ -318,16 +330,16 @@ class TestCompositions:
     def test_parses_compositions_key_wrapper(self, sample_remotion_project):
         """compositions() should handle {"compositions": [...]} wrapper format."""
         project = str(sample_remotion_project)
-        comp_json = json.dumps({
-            "compositions": [
-                {"id": "A", "width": 1920, "height": 1080, "fps": 30, "durationInFrames": 60},
-            ]
-        })
+        comp_json = json.dumps(
+            {
+                "compositions": [
+                    {"id": "A", "width": 1920, "height": 1080, "fps": 30, "durationInFrames": 60},
+                ]
+            }
+        )
         fake_cp = _make_completed_process(stdout=comp_json)
 
-        with _mock_deps_ok(), \
-             patch("mcp_video.remotion_engine.subprocess.run", return_value=fake_cp):
-
+        with _mock_deps_ok(), patch("mcp_video.remotion_engine.subprocess.run", return_value=fake_cp):
             result = compositions(project)
             assert len(result.compositions) == 1
             assert result.compositions[0].id == "A"
@@ -337,9 +349,7 @@ class TestCompositions:
         project = str(sample_remotion_project)
         fake_cp = _make_completed_process(stdout="not json at all")
 
-        with _mock_deps_ok(), \
-             patch("mcp_video.remotion_engine.subprocess.run", return_value=fake_cp):
-
+        with _mock_deps_ok(), patch("mcp_video.remotion_engine.subprocess.run", return_value=fake_cp):
             result = compositions(project)
             assert result.compositions == []
 
@@ -361,9 +371,7 @@ class TestCompositions:
         comp_json = json.dumps([{"id": "Main"}])
         fake_cp = _make_completed_process(stdout=comp_json)
 
-        with _mock_deps_ok(), \
-             patch("mcp_video.remotion_engine.subprocess.run", return_value=fake_cp) as mock_run:
-
+        with _mock_deps_ok(), patch("mcp_video.remotion_engine.subprocess.run", return_value=fake_cp) as mock_run:
             compositions(project, composition_id="Main")
             cmd = mock_run.call_args[0][0]
             assert "--composition" in cmd
@@ -373,14 +381,14 @@ class TestCompositions:
     def test_uses_composition_id_alias(self, sample_remotion_project):
         """compositions() should handle 'compositionId' key in JSON output."""
         project = str(sample_remotion_project)
-        comp_json = json.dumps([
-            {"compositionId": "Alias", "width": 1280, "height": 720},
-        ])
+        comp_json = json.dumps(
+            [
+                {"compositionId": "Alias", "width": 1280, "height": 720},
+            ]
+        )
         fake_cp = _make_completed_process(stdout=comp_json)
 
-        with _mock_deps_ok(), \
-             patch("mcp_video.remotion_engine.subprocess.run", return_value=fake_cp):
-
+        with _mock_deps_ok(), patch("mcp_video.remotion_engine.subprocess.run", return_value=fake_cp):
             result = compositions(project)
             assert result.compositions[0].id == "Alias"
 
@@ -388,6 +396,7 @@ class TestCompositions:
 # ---------------------------------------------------------------------------
 # Test: studio
 # ---------------------------------------------------------------------------
+
 
 class TestStudio:
     """Tests for studio()."""
@@ -397,9 +406,7 @@ class TestStudio:
         project = str(sample_remotion_project)
         mock_proc = MagicMock()
 
-        with _mock_deps_ok(), \
-             patch("mcp_video.remotion_engine.subprocess.Popen", return_value=mock_proc):
-
+        with _mock_deps_ok(), patch("mcp_video.remotion_engine.subprocess.Popen", return_value=mock_proc):
             result = studio(project, port=3000)
             assert result.url == "http://localhost:3000"
             assert result.port == 3000
@@ -409,9 +416,7 @@ class TestStudio:
         project = str(sample_remotion_project)
         mock_proc = MagicMock()
 
-        with _mock_deps_ok(), \
-             patch("mcp_video.remotion_engine.subprocess.Popen", return_value=mock_proc):
-
+        with _mock_deps_ok(), patch("mcp_video.remotion_engine.subprocess.Popen", return_value=mock_proc):
             result = studio(project, port=8080)
             assert result.url == "http://localhost:8080"
             assert result.port == 8080
@@ -421,9 +426,7 @@ class TestStudio:
         project = str(sample_remotion_project)
         mock_proc = MagicMock()
 
-        with _mock_deps_ok(), \
-             patch("mcp_video.remotion_engine.subprocess.Popen", return_value=mock_proc) as mock_popen:
-
+        with _mock_deps_ok(), patch("mcp_video.remotion_engine.subprocess.Popen", return_value=mock_proc) as mock_popen:
             studio(project, port=3001)
 
             call_args = mock_popen.call_args
@@ -440,6 +443,7 @@ class TestStudio:
 # Test: still
 # ---------------------------------------------------------------------------
 
+
 class TestStill:
     """Tests for still()."""
 
@@ -448,9 +452,7 @@ class TestStill:
         project = str(sample_remotion_project)
         fake_cp = _make_completed_process(stdout="Rendered frame.")
 
-        with _mock_deps_ok(), \
-             patch("mcp_video.remotion_engine.subprocess.run", return_value=fake_cp) as mock_run:
-
+        with _mock_deps_ok(), patch("mcp_video.remotion_engine.subprocess.run", return_value=fake_cp) as mock_run:
             result = still(
                 project,
                 composition_id="MyComp",
@@ -476,10 +478,11 @@ class TestStill:
         project = str(sample_remotion_project)
         fake_cp = _make_completed_process(stdout="ok")
 
-        with _mock_deps_ok(), \
-             patch("mcp_video.remotion_engine.subprocess.run", return_value=fake_cp), \
-             patch("os.makedirs"):
-
+        with (
+            _mock_deps_ok(),
+            patch("mcp_video.remotion_engine.subprocess.run", return_value=fake_cp),
+            patch("os.makedirs"),
+        ):
             result = still(project, composition_id="Comp", frame=5)
             assert "Comp_frame5.png" in result.output_path
 
@@ -488,10 +491,11 @@ class TestStill:
         project = str(sample_remotion_project)
         fake_cp = _make_completed_process(stdout="ok")
 
-        with _mock_deps_ok(), \
-             patch("mcp_video.remotion_engine.subprocess.run", return_value=fake_cp), \
-             patch("os.makedirs"):
-
+        with (
+            _mock_deps_ok(),
+            patch("mcp_video.remotion_engine.subprocess.run", return_value=fake_cp),
+            patch("os.makedirs"),
+        ):
             result = still(
                 project,
                 composition_id="Comp",
@@ -517,13 +521,13 @@ class TestStill:
 # Test: create_project
 # ---------------------------------------------------------------------------
 
+
 class TestCreateProject:
     """Tests for create_project()."""
 
     def test_creates_directory_structure(self, tmp_path):
         """create_project() should create the expected directory structure."""
-        with _mock_deps_ok(), \
-             patch("mcp_video.remotion_engine.subprocess.run") as mock_run:
+        with _mock_deps_ok(), patch("mcp_video.remotion_engine.subprocess.run") as mock_run:
             # Let npm install succeed (or be skipped)
             mock_run.return_value = _make_completed_process(stdout="installed")
 
@@ -538,9 +542,7 @@ class TestCreateProject:
 
     def test_package_json_contains_project_name(self, tmp_path):
         """package.json should contain the provided project name."""
-        with _mock_deps_ok(), \
-             patch("mcp_video.remotion_engine.subprocess.run", return_value=_make_completed_process()):
-
+        with _mock_deps_ok(), patch("mcp_video.remotion_engine.subprocess.run", return_value=_make_completed_process()):
             create_project("my-remotion-app", output_dir=str(tmp_path))
 
             pkg = json.loads((tmp_path / "my-remotion-app" / "package.json").read_text())
@@ -548,9 +550,7 @@ class TestCreateProject:
 
     def test_blank_template(self, tmp_path):
         """Blank template should create a minimal Root.tsx."""
-        with _mock_deps_ok(), \
-             patch("mcp_video.remotion_engine.subprocess.run", return_value=_make_completed_process()):
-
+        with _mock_deps_ok(), patch("mcp_video.remotion_engine.subprocess.run", return_value=_make_completed_process()):
             result = create_project("proj", output_dir=str(tmp_path), template="blank")
             assert result.template == "blank"
 
@@ -560,9 +560,7 @@ class TestCreateProject:
 
     def test_hello_world_template(self, tmp_path):
         """hello-world template should include HelloWorld composition."""
-        with _mock_deps_ok(), \
-             patch("mcp_video.remotion_engine.subprocess.run", return_value=_make_completed_process()):
-
+        with _mock_deps_ok(), patch("mcp_video.remotion_engine.subprocess.run", return_value=_make_completed_process()):
             result = create_project("proj", output_dir=str(tmp_path), template="hello-world")
             assert result.template == "hello-world"
 
@@ -575,9 +573,7 @@ class TestCreateProject:
 
     def test_returns_correct_files_list(self, tmp_path):
         """create_project() should return the list of created files."""
-        with _mock_deps_ok(), \
-             patch("mcp_video.remotion_engine.subprocess.run", return_value=_make_completed_process()):
-
+        with _mock_deps_ok(), patch("mcp_video.remotion_engine.subprocess.run", return_value=_make_completed_process()):
             result = create_project("proj", output_dir=str(tmp_path), template="hello-world")
             assert "package.json" in result.files
             assert "tsconfig.json" in result.files
@@ -587,28 +583,26 @@ class TestCreateProject:
 
     def test_runs_npm_install(self, tmp_path):
         """create_project() should run npm install in the project directory."""
-        with _mock_deps_ok(), \
-             patch("mcp_video.remotion_engine.subprocess.run", return_value=_make_completed_process()) as mock_run:
-
+        with (
+            _mock_deps_ok(),
+            patch("mcp_video.remotion_engine.subprocess.run", return_value=_make_completed_process()) as mock_run,
+        ):
             create_project("proj", output_dir=str(tmp_path))
 
             # Find the npm install call
-            npm_calls = [
-                c for c in mock_run.call_args_list
-                if c[0][0][0] == "npm"
-            ]
+            npm_calls = [c for c in mock_run.call_args_list if c[0][0][0] == "npm"]
             assert len(npm_calls) == 1
             assert npm_calls[0][0][0] == ["npm", "install"]
 
     def test_npm_install_failure_is_non_fatal(self, tmp_path):
         """create_project() should not raise if npm install fails."""
-        with _mock_deps_ok(), \
-             patch("mcp_video.remotion_engine.subprocess.run") as mock_run:
+        with _mock_deps_ok(), patch("mcp_video.remotion_engine.subprocess.run") as mock_run:
             # Make npm install raise
             def _run_side_effect(*args, **kwargs):
                 if args[0][0] == "npm":
                     raise FileNotFoundError("npm not found")
                 return _make_completed_process()
+
             mock_run.side_effect = _run_side_effect
 
             # Should not raise
@@ -619,6 +613,7 @@ class TestCreateProject:
 # ---------------------------------------------------------------------------
 # Test: scaffold_template
 # ---------------------------------------------------------------------------
+
 
 class TestScaffoldTemplate:
     """Tests for scaffold_template()."""
@@ -709,6 +704,7 @@ class TestScaffoldTemplate:
 # ---------------------------------------------------------------------------
 # Test: validate
 # ---------------------------------------------------------------------------
+
 
 class TestValidate:
     """Tests for validate()."""
@@ -808,18 +804,21 @@ class TestValidate:
 # Test: render_and_post
 # ---------------------------------------------------------------------------
 
+
 class TestRenderAndPost:
     """Tests for render_and_post()."""
 
     @patch("mcp_video.remotion_engine.shutil.which")
     def test_chains_render_and_resize(self, mock_which, sample_remotion_project):
         """render_and_post() should render then apply resize."""
+
         def _which(name: str):
             if name in ("node", "npx"):
                 return f"/usr/bin/{name}"
             if name in ("ffmpeg", "ffprobe"):
                 return f"/usr/bin/{name}"
             return None
+
         mock_which.side_effect = _which
 
         project = str(sample_remotion_project)
@@ -828,11 +827,12 @@ class TestRenderAndPost:
         mock_resize_result = MagicMock()
         mock_resize_result.output_path = "/tmp/resized.mp4"
 
-        with patch("mcp_video.remotion_engine.subprocess.run", return_value=fake_cp), \
-             patch("os.path.isfile", return_value=True), \
-             patch("os.path.getsize", return_value=1024), \
-             patch("mcp_video.engine.resize", return_value=mock_resize_result):
-
+        with (
+            patch("mcp_video.remotion_engine.subprocess.run", return_value=fake_cp),
+            patch("os.path.isfile", return_value=True),
+            patch("os.path.getsize", return_value=1024),
+            patch("mcp_video.engine.resize", return_value=mock_resize_result),
+        ):
             result = render_and_post(
                 project,
                 composition_id="Comp",
@@ -849,10 +849,12 @@ class TestRenderAndPost:
     @patch("mcp_video.remotion_engine.shutil.which")
     def test_chains_multiple_operations(self, mock_which, sample_remotion_project):
         """render_and_post() should chain multiple post-processing ops."""
+
         def _which(name: str):
             if name in ("node", "npx", "ffmpeg", "ffprobe"):
                 return f"/usr/bin/{name}"
             return None
+
         mock_which.side_effect = _which
 
         project = str(sample_remotion_project)
@@ -861,12 +863,13 @@ class TestRenderAndPost:
         mock_result = MagicMock()
         mock_result.output_path = "/tmp/final.mp4"
 
-        with patch("mcp_video.remotion_engine.subprocess.run", return_value=fake_cp), \
-             patch("os.path.isfile", return_value=True), \
-             patch("os.path.getsize", return_value=1024), \
-             patch("mcp_video.engine.convert", return_value=mock_result), \
-             patch("mcp_video.engine.add_audio", return_value=mock_result):
-
+        with (
+            patch("mcp_video.remotion_engine.subprocess.run", return_value=fake_cp),
+            patch("os.path.isfile", return_value=True),
+            patch("os.path.getsize", return_value=1024),
+            patch("mcp_video.engine.convert", return_value=mock_result),
+            patch("mcp_video.engine.add_audio", return_value=mock_result),
+        ):
             result = render_and_post(
                 project,
                 composition_id="Comp",
@@ -881,10 +884,12 @@ class TestRenderAndPost:
     @patch("mcp_video.remotion_engine.shutil.which")
     def test_unknown_operation(self, mock_which, sample_remotion_project):
         """render_and_post() should raise ValueError for unknown operations."""
+
         def _which(name: str):
             if name in ("node", "npx"):
                 return f"/usr/bin/{name}"
             return None
+
         mock_which.side_effect = _which
 
         project = str(sample_remotion_project)
@@ -907,10 +912,12 @@ class TestRenderAndPost:
     @patch("mcp_video.remotion_engine.shutil.which")
     def test_type_alias_for_op(self, mock_which, sample_remotion_project):
         """render_and_post() should accept 'type' key as alias for 'op'."""
+
         def _which(name: str):
             if name in ("node", "npx", "ffmpeg", "ffprobe"):
                 return f"/usr/bin/{name}"
             return None
+
         mock_which.side_effect = _which
 
         project = str(sample_remotion_project)
@@ -919,11 +926,12 @@ class TestRenderAndPost:
         mock_result = MagicMock()
         mock_result.output_path = "/tmp/out.mp4"
 
-        with patch("mcp_video.remotion_engine.subprocess.run", return_value=fake_cp), \
-             patch("os.path.isfile", return_value=True), \
-             patch("os.path.getsize", return_value=1024), \
-             patch("mcp_video.engine.normalize_audio", return_value=mock_result):
-
+        with (
+            patch("mcp_video.remotion_engine.subprocess.run", return_value=fake_cp),
+            patch("os.path.isfile", return_value=True),
+            patch("os.path.getsize", return_value=1024),
+            patch("mcp_video.engine.normalize_audio", return_value=mock_result),
+        ):
             result = render_and_post(
                 project,
                 composition_id="Comp",
@@ -939,6 +947,7 @@ class TestRenderAndPost:
 # Test: Error handling
 # ---------------------------------------------------------------------------
 
+
 class TestErrorHandling:
     """Tests for error handling edge cases."""
 
@@ -946,8 +955,7 @@ class TestErrorHandling:
         """render() should raise RemotionRenderError on timeout."""
         project = str(sample_remotion_project)
 
-        with _mock_deps_ok(), \
-             patch("mcp_video.remotion_engine.subprocess.run") as mock_run:
+        with _mock_deps_ok(), patch("mcp_video.remotion_engine.subprocess.run") as mock_run:
             mock_run.side_effect = subprocess.TimeoutExpired(cmd="npx", timeout=600)
 
             with pytest.raises(RemotionRenderError, match="timed out"):
@@ -957,8 +965,7 @@ class TestErrorHandling:
         """render() should raise RemotionNotFoundError when npx binary is missing."""
         project = str(sample_remotion_project)
 
-        with _mock_deps_ok(), \
-             patch("mcp_video.remotion_engine.subprocess.run") as mock_run:
+        with _mock_deps_ok(), patch("mcp_video.remotion_engine.subprocess.run") as mock_run:
             mock_run.side_effect = FileNotFoundError("npx not found")
 
             with pytest.raises(RemotionNotFoundError, match="npx command not found"):
@@ -969,8 +976,7 @@ class TestErrorHandling:
         project = str(sample_remotion_project)
         fake_cp = _make_completed_process(returncode=42, stderr="Bad error")
 
-        with _mock_deps_ok(), \
-             patch("mcp_video.remotion_engine.subprocess.run", return_value=fake_cp):
+        with _mock_deps_ok(), patch("mcp_video.remotion_engine.subprocess.run", return_value=fake_cp):
             with pytest.raises(RemotionRenderError) as exc_info:
                 render(project, composition_id="Comp", output_path="/tmp/out.mp4")
 
@@ -984,8 +990,7 @@ class TestErrorHandling:
         project = str(sample_remotion_project)
         fake_cp = _make_completed_process(returncode=1, stderr=long_stderr)
 
-        with _mock_deps_ok(), \
-             patch("mcp_video.remotion_engine.subprocess.run", return_value=fake_cp):
+        with _mock_deps_ok(), patch("mcp_video.remotion_engine.subprocess.run", return_value=fake_cp):
             with pytest.raises(RemotionRenderError) as exc_info:
                 render(project, composition_id="Comp", output_path="/tmp/out.mp4")
 
@@ -1037,6 +1042,7 @@ class TestErrorHandling:
 # ---------------------------------------------------------------------------
 # Integration tests (require real Node.js)
 # ---------------------------------------------------------------------------
+
 
 @pytest.mark.remotion
 class TestRemotionIntegration:

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -1,6 +1,5 @@
 """Tests for editing templates — no FFmpeg needed (validate JSON output)."""
 
-
 from mcp_video.templates import (
     TEMPLATES,
     instagram_post_template,

--- a/tests/test_transitions.py
+++ b/tests/test_transitions.py
@@ -10,9 +10,15 @@ import pytest
 def create_test_video(output_path, duration=2, color="red"):
     """Helper to create test video using FFmpeg."""
     cmd = [
-        "ffmpeg", "-y", "-f", "lavfi", "-i",
+        "ffmpeg",
+        "-y",
+        "-f",
+        "lavfi",
+        "-i",
         f"color=c={color}:s=320x240:d={duration}",
-        "-pix_fmt", "yuv420p", output_path
+        "-pix_fmt",
+        "yuv420p",
+        output_path,
     ]
     subprocess.run(cmd, capture_output=True)
     return output_path


### PR DESCRIPTION
## Why
`ruff check` already passes for tests, but the test suite was not Ruff-format-normalized. Keeping this as a mechanical, isolated PR avoids mixing formatting churn with product or CI changes.

## What changed
- Ran `ruff format tests/`.
- No intentional assertion or product-code changes.

## Verification
- `ruff format --check tests/`
- `ruff check tests/`
- `python3 -m pytest tests/test_public_surface.py tests/test_adversarial_audit.py -q --tb=short`
- `python3 -m pytest tests/test_engine.py tests/test_e2e.py tests/test_server.py -q --tb=short`
- `python3 -m pytest tests/test_doctor.py tests/test_red_team.py -q --tb=short -rxX`
- `python3 -m pytest tests/ -q -m "not slow" --tb=short`

Result: `771 passed, 9 skipped, 114 deselected, 2 xpassed`.

Not run: full slow/real-media suite.
