### PR TITLE
fix: engine robustness — ffprobe parsing, afade, subtitles, dead code

### DIFF
--- a/mcp_video/ai_engine/color.py
+++ b/mcp_video/ai_engine/color.py
@@ -111,7 +111,7 @@ def ai_color_grade(
     try:
         result = subprocess.run(cmd, capture_output=True, text=True, timeout=DEFAULT_FFMPEG_TIMEOUT)
     except subprocess.TimeoutExpired:
-        raise ProcessingError("Operation timed out after 600 seconds") from None
+        raise ProcessingError(f"Operation timed out after {DEFAULT_FFMPEG_TIMEOUT}s") from None
     if result.returncode != 0:
         raise ProcessingError(" ".join(cmd), result.returncode, result.stderr)
 
@@ -138,7 +138,7 @@ def _match_reference_colors(video: str, reference: str) -> dict:
         try:
             result = subprocess.run(cmd, capture_output=True, text=True, timeout=DEFAULT_FFMPEG_TIMEOUT)
         except subprocess.TimeoutExpired:
-            raise ProcessingError("Operation timed out after 600 seconds") from None
+            raise ProcessingError(f"Operation timed out after {DEFAULT_FFMPEG_TIMEOUT}s") from None
 
         # Default values if extraction fails
         mean_rgb = {"r": 128, "g": 128, "b": 128}

--- a/mcp_video/ai_engine/scene.py
+++ b/mcp_video/ai_engine/scene.py
@@ -82,7 +82,7 @@ def ai_scene_detect(
         try:
             result = subprocess.run(cmd, capture_output=True, text=True, timeout=DEFAULT_FFMPEG_TIMEOUT)
         except subprocess.TimeoutExpired:
-            raise ProcessingError("Operation timed out after 600 seconds") from None
+            raise ProcessingError(f"Operation timed out after {DEFAULT_FFMPEG_TIMEOUT}s") from None
         if result.returncode != 0:
             # Fall back to standard detection on error
             return _standard_scene_detect(video, threshold)

--- a/mcp_video/ai_engine/silence.py
+++ b/mcp_video/ai_engine/silence.py
@@ -46,7 +46,7 @@ def _detect_silence_regions(
     try:
         result = subprocess.run(cmd, capture_output=True, text=True, timeout=DEFAULT_FFMPEG_TIMEOUT)
     except subprocess.TimeoutExpired:
-        raise ProcessingError("Operation timed out after 600 seconds") from None
+        raise ProcessingError(f"Operation timed out after {DEFAULT_FFMPEG_TIMEOUT}s") from None
 
     # Parse silence_start and silence_end from stderr
     silence_regions = []
@@ -144,7 +144,7 @@ def _concat_segments(
         try:
             result = subprocess.run(cmd, capture_output=True, text=True, timeout=DEFAULT_FFMPEG_TIMEOUT)
         except subprocess.TimeoutExpired:
-            raise ProcessingError("Operation timed out after 600 seconds") from None
+            raise ProcessingError(f"Operation timed out after {DEFAULT_FFMPEG_TIMEOUT}s") from None
         if result.returncode != 0:
             raise ProcessingError(" ".join(cmd), result.returncode, result.stderr)
         return output
@@ -173,7 +173,7 @@ def _concat_segments(
             try:
                 result = subprocess.run(cmd, capture_output=True, text=True, timeout=DEFAULT_FFMPEG_TIMEOUT)
             except subprocess.TimeoutExpired:
-                raise ProcessingError("Operation timed out after 600 seconds") from None
+                raise ProcessingError(f"Operation timed out after {DEFAULT_FFMPEG_TIMEOUT}s") from None
             if result.returncode != 0:
                 raise ProcessingError(" ".join(cmd), result.returncode, result.stderr)
 
@@ -204,7 +204,7 @@ def _concat_segments(
         try:
             result = subprocess.run(cmd, capture_output=True, text=True, timeout=DEFAULT_FFMPEG_TIMEOUT)
         except subprocess.TimeoutExpired:
-            raise ProcessingError("Operation timed out after 600 seconds") from None
+            raise ProcessingError(f"Operation timed out after {DEFAULT_FFMPEG_TIMEOUT}s") from None
         if result.returncode != 0:
             raise ProcessingError(" ".join(cmd), result.returncode, result.stderr)
 

--- a/mcp_video/ai_engine/spatial.py
+++ b/mcp_video/ai_engine/spatial.py
@@ -39,7 +39,7 @@ def _standard_scene_detect(video: str, threshold: float) -> list[dict]:
     try:
         result = subprocess.run(cmd, capture_output=True, text=True, timeout=DEFAULT_FFMPEG_TIMEOUT)
     except subprocess.TimeoutExpired:
-        raise ProcessingError("Operation timed out after 600 seconds") from None
+        raise ProcessingError(f"Operation timed out after {DEFAULT_FFMPEG_TIMEOUT}s") from None
 
     scenes = []
     for line in result.stderr.split("\n"):
@@ -234,7 +234,7 @@ def _apply_simple_spatial(
             try:
                 result = subprocess.run(cmd, capture_output=True, text=True, timeout=DEFAULT_FFMPEG_TIMEOUT)
             except subprocess.TimeoutExpired:
-                raise ProcessingError("Operation timed out after 600 seconds") from None
+                raise ProcessingError(f"Operation timed out after {DEFAULT_FFMPEG_TIMEOUT}s") from None
             if result.returncode != 0:
                 raise ProcessingError(" ".join(cmd), result.returncode, result.stderr)
 
@@ -268,7 +268,7 @@ def _apply_simple_spatial(
             try:
                 result = subprocess.run(cmd, capture_output=True, text=True, timeout=DEFAULT_FFMPEG_TIMEOUT)
             except subprocess.TimeoutExpired:
-                raise ProcessingError("Operation timed out after 600 seconds") from None
+                raise ProcessingError(f"Operation timed out after {DEFAULT_FFMPEG_TIMEOUT}s") from None
             if result.returncode != 0:
                 raise ProcessingError(" ".join(cmd), result.returncode, result.stderr)
 

--- a/mcp_video/ai_engine/stem.py
+++ b/mcp_video/ai_engine/stem.py
@@ -92,7 +92,7 @@ def ai_stem_separation(
         try:
             result = subprocess.run(cmd, capture_output=True, text=True, timeout=DEFAULT_FFMPEG_TIMEOUT)
         except subprocess.TimeoutExpired:
-            raise ProcessingError("Operation timed out after 600 seconds") from None
+            raise ProcessingError(f"Operation timed out after {DEFAULT_FFMPEG_TIMEOUT}s") from None
         if result.returncode != 0:
             raise ProcessingError(" ".join(cmd), result.returncode, result.stderr)
 

--- a/mcp_video/ai_engine/transcribe.py
+++ b/mcp_video/ai_engine/transcribe.py
@@ -87,7 +87,7 @@ def ai_transcribe(
         try:
             result = subprocess.run(cmd, capture_output=True, text=True, timeout=DEFAULT_FFMPEG_TIMEOUT)
         except subprocess.TimeoutExpired:
-            raise ProcessingError("Operation timed out after 600 seconds") from None
+            raise ProcessingError(f"Operation timed out after {DEFAULT_FFMPEG_TIMEOUT}s") from None
         if result.returncode != 0:
             raise ProcessingError(" ".join(cmd), result.returncode, result.stderr)
 

--- a/mcp_video/ai_engine/upscale.py
+++ b/mcp_video/ai_engine/upscale.py
@@ -126,7 +126,7 @@ def _ai_upscale_opencv(video_path: str, output_path: str, scale: int) -> str:
         try:
             result = subprocess.run(cmd, capture_output=True, text=True, timeout=DEFAULT_FFMPEG_TIMEOUT)
         except subprocess.TimeoutExpired:
-            raise ProcessingError("Operation timed out after 600 seconds") from None
+            raise ProcessingError(f"Operation timed out after {DEFAULT_FFMPEG_TIMEOUT}s") from None
         if result.returncode != 0:
             raise ProcessingError(" ".join(cmd), result.returncode, result.stderr)
 
@@ -168,7 +168,7 @@ def _ai_upscale_opencv(video_path: str, output_path: str, scale: int) -> str:
         try:
             result = subprocess.run(cmd, capture_output=True, text=True, timeout=DEFAULT_FFMPEG_TIMEOUT)
         except subprocess.TimeoutExpired:
-            raise ProcessingError("Operation timed out after 600 seconds") from None
+            raise ProcessingError(f"Operation timed out after {DEFAULT_FFMPEG_TIMEOUT}s") from None
         if result.returncode != 0:
             raise ProcessingError(" ".join(cmd), result.returncode, result.stderr)
 
@@ -267,7 +267,7 @@ def ai_upscale(
         try:
             result = subprocess.run(cmd, capture_output=True, text=True, timeout=DEFAULT_FFMPEG_TIMEOUT)
         except subprocess.TimeoutExpired:
-            raise ProcessingError("Operation timed out after 600 seconds") from None
+            raise ProcessingError(f"Operation timed out after {DEFAULT_FFMPEG_TIMEOUT}s") from None
         if result.returncode != 0:
             raise ProcessingError(" ".join(cmd), result.returncode, result.stderr)
 
@@ -333,7 +333,7 @@ def ai_upscale(
             try:
                 result = subprocess.run(cmd, capture_output=True, text=True, timeout=DEFAULT_FFMPEG_TIMEOUT)
             except subprocess.TimeoutExpired:
-                raise ProcessingError("Operation timed out after 600 seconds") from None
+                raise ProcessingError(f"Operation timed out after {DEFAULT_FFMPEG_TIMEOUT}s") from None
             if result.returncode != 0:
                 audio_path = None  # Continue without audio
 
@@ -382,7 +382,7 @@ def ai_upscale(
         try:
             result = subprocess.run(cmd, capture_output=True, text=True, timeout=DEFAULT_FFMPEG_TIMEOUT)
         except subprocess.TimeoutExpired:
-            raise ProcessingError("Operation timed out after 600 seconds") from None
+            raise ProcessingError(f"Operation timed out after {DEFAULT_FFMPEG_TIMEOUT}s") from None
         if result.returncode != 0:
             raise ProcessingError(" ".join(cmd), result.returncode, result.stderr)
 
@@ -406,7 +406,7 @@ def _get_video_fps(video_path: str) -> float | None:
     try:
         result = subprocess.run(cmd, capture_output=True, text=True, timeout=DEFAULT_FFMPEG_TIMEOUT)
     except subprocess.TimeoutExpired:
-        raise ProcessingError("Operation timed out after 600 seconds") from None
+        raise ProcessingError(f"Operation timed out after {DEFAULT_FFMPEG_TIMEOUT}s") from None
     if result.returncode != 0:
         return None
 
@@ -442,5 +442,5 @@ def _has_audio_stream(video_path: str) -> bool:
     try:
         result = subprocess.run(cmd, capture_output=True, text=True, timeout=DEFAULT_FFMPEG_TIMEOUT)
     except subprocess.TimeoutExpired:
-        raise ProcessingError("Operation timed out after 600 seconds") from None
+        raise ProcessingError(f"Operation timed out after {DEFAULT_FFMPEG_TIMEOUT}s") from None
     return result.returncode == 0 and "audio" in result.stdout.lower()

--- a/mcp_video/engine.py
+++ b/mcp_video/engine.py
@@ -57,7 +57,6 @@ from .engine_runtime_utils import (
     _sanitize_ffmpeg_number as _sanitize_ffmpeg_number,
     _validate_chroma_color as _validate_chroma_color,
     _validate_color as _validate_color,
-    _validate_input as _validate_input,
     _validate_position as _validate_position,
 )
 from .engine_speed import speed as speed

--- a/mcp_video/engine_audio_ops.py
+++ b/mcp_video/engine_audio_ops.py
@@ -41,8 +41,9 @@ def add_audio(
             if fade_in > 0:
                 audio_filters.append(f"afade=t=in:st=0:d={_escape_ffmpeg_filter_value(str(fade_in))}")
             if fade_out > 0:
+                fade_start = max(0, video_info.duration - fade_out)
                 audio_filters.append(
-                    f"afade=t=out:st={_escape_ffmpeg_filter_value(str(video_info.duration - fade_out))}:"
+                    f"afade=t=out:st={_escape_ffmpeg_filter_value(str(fade_start))}:"
                     f"d={_escape_ffmpeg_filter_value(str(fade_out))}"
                 )
 

--- a/mcp_video/engine_probe.py
+++ b/mcp_video/engine_probe.py
@@ -30,7 +30,10 @@ def _build_video_info(path: str, data: dict) -> VideoInfo:
         raise InputFileError(path, "No video stream found")
 
     # Duration
-    duration = float(data.get("format", {}).get("duration", 0) or vs.get("duration", 0))
+    try:
+        duration = float(data.get("format", {}).get("duration", 0) or vs.get("duration", 0))
+    except (ValueError, TypeError):
+        duration = 0.0
     if duration > MAX_VIDEO_DURATION:
         raise MCPVideoError(
             f"Video duration ({duration:.0f}s) exceeds maximum of {MAX_VIDEO_DURATION}s",
@@ -39,8 +42,11 @@ def _build_video_info(path: str, data: dict) -> VideoInfo:
         )
 
     # Resolution
-    width = int(vs.get("width", 0))
-    height = int(vs.get("height", 0))
+    try:
+        width = int(vs.get("width", 0))
+        height = int(vs.get("height", 0))
+    except (ValueError, TypeError):
+        width = height = 0
 
     # FPS — r_frame_rate is "num/den"
     rfr = vs.get("r_frame_rate", "30/1")
@@ -62,8 +68,11 @@ def _build_video_info(path: str, data: dict) -> VideoInfo:
 
     # Bitrate / size
     fmt = data.get("format", {})
-    bitrate = int(fmt.get("bit_rate", 0)) or None
-    size_bytes = int(fmt.get("size", 0)) or None
+    try:
+        bitrate = int(fmt.get("bit_rate", 0)) or None
+        size_bytes = int(fmt.get("size", 0)) or None
+    except (ValueError, TypeError):
+        bitrate = size_bytes = None
     fmt_name = fmt.get("format_name")
 
     return VideoInfo(

--- a/mcp_video/engine_probe.py
+++ b/mcp_video/engine_probe.py
@@ -23,17 +23,23 @@ def _cache_key(path: str) -> tuple[str, float, int]:
     return (path, stat.st_mtime, stat.st_size)
 
 
+def _parse_probe_duration(value: object) -> float | None:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
 def _build_video_info(path: str, data: dict) -> VideoInfo:
     """Construct a VideoInfo from raw ffprobe JSON data."""
     vs = _get_video_stream(data)
     if vs is None:
         raise InputFileError(path, "No video stream found")
 
-    # Duration
-    try:
-        duration = float(data.get("format", {}).get("duration", 0) or vs.get("duration", 0))
-    except (ValueError, TypeError):
-        duration = 0.0
+    # Duration: prefer container duration, then fall back to the video stream.
+    duration = _parse_probe_duration(data.get("format", {}).get("duration"))
+    if duration is None:
+        duration = _parse_probe_duration(vs.get("duration")) or 0.0
     if duration > MAX_VIDEO_DURATION:
         raise MCPVideoError(
             f"Video duration ({duration:.0f}s) exceeds maximum of {MAX_VIDEO_DURATION}s",

--- a/mcp_video/engine_runtime_utils.py
+++ b/mcp_video/engine_runtime_utils.py
@@ -18,7 +18,6 @@ from typing import Any
 from .errors import (
     FFmpegNotFoundError,
     FFprobeNotFoundError,
-    InputFileError,
     MCPVideoError,
     ProcessingError,
     parse_ffmpeg_error,

--- a/mcp_video/engine_runtime_utils.py
+++ b/mcp_video/engine_runtime_utils.py
@@ -23,7 +23,7 @@ from .errors import (
     ProcessingError,
     parse_ffmpeg_error,
 )
-from .limits import DEFAULT_CRF, DEFAULT_FFMPEG_TIMEOUT, DEFAULT_PRESET
+from .limits import DEFAULT_CRF, DEFAULT_FFMPEG_TIMEOUT, DEFAULT_PRESET, DOCTOR_COMMAND_TIMEOUT
 from .models import NamedPosition, Position
 
 logger = logging.getLogger(__name__)
@@ -96,13 +96,6 @@ def _require_filter(name: str, feature: str) -> None:
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
-
-
-def _validate_input(path: str) -> None:
-    if "\x00" in path:
-        raise InputFileError(path, "Path contains null bytes")
-    if not os.path.isfile(path):
-        raise InputFileError(path)
 
 
 def _sanitize_ffmpeg_number(value: Any, name: str) -> float:
@@ -452,7 +445,7 @@ def _generate_thumbnail_base64(video_path: str) -> str | None:
             ],
             capture_output=True,
             text=True,
-            timeout=15,
+            timeout=DOCTOR_COMMAND_TIMEOUT,
         )
 
         if proc.returncode != 0 or not os.path.isfile(tmp_path):

--- a/mcp_video/engine_subtitle_generate.py
+++ b/mcp_video/engine_subtitle_generate.py
@@ -84,7 +84,7 @@ def _validate_entries(entries: list[dict]) -> None:
 
 def _write_srt(entries: list[dict], input_path: str, output_path: str | None) -> str:
     if output_path:
-        if os.path.isdir(output_path):
+        if os.path.isdir(output_path) or output_path.endswith(os.sep):
             srt_dir = output_path
             srt_file = os.path.join(srt_dir, "subtitles.srt")
         else:

--- a/mcp_video/engine_subtitle_generate.py
+++ b/mcp_video/engine_subtitle_generate.py
@@ -84,13 +84,18 @@ def _validate_entries(entries: list[dict]) -> None:
 
 def _write_srt(entries: list[dict], input_path: str, output_path: str | None) -> str:
     if output_path:
-        srt_dir = output_path if os.path.isdir(output_path) else os.path.dirname(output_path) or "."
+        if os.path.isdir(output_path):
+            srt_dir = output_path
+            srt_file = os.path.join(srt_dir, "subtitles.srt")
+        else:
+            srt_dir = os.path.dirname(output_path) or "."
+            srt_file = output_path
         os.makedirs(srt_dir, exist_ok=True)
     else:
         srt_dir = _auto_output_dir(input_path, "subtitles")
         os.makedirs(srt_dir, exist_ok=True)
+        srt_file = os.path.join(srt_dir, "subtitles.srt")
 
-    srt_file = os.path.join(srt_dir, "subtitles.srt")
     with open(srt_file, "w", encoding="utf-8") as f:
         f.write(_build_srt_content(entries))
     return srt_file

--- a/tests/test_adversarial_audit.py
+++ b/tests/test_adversarial_audit.py
@@ -10,7 +10,6 @@ import contextlib
 import pytest
 
 from mcp_video.engine import (
-    _validate_input,
     _validate_color,
     _validate_position,
     _escape_ffmpeg_filter_value,
@@ -221,26 +220,6 @@ class TestTimeoutProtection:
 # ---------------------------------------------------------------------------
 # Phase 3: Path Validation
 # ---------------------------------------------------------------------------
-
-
-class TestPathValidation:
-    """Paths are validated and resolved."""
-
-    def test_validate_input_null_byte_rejected(self) -> None:
-        """Paths with null bytes are rejected by _validate_input."""
-        with pytest.raises(InputFileError):
-            _validate_input("/tmp/test\x00.mp4")
-
-    def test_validate_input_nonexistent_file_rejected(self) -> None:
-        """Non-existent files are rejected by _validate_input."""
-        with pytest.raises(InputFileError):
-            _validate_input("/nonexistent/file.mp4")
-
-    def test_original_validate_input_still_works(self, tmp_path) -> None:
-        """Original _validate_input function still works."""
-        test_file = tmp_path / "test.mp4"
-        test_file.write_text("fake video")
-        _validate_input(str(test_file))  # Should not raise
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -24,7 +24,7 @@ from mcp_video.engine import (
     thumbnail,
     trim,
 )
-from mcp_video.errors import InputFileError
+from mcp_video.errors import InputFileError, MCPVideoError
 from mcp_video.models import VideoInfo
 
 
@@ -34,6 +34,30 @@ def requires_filter(name: str, feature: str):
         not _check_filter_available(name),
         reason=f"FFmpeg filter '{name}' not available ({feature} requires it)",
     )
+
+
+
+
+def test_probe_duration_falls_back_to_stream_before_limit():
+    from mcp_video.engine_probe import _build_video_info
+    from mcp_video.limits import MAX_VIDEO_DURATION
+
+    data = {
+        "format": {"duration": "N/A"},
+        "streams": [
+            {
+                "codec_type": "video",
+                "duration": str(MAX_VIDEO_DURATION + 1),
+                "width": 640,
+                "height": 360,
+                "r_frame_rate": "30/1",
+                "codec_name": "h264",
+            }
+        ],
+    }
+
+    with pytest.raises(MCPVideoError, match="exceeds maximum"):
+        _build_video_info("video.mp4", data)
 
 
 class TestProbe:

--- a/tests/test_engine_advanced.py
+++ b/tests/test_engine_advanced.py
@@ -713,6 +713,19 @@ class TestGenerateSubtitles:
         assert result.video_path is not None
         assert os.path.isfile(result.video_path)
 
+
+    def test_directory_style_output_path_writes_subtitles_file(self, sample_video, tmp_path):
+        from mcp_video.engine import generate_subtitles
+
+        output_dir = str(tmp_path / "subtitle_dir") + os.sep
+        entries = [{"start": 0.0, "end": 1.0, "text": "Hello"}]
+
+        result = generate_subtitles(entries, sample_video, output_path=output_dir)
+
+        assert result.srt_path == os.path.join(output_dir, "subtitles.srt")
+        assert os.path.isfile(result.srt_path)
+
+
     def test_empty_entries_raises(self, sample_video):
         from mcp_video.engine import generate_subtitles
 

--- a/tests/test_public_surface.py
+++ b/tests/test_public_surface.py
@@ -235,7 +235,6 @@ def test_module_reexports():
         "_parse_ffmpeg_time",
         "_run_ffmpeg_with_progress",
         "_validate_color",
-        "_validate_input",
         "_validate_position",
         "add_text",
         "convert",


### PR DESCRIPTION
- engine_probe.py: wrap float()/int() on ffprobe output in try/except to prevent raw ValueError/TypeError from malformed data
- engine_audio_ops.py: guard fade_out against exceeding video duration, preventing negative afade start times
- engine_subtitle_generate.py: respect output_path filename when provided (was always writing 'subtitles.srt')
- engine_runtime_utils.py: remove dead code _validate_input (zero callers)
- Replace hardcoded timeout=15 with DOCTOR_COMMAND_TIMEOUT constant
- Replace all hardcoded '600 seconds' timeout messages with f-string referencing DEFAULT_FFMPEG_TIMEOUT across AI engine

Fixes P1 #10, #13-14, P2 #25-27 from edge-case audit.

## Why

<!-- Explain the user problem, bug, or maintenance risk this PR addresses. -->

## What changed

<!-- Keep this concrete and reviewable. -->

## Verification

<!-- Paste commands and outcomes. Prefer focused tests plus the relevant broader suite. -->

- [ ] `python3 -m pytest tests/ -x -q --tb=short`
- [ ] `python3 -c "import mcp_video"`
- [ ] `./scripts/git-professional-audit.sh`
- [ ] Other:

## Maintainer checklist

- [ ] Public MCP tool signatures are unchanged, or the compatibility impact is explained.
- [ ] New or changed FFmpeg filter strings escape user-controlled values with `_escape_ffmpeg_filter_value()`.
- [ ] Subprocess calls include a timeout and route FFmpeg failures through `ProcessingError`.
- [ ] New defaults live in `defaults.py`; validation constants live in `validation.py` or `limits.py`.
- [ ] No generated media, logs, caches, local research dumps, or build artifacts were committed.
- [ ] Documentation, README counts, or roadmap entries were updated when the public surface changed.
