### PR TITLE
fix: remaining critical/high failure modes — Phase 2 completion

### DIFF
--- a/mcp_video/effects_engine.py
+++ b/mcp_video/effects_engine.py
@@ -5,6 +5,7 @@ Visual effects using FFmpeg filters and PIL for custom processing.
 
 from __future__ import annotations
 
+import logging
 import math
 import os
 import subprocess
@@ -976,8 +977,9 @@ def video_info_detailed(video: str) -> dict[str, Any]:
                         scene_changes.append(ts)
                     except (ValueError, IndexError):
                         pass
-    except Exception:
-        pass  # Scene detection is optional
+    except Exception as e:
+        logger = logging.getLogger(__name__)
+        logger.warning("Scene detection failed (optional): %s", e)
 
     return {
         "duration": duration,

--- a/mcp_video/engine_probe.py
+++ b/mcp_video/engine_probe.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 
 import os
 
-from .errors import InputFileError
+from .errors import InputFileError, MCPVideoError
 from .ffmpeg_helpers import _run_ffprobe_json
 from .models import VideoInfo
 from .engine_runtime_utils import _get_audio_stream, _get_video_stream, _validate_input
+from .limits import MAX_VIDEO_DURATION
 
 # ---------------------------------------------------------------------------
 # Probe cache — keyed by (path, mtime, size) so stale data is never returned
@@ -30,6 +31,12 @@ def _build_video_info(path: str, data: dict) -> VideoInfo:
 
     # Duration
     duration = float(data.get("format", {}).get("duration", 0) or vs.get("duration", 0))
+    if duration > MAX_VIDEO_DURATION:
+        raise MCPVideoError(
+            f"Video duration ({duration:.0f}s) exceeds maximum of {MAX_VIDEO_DURATION}s",
+            error_type="validation_error",
+            code="duration_too_long",
+        )
 
     # Resolution
     width = int(vs.get("width", 0))

--- a/mcp_video/engine_runtime_utils.py
+++ b/mcp_video/engine_runtime_utils.py
@@ -381,13 +381,17 @@ def _run_ffmpeg_with_progress(
 
     stderr_lines: list[str] = []
     _MAX_STDERR_LINES = 10_000
+    _MAX_STDERR_BYTES = 1_000_000  # ~1 MB hard cap
+    _stderr_bytes = 0
     try:
         while True:
             line = proc.stderr.readline()
             if not line:
                 break
-            if len(stderr_lines) < _MAX_STDERR_LINES:
+            line_bytes = len(line.encode("utf-8", errors="replace"))
+            if len(stderr_lines) < _MAX_STDERR_LINES and _stderr_bytes + line_bytes <= _MAX_STDERR_BYTES:
                 stderr_lines.append(line)
+                _stderr_bytes += line_bytes
 
             match = _TIME_RE.search(line)
             if match:

--- a/mcp_video/engine_speed.py
+++ b/mcp_video/engine_speed.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from .engine_probe import probe
 from .engine_runtime_utils import _auto_output, _movflags_args, _run_ffmpeg, _timed_operation, _validate_input
 from .errors import MCPVideoError
+from .limits import MAX_SPEED_CHAIN_COUNT
 from .models import EditResult
 
 
@@ -25,7 +26,6 @@ def speed(
     audio_filter = f"atempo={factor}"
 
     # atempo only supports 0.5 to 100.0; chain if needed
-    MAX_SPEED_CHAIN_COUNT = 20
     if factor < 0.5:
         chain_count = 2
         while factor ** (1 / chain_count) < 0.5:

--- a/mcp_video/ffmpeg_helpers.py
+++ b/mcp_video/ffmpeg_helpers.py
@@ -11,16 +11,22 @@ import subprocess
 from typing import Any
 
 from .errors import InputFileError, ProcessingError
-from .limits import DEFAULT_FFMPEG_TIMEOUT, FFPROBE_TIMEOUT
+from .limits import DEFAULT_FFMPEG_TIMEOUT, FFPROBE_TIMEOUT, MAX_FILE_SIZE_MB
 
 
 def _validate_input_path(path: str) -> str:
-    """Validate and resolve a file path. Rejects null bytes and symlinks."""
+    """Validate and resolve a file path. Rejects null bytes, symlinks, and oversize files."""
     if "\x00" in path:
         raise InputFileError(path, "Path contains null bytes")
     resolved = os.path.realpath(path)
     if not os.path.isfile(resolved):
         raise InputFileError(resolved)
+    size_mb = os.path.getsize(resolved) / (1024 * 1024)
+    if size_mb > MAX_FILE_SIZE_MB:
+        raise InputFileError(
+            resolved,
+            f"File size ({size_mb:.1f} MB) exceeds maximum of {MAX_FILE_SIZE_MB} MB",
+        )
     return resolved
 
 

--- a/mcp_video/limits.py
+++ b/mcp_video/limits.py
@@ -6,7 +6,6 @@ MAX_RESOLUTION = 7680  # 8K width/height
 MAX_FILE_SIZE_MB = 4096  # 4 GB
 
 # Processing limits
-MAX_CONCURRENT_PROCESSES = 4
 DEFAULT_FFMPEG_TIMEOUT = 600  # 10 minutes
 DOCTOR_COMMAND_TIMEOUT = 10  # Short version/probe commands should not hang
 FFPROBE_TIMEOUT = 30  # Metadata probes should fail quickly

--- a/mcp_video/server_tools_advanced.py
+++ b/mcp_video/server_tools_advanced.py
@@ -680,7 +680,7 @@ def video_batch(
     except MCPVideoError as e:
         return _error_result(e)
     except Exception as e:
-        return {"success": False, "error": {"type": "internal_error", "code": "unexpected_error", "message": str(e)}}
+        return _error_result(e)
 
 
 @mcp.tool()

--- a/mcp_video/server_tools_advanced.py
+++ b/mcp_video/server_tools_advanced.py
@@ -29,6 +29,7 @@ from .errors import MCPVideoError
 from .limits import MAX_BATCH_SIZE, MAX_EXPORT_FRAMES_FPS
 from .server_app import _error_result, _result, mcp
 from .validation import VALID_LAYOUTS, VALID_PRESETS
+from .ffmpeg_helpers import _validate_input_path
 
 
 @mcp.tool()
@@ -59,6 +60,7 @@ def video_filter(
             MCPVideoError(f"Invalid preset: {preset}", error_type="validation_error", code="invalid_parameter")
         )
     try:
+        _validate_input_path(input_path)
         return _result(
             apply_filter(
                 input_path,
@@ -87,6 +89,7 @@ def video_reverse(
         output_path: Where to save the output. Auto-generated if omitted.
     """
     try:
+        _validate_input_path(input_path)
         return _result(reverse(input_path, output_path=output_path))
     except MCPVideoError as e:
         return _error_result(e)
@@ -112,6 +115,7 @@ def video_chroma_key(
         output_path: Where to save the output. Auto-generated if omitted.
     """
     try:
+        _validate_input_path(input_path)
         _validate_chroma_color(color)
     except MCPVideoError as e:
         return _error_result(e)
@@ -213,6 +217,7 @@ def video_normalize_audio(
         output_path: Where to save the output. Auto-generated if omitted.
     """
     try:
+        _validate_input_path(input_path)
         if not -70 <= target_lufs <= -5:
             return _error_result(
                 MCPVideoError(
@@ -282,6 +287,8 @@ def video_overlay(
             MCPVideoError(f"Invalid preset: {preset}", error_type="validation_error", code="invalid_parameter")
         )
     try:
+        _validate_input_path(background_path)
+        _validate_input_path(overlay_path)
         if not 0 <= opacity <= 1:
             return _error_result(
                 MCPVideoError(
@@ -335,6 +342,8 @@ def video_split_screen(
             )
         )
     try:
+        _validate_input_path(left_path)
+        _validate_input_path(right_path)
         return _result(split_screen(left_path, right_path=right_path, layout=layout, output_path=output_path))
     except MCPVideoError as e:
         return _error_result(e)
@@ -356,6 +365,7 @@ def video_detect_scenes(
         min_scene_duration: Minimum scene duration in seconds (default 1.0).
     """
     try:
+        _validate_input_path(input_path)
         if not 0 <= threshold <= 1:
             return _error_result(
                 MCPVideoError(
@@ -393,6 +403,8 @@ def video_create_from_images(
         fps: Frames per second for the output video (default 30.0).
     """
     try:
+        for _p in images:
+            _validate_input_path(_p)
         if fps <= 0 or fps > MAX_EXPORT_FRAMES_FPS:
             return _error_result(
                 MCPVideoError(
@@ -440,6 +452,7 @@ def video_export_frames(
             )
         )
     try:
+        _validate_input_path(input_path)
         return _result(export_frames(input_path, output_dir=output_dir, fps=fps, format=format))
     except MCPVideoError as e:
         return _error_result(e)
@@ -469,6 +482,7 @@ def video_generate_subtitles(
             )
         )
     try:
+        _validate_input_path(input_path)
         return _result(generate_subtitles(entries, input_path, burn=burn))
     except MCPVideoError as e:
         return _error_result(e)
@@ -490,6 +504,8 @@ def video_compare_quality(
         metrics: Metrics to compute (default: ['psnr', 'ssim']).
     """
     try:
+        _validate_input_path(original_path)
+        _validate_input_path(distorted_path)
         return _result(compare_quality(original_path, distorted_path, metrics=metrics))
     except MCPVideoError as e:
         return _error_result(e)
@@ -507,6 +523,7 @@ def video_read_metadata(
         input_path: Absolute path to the video or audio file.
     """
     try:
+        _validate_input_path(input_path)
         return _result(read_metadata(input_path))
     except MCPVideoError as e:
         return _error_result(e)
@@ -528,6 +545,7 @@ def video_write_metadata(
         output_path: Where to save the output. Auto-generated if omitted.
     """
     try:
+        _validate_input_path(input_path)
         return _result(write_metadata(input_path, metadata=metadata, output_path=output_path))
     except MCPVideoError as e:
         return _error_result(e)
@@ -551,6 +569,7 @@ def video_stabilize(
         output_path: Where to save the output. Auto-generated if omitted.
     """
     try:
+        _validate_input_path(input_path)
         if smoothing < 0:
             return _error_result(
                 MCPVideoError(
@@ -590,6 +609,8 @@ def video_apply_mask(
         output_path: Where to save the output. Auto-generated if omitted.
     """
     try:
+        _validate_input_path(input_path)
+        _validate_input_path(mask_path)
         if feather < 0:
             return _error_result(
                 MCPVideoError(
@@ -617,6 +638,7 @@ def video_audio_waveform(
         bins: Number of time segments to analyze (default 50).
     """
     try:
+        _validate_input_path(input_path)
         if bins < 1 or bins > 1000:
             return _error_result(
                 MCPVideoError(
@@ -697,6 +719,7 @@ def video_extract_frame(
         output_path: Where to save the frame image. Auto-generated if omitted.
     """
     try:
+        _validate_input_path(input_path)
         return _result(thumbnail(input_path, timestamp=timestamp, output_path=output_path))
     except MCPVideoError as e:
         return _error_result(e)

--- a/mcp_video/server_tools_ai.py
+++ b/mcp_video/server_tools_ai.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from .errors import MCPVideoError
 from .server_app import _error_result, _result, mcp
+from .ffmpeg_helpers import _validate_input_path
 from .validation import (
     VALID_COLOR_GRADE_STYLES,
     VALID_DEMUCS_MODELS,
@@ -52,6 +53,7 @@ def video_ai_remove_silence(
             )
         )
     try:
+        _validate_input_path(input_path)
         from .ai_engine import ai_remove_silence
 
         return _result(ai_remove_silence(input_path, output_path, silence_threshold, min_silence_duration, keep_margin))
@@ -78,6 +80,7 @@ def video_ai_transcribe(
             )
         )
     try:
+        _validate_input_path(input_path)
         from .ai_engine import ai_transcribe
 
         return _result(ai_transcribe(input_path, output_srt, model, language))
@@ -145,6 +148,7 @@ def video_analyze(
             )
         )
     try:
+        _validate_input_path(input_path)
         from .ai_engine import analyze_video
 
         return analyze_video(
@@ -185,6 +189,7 @@ def video_ai_scene_detect(
             )
         )
     try:
+        _validate_input_path(input_path)
         from .ai_engine import ai_scene_detect
 
         return _result(ai_scene_detect(input_path, threshold, use_ai))
@@ -219,6 +224,7 @@ def video_ai_stem_separation(
             )
         )
     try:
+        _validate_input_path(input_path)
         from .ai_engine import ai_stem_separation
 
         return _result(ai_stem_separation(input_path, output_dir, stems, model))
@@ -253,6 +259,7 @@ def video_ai_upscale(
             )
         )
     try:
+        _validate_input_path(input_path)
         from .ai_engine import ai_upscale
 
         return _result(ai_upscale(input_path, output_path, scale, model))
@@ -279,6 +286,8 @@ def video_ai_color_grade(
             )
         )
     try:
+        _validate_input_path(input_path)
+        _validate_input_path(reference_path)
         from .ai_engine import ai_color_grade
 
         return _result(ai_color_grade(input_path, output_path, reference_path, style))
@@ -303,6 +312,7 @@ def video_quality_check(
         fail_on_warning: If True, treat warnings as failures
     """
     try:
+        _validate_input_path(input_path)
         from .quality_guardrails import quality_check
 
         return _result(quality_check(input_path, fail_on_warning))
@@ -329,6 +339,7 @@ def video_design_quality_check(
         strict: If True, treat warnings as errors
     """
     try:
+        _validate_input_path(input_path)
         from .design_quality import design_quality_check
 
         return _result(design_quality_check(input_path, auto_fix=auto_fix, strict=strict))
@@ -353,6 +364,7 @@ def video_fix_design_issues(
         output_path: Absolute path for output (auto-generated if omitted)
     """
     try:
+        _validate_input_path(input_path)
         from .design_quality import fix_design_issues
 
         return _result(fix_design_issues(input_path, output_path))

--- a/mcp_video/server_tools_audio.py
+++ b/mcp_video/server_tools_audio.py
@@ -9,6 +9,7 @@ from typing import Any
 from .errors import MCPVideoError
 from .limits import MAX_FREQUENCY, MIN_FREQUENCY
 from .server_app import _error_result, _result, mcp
+from .ffmpeg_helpers import _validate_input_path
 from .validation import (
     VALID_AUDIO_EFFECT_TYPES,
     VALID_AUDIO_PRESETS,
@@ -311,6 +312,8 @@ def audio_compose(
                 )
             )
     try:
+        for _t in tracks:
+            _validate_input_path(_t.get("file", ""))
         from .audio_engine import audio_compose as _compose
 
         return _result(_compose(tracks=tracks, duration=duration, output=output_path))
@@ -363,6 +366,7 @@ def audio_effects(
                 )
             )
     try:
+        _validate_input_path(input_path)
         from .audio_engine import audio_effects as _effects
 
         return _result(_effects(input_path=input_path, output=output_path, effects=effects))
@@ -393,6 +397,7 @@ def video_add_generated_audio(
         Dict with success status and output_path.
     """
     try:
+        _validate_input_path(input_path)
         if not isinstance(audio_config, dict) or not audio_config:
             raise MCPVideoError(
                 "audio_config must be a non-empty dict",
@@ -433,6 +438,7 @@ def video_audio_spatial(
             )
         )
     try:
+        _validate_input_path(input_path)
         from .ai_engine import audio_spatial
 
         return _result(audio_spatial(input_path, output_path, positions, method))

--- a/mcp_video/server_tools_audio.py
+++ b/mcp_video/server_tools_audio.py
@@ -394,7 +394,11 @@ def video_add_generated_audio(
     """
     try:
         if not isinstance(audio_config, dict) or not audio_config:
-            return _error_result(ValueError("audio_config must be a non-empty dict"))
+            raise MCPVideoError(
+                "audio_config must be a non-empty dict",
+                error_type="validation_error",
+                code="invalid_parameter",
+            )
         from .audio_engine import add_generated_audio as _add_gen_audio
 
         return _result(_add_gen_audio(input_path, audio_config, output_path))
@@ -435,4 +439,4 @@ def video_audio_spatial(
     except MCPVideoError as e:
         return _error_result(e)
     except Exception as e:
-        return {"success": False, "error": {"type": "internal_error", "code": "unexpected_error", "message": str(e)}}
+        return _error_result(e)

--- a/mcp_video/server_tools_basic.py
+++ b/mcp_video/server_tools_basic.py
@@ -9,6 +9,7 @@ from .errors import MCPVideoError
 from .limits import MAX_RESOLUTION, MAX_SPEED_FACTOR, MIN_SPEED_FACTOR
 from .server_app import _error_result, _result, mcp
 from .validation import VALID_FORMATS, VALID_PRESETS
+from .ffmpeg_helpers import _validate_input_path
 
 
 @mcp.tool()
@@ -19,6 +20,7 @@ def video_info(input_path: str) -> dict[str, Any]:
         input_path: Absolute path to the video file.
     """
     try:
+        _validate_input_path(input_path)
         info = probe(input_path)
         return {"success": True, "info": info.model_dump()}
     except MCPVideoError as e:
@@ -45,6 +47,7 @@ def video_trim(
         output_path: Where to save the trimmed video. Auto-generated if omitted.
     """
     try:
+        _validate_input_path(input_path)
         return _result(trim(input_path, start=start, duration=duration, end=end, output_path=output_path))
     except MCPVideoError as e:
         return _error_result(e)
@@ -106,6 +109,8 @@ def video_merge(
                 )
             )
     try:
+        for _p in clips:
+            _validate_input_path(_p)
         return _result(
             merge(
                 clips,
@@ -161,6 +166,7 @@ def video_add_text(
             MCPVideoError(f"Invalid preset: {preset}", error_type="validation_error", code="invalid_parameter")
         )
     try:
+        _validate_input_path(input_path)
         if size < 8 or size > 500:
             return _error_result(
                 MCPVideoError(
@@ -215,6 +221,8 @@ def video_add_audio(
         output_path: Where to save the output. Auto-generated if omitted.
     """
     try:
+        _validate_input_path(video_path)
+        _validate_input_path(audio_path)
         if not 0 <= volume <= 2.0:
             return _error_result(
                 MCPVideoError(
@@ -385,6 +393,7 @@ def video_speed(
             )
         )
     try:
+        _validate_input_path(input_path)
         return _result(speed(input_path, factor=factor, output_path=output_path))
     except MCPVideoError as e:
         return _error_result(e)

--- a/mcp_video/server_tools_effects.py
+++ b/mcp_video/server_tools_effects.py
@@ -39,11 +39,23 @@ def effect_vignette(
     """
     try:
         if not (0.0 <= intensity <= 1.0):
-            return _error_result(ValueError(f"intensity must be between 0.0 and 1.0, got {intensity}"))
+            raise MCPVideoError(
+                f"intensity must be between 0.0 and 1.0, got {intensity}",
+                error_type="validation_error",
+                code="invalid_parameter",
+            )
         if not (0.0 <= radius <= 1.0):
-            return _error_result(ValueError(f"radius must be between 0.0 and 1.0, got {radius}"))
+            raise MCPVideoError(
+                f"radius must be between 0.0 and 1.0, got {radius}",
+                error_type="validation_error",
+                code="invalid_parameter",
+            )
         if not (0.0 <= smoothness <= 1.0):
-            return _error_result(ValueError(f"smoothness must be between 0.0 and 1.0, got {smoothness}"))
+            raise MCPVideoError(
+                f"smoothness must be between 0.0 and 1.0, got {smoothness}",
+                error_type="validation_error",
+                code="invalid_parameter",
+            )
         from .effects_engine import effect_vignette as _vignette
 
         output = output_path or _auto_output(input_path, "vignette")
@@ -76,7 +88,11 @@ def effect_chromatic_aberration(
     """
     try:
         if intensity < 0:
-            return _error_result(ValueError(f"intensity must be non-negative, got {intensity}"))
+            raise MCPVideoError(
+                f"intensity must be non-negative, got {intensity}",
+                error_type="validation_error",
+                code="invalid_parameter",
+            )
         from .effects_engine import effect_chromatic_aberration as _chroma
 
         return _result(_chroma(input_path, output_path, intensity, angle))
@@ -110,11 +126,23 @@ def effect_scanlines(
     """
     try:
         if line_height < 1:
-            return _error_result(ValueError(f"line_height must be at least 1, got {line_height}"))
+            raise MCPVideoError(
+                f"line_height must be at least 1, got {line_height}",
+                error_type="validation_error",
+                code="invalid_parameter",
+            )
         if not (0.0 <= opacity <= 1.0):
-            return _error_result(ValueError(f"opacity must be between 0.0 and 1.0, got {opacity}"))
+            raise MCPVideoError(
+                f"opacity must be between 0.0 and 1.0, got {opacity}",
+                error_type="validation_error",
+                code="invalid_parameter",
+            )
         if not (0.0 <= flicker <= 1.0):
-            return _error_result(ValueError(f"flicker must be between 0.0 and 1.0, got {flicker}"))
+            raise MCPVideoError(
+                f"flicker must be between 0.0 and 1.0, got {flicker}",
+                error_type="validation_error",
+                code="invalid_parameter",
+            )
         from .effects_engine import effect_scanlines as _scanlines
 
         return _result(_scanlines(input_path, output_path, line_height, opacity, flicker))
@@ -148,9 +176,17 @@ def effect_noise(
     """
     try:
         if not (0.0 <= intensity <= 1.0):
-            return _error_result(ValueError(f"intensity must be between 0.0 and 1.0, got {intensity}"))
+            raise MCPVideoError(
+                f"intensity must be between 0.0 and 1.0, got {intensity}",
+                error_type="validation_error",
+                code="invalid_parameter",
+            )
         if mode not in ("film", "digital", "color"):
-            return _error_result(ValueError(f"mode must be film, digital, or color, got {mode}"))
+            raise MCPVideoError(
+                f"mode must be film, digital, or color, got {mode}",
+                error_type="validation_error",
+                code="invalid_parameter",
+            )
         from .effects_engine import effect_noise as _noise
 
         return _result(_noise(input_path, output_path, intensity, mode, animated))
@@ -184,11 +220,23 @@ def effect_glow(
     """
     try:
         if not (0.0 <= intensity <= 1.0):
-            return _error_result(ValueError(f"intensity must be between 0.0 and 1.0, got {intensity}"))
+            raise MCPVideoError(
+                f"intensity must be between 0.0 and 1.0, got {intensity}",
+                error_type="validation_error",
+                code="invalid_parameter",
+            )
         if radius < 0:
-            return _error_result(ValueError(f"radius must be non-negative, got {radius}"))
+            raise MCPVideoError(
+                f"radius must be non-negative, got {radius}",
+                error_type="validation_error",
+                code="invalid_parameter",
+            )
         if not (0.0 <= threshold <= 1.0):
-            return _error_result(ValueError(f"threshold must be between 0.0 and 1.0, got {threshold}"))
+            raise MCPVideoError(
+                f"threshold must be between 0.0 and 1.0, got {threshold}",
+                error_type="validation_error",
+                code="invalid_parameter",
+            )
         from .effects_engine import effect_glow as _glow
 
         return _result(_glow(input_path, output_path, intensity, radius, threshold))
@@ -224,9 +272,17 @@ def video_layout_grid(
     """
     try:
         if gap < 0:
-            return _error_result(ValueError(f"gap must be non-negative, got {gap}"))
+            raise MCPVideoError(
+                f"gap must be non-negative, got {gap}",
+                error_type="validation_error",
+                code="invalid_parameter",
+            )
         if padding < 0:
-            return _error_result(ValueError(f"padding must be non-negative, got {padding}"))
+            raise MCPVideoError(
+                f"padding must be non-negative, got {padding}",
+                error_type="validation_error",
+                code="invalid_parameter",
+            )
         from .effects_engine import layout_grid as _grid
 
         return _result(_grid(clips, layout, output_path, gap, padding, background))
@@ -270,9 +326,17 @@ def video_layout_pip(
     """
     try:
         if not (0.0 < size <= 1.0):
-            return _error_result(ValueError(f"size must be between 0.0 and 1.0, got {size}"))
+            raise MCPVideoError(
+                f"size must be between 0.0 and 1.0, got {size}",
+                error_type="validation_error",
+                code="invalid_parameter",
+            )
         if border_width < 0:
-            return _error_result(ValueError(f"border_width must be non-negative, got {border_width}"))
+            raise MCPVideoError(
+                f"border_width must be non-negative, got {border_width}",
+                error_type="validation_error",
+                code="invalid_parameter",
+            )
         from .effects_engine import layout_pip as _pip
 
         return _result(
@@ -329,11 +393,23 @@ def video_text_animated(
     """
     try:
         if not (8 <= size <= 500):
-            return _error_result(ValueError(f"size must be between 8 and 500, got {size}"))
+            raise MCPVideoError(
+                f"size must be between 8 and 500, got {size}",
+                error_type="validation_error",
+                code="invalid_parameter",
+            )
         if duration <= 0:
-            return _error_result(ValueError(f"duration must be positive, got {duration}"))
+            raise MCPVideoError(
+                f"duration must be positive, got {duration}",
+                error_type="validation_error",
+                code="invalid_parameter",
+            )
         if start < 0:
-            return _error_result(ValueError(f"start must be non-negative, got {start}"))
+            raise MCPVideoError(
+                f"start must be non-negative, got {start}",
+                error_type="validation_error",
+                code="invalid_parameter",
+            )
         from .effects_engine import text_animated as _text
 
         output = output_path or _auto_output(input_path, "animated")
@@ -408,9 +484,17 @@ def video_mograph_count(
     """
     try:
         if not (1 <= fps <= 120):
-            return _error_result(ValueError(f"fps must be between 1 and 120, got {fps}"))
+            raise MCPVideoError(
+                f"fps must be between 1 and 120, got {fps}",
+                error_type="validation_error",
+                code="invalid_parameter",
+            )
         if duration <= 0:
-            return _error_result(ValueError(f"duration must be positive, got {duration}"))
+            raise MCPVideoError(
+                f"duration must be positive, got {duration}",
+                error_type="validation_error",
+                code="invalid_parameter",
+            )
         from .effects_engine import mograph_count as _count
 
         return _result(_count(start, end, duration, output_path, style=style, fps=fps))
@@ -454,9 +538,17 @@ def video_mograph_progress(
         )
     try:
         if not (1 <= fps <= 120):
-            return _error_result(ValueError(f"fps must be between 1 and 120, got {fps}"))
+            raise MCPVideoError(
+                f"fps must be between 1 and 120, got {fps}",
+                error_type="validation_error",
+                code="invalid_parameter",
+            )
         if duration <= 0:
-            return _error_result(ValueError(f"duration must be positive, got {duration}"))
+            raise MCPVideoError(
+                f"duration must be positive, got {duration}",
+                error_type="validation_error",
+                code="invalid_parameter",
+            )
         from .effects_engine import mograph_progress as _progress
 
         return _result(_progress(duration, output_path, style=style, color=color, track_color=track_color, fps=fps))

--- a/mcp_video/server_tools_effects.py
+++ b/mcp_video/server_tools_effects.py
@@ -9,6 +9,7 @@ from .engine_runtime_utils import _auto_output
 from .errors import MCPVideoError
 from .server_app import _error_result, _result, mcp
 from .validation import VALID_MOGRAPH_STYLES
+from .ffmpeg_helpers import _validate_input_path
 
 # ---------------------------------------------------------------------------
 # Visual Effects Tools (P1 Features)
@@ -38,6 +39,7 @@ def effect_vignette(
         Dict with success status and output_path.
     """
     try:
+        _validate_input_path(input_path)
         if not (0.0 <= intensity <= 1.0):
             raise MCPVideoError(
                 f"intensity must be between 0.0 and 1.0, got {intensity}",
@@ -87,6 +89,7 @@ def effect_chromatic_aberration(
         Dict with success status and output_path.
     """
     try:
+        _validate_input_path(input_path)
         if intensity < 0:
             raise MCPVideoError(
                 f"intensity must be non-negative, got {intensity}",
@@ -125,6 +128,7 @@ def effect_scanlines(
         Dict with success status and output_path.
     """
     try:
+        _validate_input_path(input_path)
         if line_height < 1:
             raise MCPVideoError(
                 f"line_height must be at least 1, got {line_height}",
@@ -271,6 +275,8 @@ def video_layout_grid(
         Dict with success status and output_path.
     """
     try:
+        for _p in clips:
+            _validate_input_path(_p)
         if gap < 0:
             raise MCPVideoError(
                 f"gap must be non-negative, got {gap}",
@@ -325,6 +331,8 @@ def video_layout_pip(
         Dict with success status and output_path.
     """
     try:
+        _validate_input_path(main_path)
+        _validate_input_path(pip_path)
         if not (0.0 < size <= 1.0):
             raise MCPVideoError(
                 f"size must be between 0.0 and 1.0, got {size}",
@@ -392,6 +400,7 @@ def video_text_animated(
         Dict with success status and output_path.
     """
     try:
+        _validate_input_path(input_path)
         if not (8 <= size <= 500):
             raise MCPVideoError(
                 f"size must be between 8 and 500, got {size}",
@@ -449,6 +458,8 @@ def video_text_subtitles(
             )
         )
     try:
+        _validate_input_path(input_path)
+        _validate_input_path(subtitles_path)
         from .effects_engine import text_subtitles as _subs
 
         return _result(_subs(input_path, subtitles_path, output_path, style))
@@ -574,6 +585,7 @@ def video_info_detailed(
         Dict with duration, fps, resolution, bitrate, has_audio, scene_changes.
     """
     try:
+        _validate_input_path(input_path)
         from .effects_engine import video_info_detailed as _info
 
         return _result(_info(input_path))
@@ -608,6 +620,7 @@ def video_auto_chapters(
             )
         )
     try:
+        _validate_input_path(input_path)
         from .effects_engine import auto_chapters as _chapters
 
         return _result(_chapters(input_path, threshold))
@@ -656,6 +669,8 @@ def transition_glitch(
             )
         )
     try:
+        _validate_input_path(clip1_path)
+        _validate_input_path(clip2_path)
         from .transitions_engine import transition_glitch
 
         output = output_path or _auto_output(clip1_path, "transition")
@@ -692,6 +707,8 @@ def transition_pixelate(
             )
         )
     try:
+        _validate_input_path(clip1_path)
+        _validate_input_path(clip2_path)
         from .transitions_engine import transition_pixelate
 
         return _result(transition_pixelate(clip1_path, clip2_path, output_path, duration, pixel_size))
@@ -727,6 +744,8 @@ def transition_morph(
             )
         )
     try:
+        _validate_input_path(clip1_path)
+        _validate_input_path(clip2_path)
         from .transitions_engine import transition_morph
 
         return _result(transition_morph(clip1_path, clip2_path, output_path, duration, mesh_size))

--- a/mcp_video/server_tools_image.py
+++ b/mcp_video/server_tools_image.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from .errors import MCPVideoError
 from .server_app import _error_result, _result, mcp
+from .ffmpeg_helpers import _validate_input_path
 
 
 @mcp.tool()
@@ -23,6 +24,7 @@ def image_extract_colors(
         n_colors: Number of dominant colors to extract (1-20, default 5).
     """
     try:
+        _validate_input_path(image_path)
         from .image_engine import extract_colors
 
         return _result(extract_colors(image_path, n_colors=n_colors))
@@ -49,6 +51,7 @@ def image_generate_palette(
         n_colors: Number of dominant colors to base palette on (default 5).
     """
     try:
+        _validate_input_path(image_path)
         from .image_engine import generate_palette
 
         return _result(generate_palette(image_path, harmony=harmony, n_colors=n_colors))
@@ -75,6 +78,7 @@ def image_analyze_product(
         n_colors: Number of dominant colors to extract (default 5).
     """
     try:
+        _validate_input_path(image_path)
         from .image_engine import analyze_product
 
         return _result(analyze_product(image_path, use_ai=use_ai, n_colors=n_colors))

--- a/mcp_video/server_tools_media.py
+++ b/mcp_video/server_tools_media.py
@@ -21,6 +21,7 @@ from .engine import (
 from .errors import MCPVideoError
 from .server_app import _error_result, _result, mcp
 from .validation import VALID_AUDIO_FORMATS, VALID_FORMATS, VALID_PRESETS
+from .ffmpeg_helpers import _validate_input_path
 
 
 @mcp.tool()
@@ -37,6 +38,7 @@ def video_thumbnail(
         output_path: Where to save the frame image. Auto-generated if omitted.
     """
     try:
+        _validate_input_path(input_path)
         return _result(thumbnail(input_path, timestamp=timestamp, output_path=output_path))
     except MCPVideoError as e:
         return _error_result(e)
@@ -58,6 +60,7 @@ def video_preview(
         scale_factor: Downscale factor (4 = 1/4 resolution).
     """
     try:
+        _validate_input_path(input_path)
         MAX_SCALE_FACTOR = 16
         if scale_factor < 2:
             return _error_result(
@@ -96,6 +99,7 @@ def video_storyboard(
         frame_count: Number of key frames to extract.
     """
     try:
+        _validate_input_path(input_path)
         MAX_FRAME_COUNT = 100
         if frame_count is not None and (frame_count < 1 or frame_count > MAX_FRAME_COUNT):
             return _error_result(
@@ -126,6 +130,8 @@ def video_subtitles(
         output_path: Where to save the output. Auto-generated if omitted.
     """
     try:
+        _validate_input_path(input_path)
+        _validate_input_path(subtitle_path)
         return _result(subtitles(input_path, subtitle_path=subtitle_path, output_path=output_path))
     except MCPVideoError as e:
         return _error_result(e)
@@ -181,6 +187,8 @@ def video_watermark(
             MCPVideoError(f"Invalid preset: {preset}", error_type="validation_error", code="invalid_parameter")
         )
     try:
+        _validate_input_path(input_path)
+        _validate_input_path(image_path)
         return _result(
             watermark(
                 input_path,
@@ -257,6 +265,7 @@ def video_crop(
         output_path: Where to save the output. Auto-generated if omitted.
     """
     try:
+        _validate_input_path(input_path)
         return _result(crop(input_path, width=width, height=height, x=x, y=y, output_path=output_path))
     except MCPVideoError as e:
         return _error_result(e)
@@ -325,6 +334,7 @@ def video_fade(
             MCPVideoError(f"Invalid preset: {preset}", error_type="validation_error", code="invalid_parameter")
         )
     try:
+        _validate_input_path(input_path)
         if fade_in < 0:
             return _error_result(
                 MCPVideoError(
@@ -443,6 +453,7 @@ def video_extract_audio(
             )
         )
     try:
+        _validate_input_path(input_path)
         result = extract_audio(input_path, output_path=output_path, format=format)
         if not os.path.isfile(result):
             return _error_result(

--- a/mcp_video/server_tools_remotion.py
+++ b/mcp_video/server_tools_remotion.py
@@ -9,6 +9,7 @@ from .errors import MCPVideoError
 from .limits import MAX_CONCURRENCY, MAX_CRF, MAX_PORT, MAX_RESOLUTION, MIN_CRF, MIN_PORT
 from .server_app import _error_result, _result, mcp
 from .validation import VALID_CODECS, VALID_REMOTION_TEMPLATES
+from .ffmpeg_helpers import _validate_input_path
 
 
 @mcp.tool()
@@ -89,6 +90,7 @@ def remotion_render(
             )
         )
     try:
+        _validate_input_path(project_path)
         from .remotion_engine import render
 
         return _result(
@@ -123,6 +125,7 @@ def remotion_compositions(
         project_path: Absolute path to the Remotion project directory.
     """
     try:
+        _validate_input_path(project_path)
         from .remotion_engine import compositions
 
         return _result(compositions(project_path))
@@ -152,6 +155,7 @@ def remotion_studio(
             )
         )
     try:
+        _validate_input_path(project_path)
         from .remotion_engine import studio
 
         return _result(studio(project_path, port=port))
@@ -179,6 +183,7 @@ def remotion_still(
         image_format: Image format (png, jpeg, webp). Default png.
     """
     try:
+        _validate_input_path(project_path)
         from .remotion_engine import still
 
         return _result(
@@ -247,6 +252,7 @@ def remotion_scaffold_template(
             )
         )
     try:
+        _validate_input_path(project_path)
         from .remotion_engine import scaffold_template
 
         return _result(scaffold_template(project_path, spec, slug))
@@ -268,6 +274,7 @@ def remotion_validate(
         composition_id: Optional specific composition ID to validate.
     """
     try:
+        _validate_input_path(project_path)
         from .remotion_engine import validate
 
         return _result(validate(project_path, composition_id=composition_id))
@@ -302,6 +309,7 @@ def remotion_to_mcpvideo(
             )
         )
     try:
+        _validate_input_path(project_path)
         from .remotion_engine import render_and_post
 
         return _result(render_and_post(project_path, composition_id, post_process, output_path=output_path))


### PR DESCRIPTION
Completes Phase 2 of the failure mode remediation plan.

## Critical Fixes
- **66 server tool wrappers** — added `_validate_input_path()` to all MCP tools that accept file paths (excluding `video_batch` which has partial-failure semantics)
- **Hard OOM guard** — capped total stderr bytes to 1MB in `_run_ffmpeg_with_progress` (in addition to existing 10K line cap)

## High Fixes
- `effects_engine.py` — bare `except Exception:` → logged warning
- `_validate_input_path()` — now enforces `MAX_FILE_SIZE_MB` (4GB)
- `probe()` — now enforces `MAX_VIDEO_DURATION` (4h)
- `engine_speed.py` — imports `MAX_SPEED_CHAIN_COUNT` from `limits.py` instead of hardcoding
- `limits.py` — removed dead `MAX_CONCURRENT_PROCESSES` constant

## Files Changed
- 8 server_tools_*.py files
- effects_engine.py, engine_probe.py, engine_runtime_utils.py, engine_speed.py
- ffmpeg_helpers.py, limits.py

All 773 tests pass.