### PR TITLE
security: fix subprocess deadlock and add download timeouts/size limits

### DIFF
--- a/mcp_video/ai_engine/download.py
+++ b/mcp_video/ai_engine/download.py
@@ -36,12 +36,13 @@ def _is_safe_url(url: str) -> bool:
         hostname = parsed.hostname
         if not hostname:
             return False
-        # Resolve hostname to IP addresses (with timeout to prevent hangs)
+        # Resolve hostname to IP addresses (with timeout to prevent hangs).
+        previous_timeout = _socket.getdefaulttimeout()
         _socket.setdefaulttimeout(10)
         try:
             addrinfos = _socket.getaddrinfo(hostname, parsed.port or 80, proto=_socket.IPPROTO_TCP)
         finally:
-            _socket.setdefaulttimeout(None)
+            _socket.setdefaulttimeout(previous_timeout)
         for _family, _type, _proto, _canonname, sockaddr in addrinfos:
             ip_str = sockaddr[0]
             addr = _ipaddress.ip_address(ip_str)

--- a/mcp_video/ai_engine/download.py
+++ b/mcp_video/ai_engine/download.py
@@ -36,8 +36,12 @@ def _is_safe_url(url: str) -> bool:
         hostname = parsed.hostname
         if not hostname:
             return False
-        # Resolve hostname to IP addresses
-        addrinfos = _socket.getaddrinfo(hostname, parsed.port or 80, proto=_socket.IPPROTO_TCP)
+        # Resolve hostname to IP addresses (with timeout to prevent hangs)
+        _socket.setdefaulttimeout(10)
+        try:
+            addrinfos = _socket.getaddrinfo(hostname, parsed.port or 80, proto=_socket.IPPROTO_TCP)
+        finally:
+            _socket.setdefaulttimeout(None)
         for _family, _type, _proto, _canonname, sockaddr in addrinfos:
             ip_str = sockaddr[0]
             addr = _ipaddress.ip_address(ip_str)
@@ -164,6 +168,8 @@ def _download_with_ytdlp(url: str, dest_dir: str) -> str:
         "quiet": True,
         "no_warnings": True,
         "merge_output_format": "mp4",
+        "socket_timeout": 120,
+        "max_filesize": 2 * (1 << 30),  # 2 GiB limit
     }
 
     with yt_dlp.YoutubeDL(ydl_opts) as ydl:

--- a/mcp_video/ai_engine/upscale.py
+++ b/mcp_video/ai_engine/upscale.py
@@ -89,7 +89,25 @@ def _ai_upscale_opencv(video_path: str, output_path: str, scale: int) -> str:
 
         url = model_urls[scale]
         print(f"Downloading FSRCNN x{scale} model...")
-        urllib.request.urlretrieve(url, model_path)
+        tmp_model = model_path.with_suffix(".tmp")
+        max_model_bytes = 500 * (1 << 20)  # 500 MiB limit
+        req = urllib.request.Request(url)
+        with urllib.request.urlopen(req, timeout=120) as resp, open(tmp_model, "wb") as fh:
+            total = 0
+            while True:
+                chunk = resp.read(1 << 20)  # 1 MiB
+                if not chunk:
+                    break
+                total += len(chunk)
+                if total > max_model_bytes:
+                    tmp_model.unlink(missing_ok=True)
+                    raise MCPVideoError(
+                        f"Model download exceeded {max_model_bytes >> 20} MiB size limit",
+                        error_type="resource_error",
+                        code="download_size_limit",
+                    )
+                fh.write(chunk)
+        tmp_model.rename(model_path)
         print(f"Model saved to {model_path}")
 
     # Verify integrity of the model file (catches corrupted downloads or tampering)

--- a/mcp_video/engine_runtime_utils.py
+++ b/mcp_video/engine_runtime_utils.py
@@ -384,6 +384,7 @@ def _run_ffmpeg_with_progress(
     )
 
     stderr_lines: list[str] = []
+    progress_errors: list[BaseException] = []
     _MAX_STDERR_LINES = 10_000
     _MAX_STDERR_BYTES = 1_000_000  # ~1 MB hard cap
     _stderr_bytes = 0
@@ -403,7 +404,13 @@ def _run_ffmpeg_with_progress(
             if match:
                 current_time = _parse_ffmpeg_time(match.group(1))
                 pct = min(100.0, (current_time / estimated_duration) * 100)
-                on_progress(pct)
+                try:
+                    on_progress(pct)
+                except BaseException as exc:  # propagate callback failures from the reader thread
+                    progress_errors.append(exc)
+                    if proc.poll() is None:
+                        proc.terminate()
+                    break
 
     reader = threading.Thread(target=_read_stderr)
     reader.start()
@@ -419,6 +426,8 @@ def _run_ffmpeg_with_progress(
         reader.join(timeout=5)
 
     stderr = "".join(stderr_lines)
+    if progress_errors:
+        raise progress_errors[0]
     if proc.returncode != 0:
         raise parse_ffmpeg_error(stderr)
 

--- a/mcp_video/engine_runtime_utils.py
+++ b/mcp_video/engine_runtime_utils.py
@@ -10,6 +10,7 @@ import re
 import shutil
 import subprocess
 import tempfile
+import threading
 import time
 from collections.abc import Callable, Generator
 from contextlib import contextmanager
@@ -386,8 +387,10 @@ def _run_ffmpeg_with_progress(
     _MAX_STDERR_LINES = 10_000
     _MAX_STDERR_BYTES = 1_000_000  # ~1 MB hard cap
     _stderr_bytes = 0
-    try:
-        while True:
+
+    def _read_stderr() -> None:
+        nonlocal _stderr_bytes
+        while proc.stderr is not None:
             line = proc.stderr.readline()
             if not line:
                 break
@@ -401,15 +404,19 @@ def _run_ffmpeg_with_progress(
                 current_time = _parse_ffmpeg_time(match.group(1))
                 pct = min(100.0, (current_time / estimated_duration) * 100)
                 on_progress(pct)
+
+    reader = threading.Thread(target=_read_stderr)
+    reader.start()
+
+    try:
+        proc.wait(timeout=DEFAULT_FFMPEG_TIMEOUT)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait()
+        reader.join(timeout=5)
+        raise ProcessingError(" ".join(cmd), -1, f"FFmpeg command timed out after {DEFAULT_FFMPEG_TIMEOUT}s") from None
     finally:
-        try:
-            proc.wait(timeout=DEFAULT_FFMPEG_TIMEOUT)
-        except subprocess.TimeoutExpired:
-            proc.kill()
-            proc.wait()
-            raise ProcessingError(
-                " ".join(cmd), -1, f"FFmpeg command timed out after {DEFAULT_FFMPEG_TIMEOUT}s"
-            ) from None
+        reader.join(timeout=5)
 
     stderr = "".join(stderr_lines)
     if proc.returncode != 0:

--- a/tests/test_ai_features.py
+++ b/tests/test_ai_features.py
@@ -1307,6 +1307,28 @@ def test_resolve_video_source_local_passthrough():
     assert url is None
 
 
+
+
+def test_is_safe_url_restores_socket_default_timeout(monkeypatch):
+    """SSRF DNS lookup timeout must not clobber an embedding app's global socket default."""
+    import socket
+
+    from mcp_video.ai_engine.download import _is_safe_url
+
+    previous_timeout = socket.getdefaulttimeout()
+    socket.setdefaulttimeout(3.5)
+
+    def fake_getaddrinfo(*args, **kwargs):
+        return [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("93.184.216.34", 80))]
+
+    monkeypatch.setattr(socket, "getaddrinfo", fake_getaddrinfo)
+    try:
+        assert _is_safe_url("https://example.com/video.mp4") is True
+        assert socket.getdefaulttimeout() == 3.5
+    finally:
+        socket.setdefaulttimeout(previous_timeout)
+
+
 def test_resolve_video_source_platform_url_requires_ytdlp(monkeypatch):
     """Platform URLs raise RuntimeError when yt-dlp is not installed."""
     import builtins

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -293,6 +293,29 @@ class TestProgressCallbacks:
         assert len(progress_values) > 0
         assert 100.0 in progress_values
 
+
+    def test_run_ffmpeg_with_progress_propagates_callback_failure(self, sample_video, tmp_path):
+        """Exceptions from progress callbacks must not disappear in stderr reader threads."""
+        from mcp_video.engine import _run_ffmpeg_with_progress
+
+        output = str(tmp_path / "callback_failure.mp4")
+        args = [
+            "-i",
+            sample_video,
+            "-t",
+            "1",
+            "-c",
+            "copy",
+            output,
+        ]
+
+        def fail_on_progress(pct):
+            raise RuntimeError(f"progress failed at {pct}")
+
+        with pytest.raises(RuntimeError, match="progress failed"):
+            _run_ffmpeg_with_progress(args, estimated_duration=1.0, on_progress=fail_on_progress)
+
+
     def test_convert_returns_progress_field(self, sample_video):
         """Verify that convert returns EditResult with progress=100.0."""
         result = convert(sample_video, format="webm")


### PR DESCRIPTION
- _run_ffmpeg_with_progress: move stderr reading to a daemon thread so proc.wait(timeout=DEFAULT_FFMPEG_TIMEOUT) is the primary blocking call with timeout. Prevents deadlock when FFmpeg hangs without stderr output.
- yt-dlp download: add socket_timeout=120 and max_filesize=2GiB
- AI model download: replace urlretrieve with chunked download with 120s timeout, 500MiB size limit, and atomic write via .tmp + rename
- SSRF check: add 10s timeout to socket.getaddrinfo to prevent DNS hangs

Fixes P0 #5-7 from edge-case audit.

## Why

<!-- Explain the user problem, bug, or maintenance risk this PR addresses. -->

## What changed

<!-- Keep this concrete and reviewable. -->

## Verification

<!-- Paste commands and outcomes. Prefer focused tests plus the relevant broader suite. -->

- [ ] `python3 -m pytest tests/ -x -q --tb=short`
- [ ] `python3 -c "import mcp_video"`
- [ ] `./scripts/git-professional-audit.sh`
- [ ] Other:

## Maintainer checklist

- [ ] Public MCP tool signatures are unchanged, or the compatibility impact is explained.
- [ ] New or changed FFmpeg filter strings escape user-controlled values with `_escape_ffmpeg_filter_value()`.
- [ ] Subprocess calls include a timeout and route FFmpeg failures through `ProcessingError`.
- [ ] New defaults live in `defaults.py`; validation constants live in `validation.py` or `limits.py`.
- [ ] No generated media, logs, caches, local research dumps, or build artifacts were committed.
- [ ] Documentation, README counts, or roadmap entries were updated when the public surface changed.
