### PR TITLE
Add architecture regression guardrails

### DIFF
--- a/mcp_video/engine_batch.py
+++ b/mcp_video/engine_batch.py
@@ -6,8 +6,10 @@ import os
 from typing import Any
 
 from .engine_audio_normalize import normalize_audio
+from .engine_convert import convert
 from .engine_edit import trim
 from .engine_fade import fade
+from .engine_filters import apply_filter
 from .engine_resize import resize
 from .engine_speed import speed
 from .engine_watermark import watermark
@@ -89,8 +91,6 @@ def _run_batch_operation(
             output_path=_batch_output(),
         )
     if operation == "convert":
-        from .engine import convert
-
         out_ext = f".{params.get('format', 'mp4')}"
         return convert(
             input_path,
@@ -99,8 +99,6 @@ def _run_batch_operation(
             output_path=_batch_output(out_ext),
         )
     if operation == "filter":
-        from .engine import apply_filter
-
         return apply_filter(
             input_path,
             filter_type=params.get("filter_type", "blur"),
@@ -108,14 +106,10 @@ def _run_batch_operation(
             output_path=_batch_output(),
         )
     if operation == "blur":
-        from .engine import apply_filter
-
         return apply_filter(
             input_path, filter_type="blur", params=params.get("filter_params", {}), output_path=_batch_output()
         )
     if operation == "color_grade":
-        from .engine import apply_filter
-
         return apply_filter(
             input_path,
             filter_type="color_preset",

--- a/mcp_video/engine_export.py
+++ b/mcp_video/engine_export.py
@@ -19,9 +19,9 @@ def export_video(
 ) -> EditResult:
     """Export a video with specified quality and format settings."""
     _validate_input(input_path)
-    from . import engine as _engine
+    from .engine_convert import convert
 
-    result = _engine.convert(
+    result = convert(
         input_path,
         format=format,
         quality=quality,

--- a/scripts/repo-readiness-audit.py
+++ b/scripts/repo-readiness-audit.py
@@ -8,6 +8,7 @@ import subprocess
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
+PACKAGE = ROOT / "mcp_video"
 
 REQUIRED_FILES = [
     "README.md",
@@ -94,6 +95,10 @@ def dependabot_groups_by_ecosystem() -> dict[tuple[str, str], set[str]]:
         if line and not raw_line.startswith("      ") and not line.startswith("-"):
             in_groups = False
     return grouped
+
+
+def line_count(path: Path) -> int:
+    return len(path.read_text(encoding="utf-8").splitlines())
 
 
 def main() -> int:
@@ -247,6 +252,34 @@ def main() -> int:
             failures=failures,
             warnings=warnings,
         )
+
+    print("\n== Architecture guardrail checks ==")
+    for relative_path, max_lines in [
+        ("mcp_video/engine.py", 140),
+        ("mcp_video/server.py", 180),
+    ]:
+        actual_lines = line_count(ROOT / relative_path)
+        check(
+            actual_lines <= max_lines,
+            f"{relative_path} remains a thin facade ({actual_lines} lines)",
+            f"{relative_path} should remain a thin facade; found {actual_lines} lines",
+            failures=failures,
+            warnings=warnings,
+        )
+
+    oversized_modules = sorted(
+        f"{path.relative_to(ROOT)} ({line_count(path)} lines)"
+        for pattern in ["engine*.py", "server*.py"]
+        for path in PACKAGE.glob(pattern)
+        if line_count(path) > 800
+    )
+    check(
+        oversized_modules == [],
+        "Engine/server modules stay below 800 lines",
+        "Engine/server modules exceed 800 lines: " + ", ".join(oversized_modules),
+        failures=failures,
+        warnings=warnings,
+    )
 
     print("\n== Release/tag visibility checks ==")
     tags = git_stdout("tag", "--list")

--- a/tests/test_architecture_guardrails.py
+++ b/tests/test_architecture_guardrails.py
@@ -1,0 +1,143 @@
+"""Architecture guardrails for the post-remediation module layout."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PACKAGE = ROOT / "mcp_video"
+
+FACADE_MODULES = {
+    "engine.py": {
+        "max_lines": 140,
+        "allowed_assignments": {"apply_mask", "apply_filter", "overlay_video", "split_screen", "video_batch"},
+    },
+    "server.py": {
+        "max_lines": 180,
+        "allowed_assignments": set(),
+    },
+}
+
+
+def source_lines(path: Path) -> list[str]:
+    return path.read_text(encoding="utf-8").splitlines()
+
+
+def parse_module(path: Path) -> ast.Module:
+    return ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+
+
+def module_line_count(path: Path) -> int:
+    return len(source_lines(path))
+
+
+def public_engine_modules() -> list[Path]:
+    return sorted(PACKAGE.glob("engine*.py"))
+
+
+def server_modules() -> list[Path]:
+    return sorted(PACKAGE.glob("server*.py"))
+
+
+def test_engine_and_server_facades_stay_thin() -> None:
+    """The old giant engine/server files should remain compatibility facades."""
+    for relative_path, limits in FACADE_MODULES.items():
+        path = PACKAGE / relative_path
+        assert module_line_count(path) <= limits["max_lines"], f"{relative_path} is no longer a thin facade"
+
+        tree = parse_module(path)
+        definitions = [
+            node.name for node in tree.body if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef)
+        ]
+        assert definitions == [], f"{relative_path} should re-export/import behavior, not define {definitions}"
+
+        assignments = {
+            target.id
+            for node in tree.body
+            if isinstance(node, ast.Assign)
+            for target in node.targets
+            if isinstance(target, ast.Name)
+        }
+        assert assignments <= limits["allowed_assignments"], f"{relative_path} has unexpected facade assignments"
+
+
+def test_engine_modules_stay_below_project_size_limit() -> None:
+    """No engine module should grow back into the pre-remediation monolith."""
+    oversized = {
+        path.relative_to(ROOT).as_posix(): module_line_count(path)
+        for path in public_engine_modules()
+        if module_line_count(path) > 800
+    }
+
+    assert oversized == {}
+
+
+def test_server_modules_stay_below_project_size_limit() -> None:
+    """Server registration groups should remain reviewable and split by family."""
+    oversized = {
+        path.relative_to(ROOT).as_posix(): module_line_count(path)
+        for path in server_modules()
+        if module_line_count(path) > 800
+    }
+
+    assert oversized == {}
+
+
+def test_engine_operation_modules_do_not_import_compatibility_facade() -> None:
+    """Engine implementation modules must not depend on the compatibility facade."""
+    offenders: dict[str, list[str]] = {}
+    for path in public_engine_modules():
+        if path.name == "engine.py":
+            continue
+        tree = parse_module(path)
+        bad_imports: list[str] = []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom) and node.module in {"engine", "mcp_video.engine"}:
+                bad_imports.append(f"from {node.module} import ...")
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    if alias.name == "mcp_video.engine":
+                        bad_imports.append("import mcp_video.engine")
+        if bad_imports:
+            offenders[path.relative_to(ROOT).as_posix()] = bad_imports
+
+    assert offenders == {}
+
+
+def test_server_tool_modules_register_against_server_app_not_facade() -> None:
+    """Tool groups should import mcp from server_app to avoid circular facade coupling."""
+    offenders: dict[str, list[str]] = {}
+    for path in sorted(PACKAGE.glob("server_tools_*.py")):
+        tree = parse_module(path)
+        bad_imports: list[str] = []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom) and node.module in {"server", "mcp_video.server"}:
+                bad_imports.append(f"from {node.module} import ...")
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    if alias.name == "mcp_video.server":
+                        bad_imports.append("import mcp_video.server")
+        if bad_imports:
+            offenders[path.relative_to(ROOT).as_posix()] = bad_imports
+
+    assert offenders == {}
+
+
+def test_shared_ffmpeg_helpers_remain_canonical_for_core_utilities() -> None:
+    """Prevent new copies of the canonical FFmpeg helper utilities."""
+    allowed_definitions = {
+        "_run_ffmpeg": {"mcp_video/ffmpeg_helpers.py", "mcp_video/engine_runtime_utils.py"},
+        "_get_video_duration": {"mcp_video/ffmpeg_helpers.py", "mcp_video/ai_engine.py"},
+        "_seconds_to_srt_time": {"mcp_video/ffmpeg_helpers.py"},
+    }
+    definitions = {name: set() for name in allowed_definitions}
+
+    for path in sorted(PACKAGE.glob("*.py")):
+        tree = parse_module(path)
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef) and node.name in definitions:
+                definitions[node.name].add(path.relative_to(ROOT).as_posix())
+
+    assert definitions == allowed_definitions

--- a/tests/test_architecture_guardrails.py
+++ b/tests/test_architecture_guardrails.py
@@ -94,8 +94,17 @@ def test_engine_operation_modules_do_not_import_compatibility_facade() -> None:
         tree = parse_module(path)
         bad_imports: list[str] = []
         for node in ast.walk(tree):
-            if isinstance(node, ast.ImportFrom) and node.module in {"engine", "mcp_video.engine"}:
-                bad_imports.append(f"from {node.module} import ...")
+            if isinstance(node, ast.ImportFrom):
+                # Catch: "from engine import …", "from mcp_video.engine import …",
+                # "from . import engine", "from .engine import …"
+                if node.module in {"engine", "mcp_video.engine"}:
+                    bad_imports.append(f"from {node.module} import ...")
+                if node.level and node.level >= 1 and node.module == "engine":
+                    bad_imports.append(f"from {'.' * node.level}engine import ...")
+                if node.level == 1 and node.module is None:
+                    for alias in node.names:
+                        if alias.name == "engine":
+                            bad_imports.append("from . import engine")
             if isinstance(node, ast.Import):
                 for alias in node.names:
                     if alias.name == "mcp_video.engine":
@@ -113,8 +122,17 @@ def test_server_tool_modules_register_against_server_app_not_facade() -> None:
         tree = parse_module(path)
         bad_imports: list[str] = []
         for node in ast.walk(tree):
-            if isinstance(node, ast.ImportFrom) and node.module in {"server", "mcp_video.server"}:
-                bad_imports.append(f"from {node.module} import ...")
+            if isinstance(node, ast.ImportFrom):
+                # Catch: "from server import …", "from mcp_video.server import …",
+                # "from . import server", "from .server import …"
+                if node.module in {"server", "mcp_video.server"}:
+                    bad_imports.append(f"from {node.module} import ...")
+                if node.level and node.level >= 1 and node.module == "server":
+                    bad_imports.append(f"from {'.' * node.level}server import ...")
+                if node.level == 1 and node.module is None:
+                    for alias in node.names:
+                        if alias.name == "server":
+                            bad_imports.append("from . import server")
             if isinstance(node, ast.Import):
                 for alias in node.names:
                     if alias.name == "mcp_video.server":


### PR DESCRIPTION
## Summary
- add architecture guardrail tests that keep engine/server facades thin and implementation modules below the 800-line project limit
- block engine/server implementation modules from importing through compatibility facades
- extend the readiness audit with architecture checks
- remove an existing engine_batch dependency on the engine facade by importing concrete operation modules directly

## Verification
- python3 -m pytest tests/test_architecture_guardrails.py tests/test_public_surface.py tests/test_adversarial_audit.py -q
- python3 -m pytest tests/test_server.py::TestVideoBatchTool tests/test_cli.py::TestCLIBatch -q
- ruff check mcp_video/ tests/
- ruff format --check mcp_video/ tests/
- ./scripts/repo-readiness-audit.py

## Notes
- The readiness audit still warns about a dirty working tree while edits are uncommitted during local runs; the committed branch is clean.