### PR TITLE
fix: failure mode remediation — crashes, error UX, validation gaps

### DIFF
--- a/mcp_video/engine_edit.py
+++ b/mcp_video/engine_edit.py
@@ -4,7 +4,25 @@ from __future__ import annotations
 
 from .engine_probe import probe
 from .engine_runtime_utils import _auto_output, _movflags_args, _run_ffmpeg, _timed_operation, _validate_input
+from .errors import MCPVideoError
 from .models import EditResult
+
+
+def _time_to_seconds(value: str | float) -> float:
+    """Convert a time string (HH:MM:SS or seconds) to float seconds."""
+    if isinstance(value, (int, float)):
+        return float(value)
+    value = value.strip()
+    # Handle HH:MM:SS or MM:SS
+    if ":" in value:
+        parts = value.split(":")
+        if len(parts) == 2:
+            m, s = parts
+            return int(m) * 60 + float(s)
+        elif len(parts) == 3:
+            h, m, s = parts
+            return int(h) * 3600 + int(m) * 60 + float(s)
+    return float(value)
 
 
 def trim(
@@ -17,6 +35,60 @@ def trim(
     """Trim a video by start time and duration or end time."""
     _validate_input(input_path)
     output = output_path or _auto_output(input_path, "trimmed")
+
+    # Validate time values
+    try:
+        start_sec = _time_to_seconds(start)
+    except ValueError:
+        raise MCPVideoError(
+            f"Invalid start time: '{start}'. Expected seconds or HH:MM:SS format.",
+            error_type="validation_error",
+            code="invalid_parameter",
+        ) from None
+    if start_sec < 0:
+        raise MCPVideoError(
+            f"Start time must be non-negative, got {start_sec}",
+            error_type="validation_error",
+            code="invalid_parameter",
+        )
+
+    if duration is not None:
+        try:
+            dur_sec = _time_to_seconds(duration)
+        except ValueError:
+            raise MCPVideoError(
+                f"Invalid duration: '{duration}'. Expected seconds or HH:MM:SS format.",
+                error_type="validation_error",
+                code="invalid_parameter",
+            ) from None
+        if dur_sec <= 0:
+            raise MCPVideoError(
+                f"Duration must be positive, got {dur_sec}",
+                error_type="validation_error",
+                code="invalid_parameter",
+            )
+
+    if end is not None:
+        try:
+            end_sec = _time_to_seconds(end)
+        except ValueError:
+            raise MCPVideoError(
+                f"Invalid end time: '{end}'. Expected seconds or HH:MM:SS format.",
+                error_type="validation_error",
+                code="invalid_parameter",
+            ) from None
+        if end_sec <= 0:
+            raise MCPVideoError(
+                f"End time must be positive, got {end_sec}",
+                error_type="validation_error",
+                code="invalid_parameter",
+            )
+        if end_sec <= start_sec:
+            raise MCPVideoError(
+                f"End time ({end_sec}s) must be greater than start time ({start_sec}s)",
+                error_type="validation_error",
+                code="invalid_parameter",
+            )
 
     args = []
     if start:

--- a/mcp_video/engine_merge.py
+++ b/mcp_video/engine_merge.py
@@ -31,6 +31,21 @@ def merge(
     """
     if not clips:
         raise InputFileError("", "No clips provided for merge")
+    if len(clips) == 1:
+        # Single clip — nothing to merge, just copy to output
+        _validate_input(clips[0])
+        output = output_path or _auto_output(clips[0], "merged")
+        shutil.copy2(clips[0], output)
+        info = probe(output)
+        return EditResult(
+            output_path=output,
+            duration=info.duration,
+            resolution=info.resolution,
+            size_mb=info.size_mb,
+            format="mp4",
+            operation="merge",
+            elapsed_ms=0.0,
+        )
 
     for c in clips:
         _validate_input(c)

--- a/mcp_video/engine_text.py
+++ b/mcp_video/engine_text.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 
 from .engine_probe import probe
+from .errors import InputFileError, MCPVideoError
 from .engine_runtime_utils import (
     _auto_output,
     _default_font,
@@ -38,6 +39,12 @@ def add_text(
     """Overlay text on a video."""
     _validate_input(input_path)
     _require_filter("drawtext", "Text overlay")
+    if not text or not text.strip():
+        raise MCPVideoError(
+            "Text cannot be empty",
+            error_type="validation_error",
+            code="invalid_parameter",
+        )
     _validate_color(color)
     output = output_path or _auto_output(input_path, "titled")
 
@@ -46,7 +53,7 @@ def add_text(
 
     # Validate font file exists when explicitly provided
     if font is not None and not os.path.isfile(fontfile):
-        raise FileNotFoundError(f"Font file not found: {fontfile}")
+        raise InputFileError(fontfile, "Font file not found")
 
     # Escape font path for FFmpeg filter syntax
     escaped_fontfile = _escape_ffmpeg_filter_value(fontfile)

--- a/mcp_video/errors.py
+++ b/mcp_video/errors.py
@@ -141,12 +141,48 @@ class RemotionRenderError(MCPVideoError):
         self.full_stderr = stderr
 
 
+def _strip_ffmpeg_banner(stderr: str) -> str:
+    """Remove FFmpeg version banner and build configuration from stderr.
+
+    The banner includes version lines, build flags, and library versions
+    that clutter error messages. We keep everything from the first 'Input #'
+    or from the first line that doesn't look like banner noise.
+    """
+    lines = stderr.splitlines()
+    result_lines: list[str] = []
+    in_banner = True
+    for line in lines:
+        if in_banner:
+            # Heuristic: banner lines are indented or start with version info
+            stripped = line.strip()
+            if stripped.startswith("ffmpeg version") or stripped.startswith("ffprobe version"):
+                continue
+            if stripped.startswith("built with") or stripped.startswith("configuration:"):
+                continue
+            if stripped.startswith("lib") and "/" in stripped:
+                continue
+            if (
+                stripped.startswith("Stream mapping:")
+                or stripped.startswith("Input #")
+                or stripped.startswith("Output #")
+                or (stripped.startswith("[") and "Error" in stripped)
+                or "error" in stripped.lower()
+            ):
+                in_banner = False
+            else:
+                # Still looks like banner noise — skip it
+                continue
+        result_lines.append(line)
+    return "\n".join(result_lines) if result_lines else stderr
+
+
 class ProcessingError(MCPVideoError):
     """FFmpeg processing failed."""
 
     def __init__(self, command: str, returncode: int, stderr: str) -> None:
+        cleaned = _strip_ffmpeg_banner(stderr)
         # Truncate stderr to last 500 chars for readability
-        stderr_short = stderr[-500:] if len(stderr) > 500 else stderr
+        stderr_short = cleaned[-500:] if len(cleaned) > 500 else cleaned
         super().__init__(
             f"FFmpeg processing failed (exit code {returncode}): {stderr_short}",
             error_type="processing_error",
@@ -170,6 +206,7 @@ class ResourceError(MCPVideoError):
 
 def parse_ffmpeg_error(stderr: str) -> MCPVideoError:
     """Parse FFmpeg stderr and return the most specific error type."""
+    stderr = _strip_ffmpeg_banner(stderr)
     stderr_lower = stderr.lower()
 
     if "no such file or directory" in stderr_lower:

--- a/mcp_video/server_tools_audio.py
+++ b/mcp_video/server_tools_audio.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import os
+import tempfile
 from typing import Any
 
 from .errors import MCPVideoError
@@ -18,7 +20,7 @@ from .validation import (
 
 @mcp.tool()
 def audio_synthesize(
-    output_path: str,
+    output_path: str | None = None,
     waveform: str = "sine",
     frequency: float = 440.0,
     duration: float = 1.0,
@@ -76,12 +78,13 @@ def audio_synthesize(
                 f"Invalid volume: must be 0-1, got {volume}", error_type="validation_error", code="invalid_parameter"
             )
         )
+    output = output_path or os.path.join(tempfile.gettempdir(), f"mcp_audio_{waveform}.wav")
     try:
         from .audio_engine import audio_synthesize as _synth
 
         return _result(
             _synth(
-                output=output_path,
+                output=output,
                 waveform=waveform,
                 frequency=frequency,
                 duration=duration,
@@ -98,7 +101,7 @@ def audio_synthesize(
 @mcp.tool()
 def audio_preset(
     preset: str,
-    output_path: str,
+    output_path: str | None = None,
     pitch: str = "mid",
     duration: float | None = None,
     intensity: float = 0.5,
@@ -155,13 +158,14 @@ def audio_preset(
                 code="invalid_parameter",
             )
         )
+    output = output_path or os.path.join(tempfile.gettempdir(), f"mcp_audio_{preset}.wav")
     try:
         from .audio_engine import audio_preset as _preset
 
         return _result(
             _preset(
                 preset=preset,
-                output=output_path,
+                output=output,
                 pitch=pitch,
                 duration=duration,
                 intensity=intensity,

--- a/mcp_video/server_tools_effects.py
+++ b/mcp_video/server_tools_effects.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 from typing import Any
 
+from .engine_runtime_utils import _auto_output
 from .errors import MCPVideoError
 from .server_app import _error_result, _result, mcp
 from .validation import VALID_MOGRAPH_STYLES
@@ -17,7 +18,7 @@ from .validation import VALID_MOGRAPH_STYLES
 @mcp.tool()
 def effect_vignette(
     input_path: str,
-    output_path: str,
+    output_path: str | None = None,
     intensity: float = 0.5,
     radius: float = 0.8,
     smoothness: float = 0.5,
@@ -45,7 +46,8 @@ def effect_vignette(
             return _error_result(ValueError(f"smoothness must be between 0.0 and 1.0, got {smoothness}"))
         from .effects_engine import effect_vignette as _vignette
 
-        return _result(_vignette(input_path, output_path, intensity, radius, smoothness))
+        output = output_path or _auto_output(input_path, "vignette")
+        return _result(_vignette(input_path, output, intensity, radius, smoothness))
     except MCPVideoError as e:
         return _error_result(e)
     except Exception as e:
@@ -297,7 +299,7 @@ def video_layout_pip(
 def video_text_animated(
     input_path: str,
     text: str,
-    output_path: str,
+    output_path: str | None = None,
     animation: str = "fade",
     font: str = "Arial",
     size: int = 48,
@@ -334,7 +336,8 @@ def video_text_animated(
             return _error_result(ValueError(f"start must be non-negative, got {start}"))
         from .effects_engine import text_animated as _text
 
-        return _result(_text(input_path, text, output_path, animation, font, size, color, position, start, duration))
+        output = output_path or _auto_output(input_path, "animated")
+        return _result(_text(input_path, text, output, animation, font, size, color, position, start, duration))
     except MCPVideoError as e:
         return _error_result(e)
     except Exception as e:
@@ -531,7 +534,7 @@ def video_auto_chapters(
 def transition_glitch(
     clip1_path: str,
     clip2_path: str,
-    output_path: str,
+    output_path: str | None = None,
     duration: float = 0.5,
     intensity: float = 0.3,
 ) -> dict[str, Any]:
@@ -563,7 +566,8 @@ def transition_glitch(
     try:
         from .transitions_engine import transition_glitch
 
-        return _result(transition_glitch(clip1_path, clip2_path, output_path, duration, intensity))
+        output = output_path or _auto_output(clip1_path, "transition")
+        return _result(transition_glitch(clip1_path, clip2_path, output, duration, intensity))
     except MCPVideoError as e:
         return _error_result(e)
     except Exception as e:

--- a/mcp_video/server_tools_media.py
+++ b/mcp_video/server_tools_media.py
@@ -359,7 +359,7 @@ def video_fade(
 
 @mcp.tool()
 def video_edit(
-    timeline: dict[str, Any],
+    timeline: dict[str, Any] | str,
     output_path: str | None = None,
 ) -> dict[str, Any]:
     """Execute a full timeline-based edit from a JSON specification.
@@ -371,11 +371,50 @@ def video_edit(
 
     Args:
         timeline: JSON object with keys: width, height, tracks (video/audio/text/image), export.
+            Can also be a JSON string or a path to a .json file.
             Image overlays in tracks: {"type": "image", "images": [{"source": "logo.png", "position": "top-right", "width": 200, "opacity": 0.8}]}
         output_path: Where to save the final video. Auto-generated if omitted.
     """
+    parsed_timeline = timeline
+    if isinstance(timeline, str):
+        import json as _json
+
+        timeline_str = timeline.strip()
+        # Try parsing as inline JSON first
+        try:
+            parsed_timeline = _json.loads(timeline_str)
+        except _json.JSONDecodeError:
+            # Try reading as a file path
+            if os.path.isfile(timeline_str):
+                try:
+                    with open(timeline_str, encoding="utf-8") as f:
+                        parsed_timeline = _json.load(f)
+                except (_json.JSONDecodeError, OSError) as exc:
+                    return _error_result(
+                        MCPVideoError(
+                            f"Invalid timeline JSON file: {timeline_str} — {exc}",
+                            error_type="validation_error",
+                            code="invalid_json",
+                        )
+                    )
+            else:
+                return _error_result(
+                    MCPVideoError(
+                        f"timeline must be a dict, valid JSON string, or path to a .json file. Got: {timeline_str[:100]}",
+                        error_type="validation_error",
+                        code="invalid_parameter",
+                    )
+                )
+    if not isinstance(parsed_timeline, dict):
+        return _error_result(
+            MCPVideoError(
+                f"timeline must be a dict or JSON object. Got: {type(parsed_timeline).__name__}",
+                error_type="validation_error",
+                code="invalid_parameter",
+            )
+        )
     try:
-        return _result(edit_timeline(timeline, output_path=output_path))
+        return _result(edit_timeline(parsed_timeline, output_path=output_path))
     except MCPVideoError as e:
         return _error_result(e)
     except Exception as e:


### PR DESCRIPTION
## What changed

### Engine fixes
- **engine_text.py**: Convert font <code>FileNotFoundError</code> → <code>InputFileError</code>. Reject empty text before re-encoding.
- **engine_edit.py**: Validate start/duration/end in <code>trim()</code> before calling FFmpeg. Clear errors for negative or invalid times.
- **engine_merge.py**: Short-circuit single-clip merge to a file copy instead of wasteful re-encode.
- **errors.py**: Strip FFmpeg version/build banner from stderr before truncating error messages.

### Server tool fixes
- **server_tools_media.py**: <code>video_edit</code> now accepts str (JSON string or file path) and validates before parsing.
- **server_tools_effects.py**: Make <code>output_path</code> optional for <code>effect_vignette</code>, <code>transition_glitch</code>, <code>video_text_animated</code>.
- **server_tools_audio.py**: Make <code>output_path</code> optional for <code>audio_synthesize</code> and <code>audio_preset</code>.

## Verification
- [x] <code>pytest tests/test_engine.py tests/test_server.py tests/test_errors.py tests/test_models.py tests/test_ffmpeg_helpers.py</code> — 223 passed
- [x] <code>pytest tests/test_effects_engine.py tests/test_transitions.py tests/test_audio_presets.py</code> — 7 passed
- [x] <code>python -c "import mcp_video"</code> — no broken imports