### PR TITLE
docs: document CVE-2024-27763 mitigation in ai_upscale

### DIFF
--- a/mcp_video/ai_engine.py
+++ b/mcp_video/ai_engine.py
@@ -1320,6 +1320,9 @@ def ai_upscale(
         raise InputFileError(video)
 
     # Try to use Real-ESRGAN if available, otherwise use OpenCV DNN fallback
+    # NOTE: basicsr <= 1.4.2 has CVE-2024-27763 (command injection via SLURM_NODELIST).
+    # Our usage only imports the RRDBNet architecture class for inference.
+    # We do not execute the vulnerable scontrol path in basicsr/utils/dist_util.py.
     try:
         from realesrgan import RealESRGANer
         from basicsr.archs.rrdbnet_arch import RRDBNet


### PR DESCRIPTION
Documents the security rationale for using basicsr <= 1.4.2 despite CVE-2024-27763.

## Context
Dependabot alert #7 flagged basicsr for command injection (CVE-2024-27763, medium severity). No patched version is available upstream.

## Mitigation
Our code only imports RRDBNet from basicsr.archs.rrdbnet_arch for inference. The vulnerable code path (scontrol show hostname via crafted SLURM_NODELIST in basicsr/utils/dist_util.py) is never executed by our usage pattern.

The Dependabot alert has been dismissed with reason: not_used.