### PR TITLE
security: fix TOCTOU and sanitize numeric values in FFmpeg filters

### DIFF
--- a/mcp_video/effects_engine/core.py
+++ b/mcp_video/effects_engine/core.py
@@ -10,6 +10,7 @@ import math
 
 from ..errors import ProcessingError
 from ..ffmpeg_helpers import _validate_input_path, _run_ffmpeg
+from ..engine_runtime_utils import _sanitize_ffmpeg_number
 
 logger = logging.getLogger(__name__)
 
@@ -34,6 +35,9 @@ def effect_vignette(
         Path to output video
     """
     input_path = _validate_input_path(input_path)
+    intensity = _sanitize_ffmpeg_number(intensity, "intensity")
+    radius = _sanitize_ffmpeg_number(radius, "radius")
+
     # FFmpeg vignette filter: angle (in radians) controls the radius
     # intensity maps to darkness
 
@@ -154,6 +158,10 @@ def effect_scanlines(
         Path to output video
     """
     input_path = _validate_input_path(input_path)
+    line_height = _sanitize_ffmpeg_number(line_height, "line_height")
+    opacity = _sanitize_ffmpeg_number(opacity, "opacity")
+    flicker = _sanitize_ffmpeg_number(flicker, "flicker")
+
     # Use drawgrid filter to create scanlines - simpler and more reliable
     # drawgrid creates horizontal lines with specified spacing
     grid_spacing = line_height * 2
@@ -263,6 +271,10 @@ def effect_glow(
         Path to output video
     """
     input_path = _validate_input_path(input_path)
+    radius = int(_sanitize_ffmpeg_number(radius, "radius"))
+    intensity = _sanitize_ffmpeg_number(intensity, "intensity")
+    threshold = _sanitize_ffmpeg_number(threshold, "threshold")
+
     # Extract highlights, blur them, overlay back
     threshold_8bit = int(threshold * 255)
 

--- a/mcp_video/effects_engine/utility.py
+++ b/mcp_video/effects_engine/utility.py
@@ -127,7 +127,7 @@ def auto_chapters(
     Raises:
         MCPVideoError: If *threshold* is not a number in [0.0, 1.0].
     """
-    _validate_input_path(video)
+    video = _validate_input_path(video)
 
     if not isinstance(threshold, (int, float)) or not (0.0 <= threshold <= 1.0):
         raise MCPVideoError(f"threshold must be a number between 0.0 and 1.0, got {threshold!r}")

--- a/mcp_video/engine_audio_normalize.py
+++ b/mcp_video/engine_audio_normalize.py
@@ -31,7 +31,7 @@ def normalize_audio(
         lra: Loudness range target in LU. Default 11.0.
         output_path: Where to save the output.
     """
-    _validate_input_path(input_path)
+    input_path = _validate_input_path(input_path)
     if not isinstance(target_lufs, (int, float)) or not (-70 <= target_lufs <= -5):
         raise MCPVideoError(
             f"target_lufs must be -70 to -5, got {target_lufs}", error_type="validation_error", code="invalid_parameter"

--- a/mcp_video/engine_audio_ops.py
+++ b/mcp_video/engine_audio_ops.py
@@ -26,8 +26,8 @@ def add_audio(
     output_path: str | None = None,
 ) -> EditResult:
     """Add or replace audio track on a video."""
-    _validate_input_path(video_path)
-    _validate_input_path(audio_path)
+    video_path = _validate_input_path(video_path)
+    audio_path = _validate_input_path(audio_path)
     output = output_path or _auto_output(video_path, "audio")
 
     video_info = probe(video_path)

--- a/mcp_video/engine_audio_waveform.py
+++ b/mcp_video/engine_audio_waveform.py
@@ -22,7 +22,7 @@ def audio_waveform(
         input_path: Path to the input video/audio file.
         bins: Number of time segments to analyze (default 50).
     """
-    _validate_input_path(input_path)
+    input_path = _validate_input_path(input_path)
     if not isinstance(bins, int) or bins < 1 or bins > 1000:
         raise MCPVideoError(
             f"bins must be between 1 and 1000, got {bins}",

--- a/mcp_video/engine_batch.py
+++ b/mcp_video/engine_batch.py
@@ -38,7 +38,7 @@ def video_batch(
 
     for input_path in inputs:
         try:
-            _validate_input_path(input_path)
+            input_path = _validate_input_path(input_path)
             if output_dir:
                 os.makedirs(output_dir, exist_ok=True)
 

--- a/mcp_video/engine_chroma_key.py
+++ b/mcp_video/engine_chroma_key.py
@@ -38,7 +38,7 @@ def chroma_key(
     background). Non-MOV outputs will encode with libx264 which does not
     support transparency.
     """
-    _validate_input_path(input_path)
+    input_path = _validate_input_path(input_path)
     output = output_path or _auto_output(input_path, "chromakey")
 
     _require_filter("chromakey", "Chroma key filter")

--- a/mcp_video/engine_compare_quality.py
+++ b/mcp_video/engine_compare_quality.py
@@ -26,8 +26,8 @@ def compare_quality(
         distorted_path: Path to the distorted/processed video.
         metrics: List of metrics to compute (default: ["psnr", "ssim"]).
     """
-    _validate_input_path(original_path)
-    _validate_input_path(distorted_path)
+    original_path = _validate_input_path(original_path)
+    distorted_path = _validate_input_path(distorted_path)
     requested_metrics = metrics or ["psnr", "ssim"]
     supported_metrics = [metric.lower() for metric in requested_metrics if metric.lower() in ("psnr", "ssim")]
 

--- a/mcp_video/engine_convert.py
+++ b/mcp_video/engine_convert.py
@@ -32,7 +32,7 @@ def convert(
     target_bitrate: int | None = None,
 ) -> EditResult:
     """Convert video to a different format."""
-    _validate_input_path(input_path)
+    input_path = _validate_input_path(input_path)
 
     if two_pass and format not in ("mp4", "mov"):
         raise MCPVideoError(

--- a/mcp_video/engine_crop.py
+++ b/mcp_video/engine_crop.py
@@ -24,7 +24,7 @@ def crop(
     output_path: str | None = None,
 ) -> EditResult:
     """Crop a video to a rectangular region."""
-    _validate_input_path(input_path)
+    input_path = _validate_input_path(input_path)
     if width <= 0 or height <= 0:
         raise MCPVideoError("Crop dimensions must be positive", code="invalid_crop")
 

--- a/mcp_video/engine_detect_scenes.py
+++ b/mcp_video/engine_detect_scenes.py
@@ -25,7 +25,7 @@ def detect_scenes(
         threshold: Scene detection sensitivity (0.0-1.0, lower = more sensitive).
         min_scene_duration: Minimum duration of a scene in seconds.
     """
-    _validate_input_path(input_path)
+    input_path = _validate_input_path(input_path)
     if not isinstance(threshold, (int, float)) or not (0.0 <= threshold <= 1.0):
         raise MCPVideoError(
             f"threshold must be 0.0-1.0, got {threshold}", error_type="validation_error", code="invalid_parameter"

--- a/mcp_video/engine_edit.py
+++ b/mcp_video/engine_edit.py
@@ -35,7 +35,7 @@ def trim(
     output_path: str | None = None,
 ) -> EditResult:
     """Trim a video by start time and duration or end time."""
-    _validate_input_path(input_path)
+    input_path = _validate_input_path(input_path)
     output = output_path or _auto_output(input_path, "trimmed")
 
     # Validate time values

--- a/mcp_video/engine_export.py
+++ b/mcp_video/engine_export.py
@@ -18,7 +18,7 @@ def export_video(
     target_bitrate: int | None = None,
 ) -> EditResult:
     """Export a video with specified quality and format settings."""
-    _validate_input_path(input_path)
+    input_path = _validate_input_path(input_path)
     from .engine_convert import convert
 
     result = convert(

--- a/mcp_video/engine_extract_audio.py
+++ b/mcp_video/engine_extract_audio.py
@@ -20,7 +20,7 @@ def extract_audio(
             error_type="validation_error",
             code="invalid_parameter",
         )
-    _validate_input_path(input_path)
+    input_path = _validate_input_path(input_path)
     ext = f".{format}" if not format.startswith(".") else format
     output = output_path or _auto_output(input_path, "audio", ext=ext)
 

--- a/mcp_video/engine_fade.py
+++ b/mcp_video/engine_fade.py
@@ -8,6 +8,7 @@ from .engine_runtime_utils import (
     _movflags_args,
     _quality_args,
     _run_ffmpeg,
+    _sanitize_ffmpeg_number,
     _timed_operation,
 )
 from .ffmpeg_helpers import _validate_input_path
@@ -24,7 +25,9 @@ def fade(
     preset: str | None = None,
 ) -> EditResult:
     """Add fade in/out effect to a video."""
-    _validate_input_path(input_path)
+    input_path = _validate_input_path(input_path)
+    fade_in = _sanitize_ffmpeg_number(fade_in, "fade_in")
+    fade_out = _sanitize_ffmpeg_number(fade_out, "fade_out")
     if fade_in <= 0 and fade_out <= 0:
         raise MCPVideoError("Specify fade_in and/or fade_out > 0", code="no_fade")
 

--- a/mcp_video/engine_filters.py
+++ b/mcp_video/engine_filters.py
@@ -71,7 +71,7 @@ def apply_filter(
     preset: str | None = None,
 ) -> EditResult:
     """Apply a visual or audio filter to a video."""
-    _validate_input_path(input_path)
+    input_path = _validate_input_path(input_path)
     params = _sanitize_params(params or {})
     output = output_path or _auto_output(input_path, f"filter_{filter_type}")
     info = probe(input_path)

--- a/mcp_video/engine_frames.py
+++ b/mcp_video/engine_frames.py
@@ -6,7 +6,7 @@ import os
 
 from .ffmpeg_helpers import _validate_input_path
 from .engine_probe import probe
-from .engine_runtime_utils import _auto_output_dir, _run_ffmpeg
+from .engine_runtime_utils import _auto_output_dir, _run_ffmpeg, _sanitize_ffmpeg_number
 from .errors import MCPVideoError
 from .models import ImageSequenceResult
 
@@ -25,7 +25,8 @@ def export_frames(
         fps: Frames per second to extract (1.0 = 1 frame per second).
         format: Output image format (jpg, png).
     """
-    _validate_input_path(input_path)
+    input_path = _validate_input_path(input_path)
+    fps = _sanitize_ffmpeg_number(fps, "fps")
     if format == "mjpeg":
         format = "jpg"
     if format not in ("jpg", "png"):

--- a/mcp_video/engine_mask.py
+++ b/mcp_video/engine_mask.py
@@ -32,8 +32,8 @@ def apply_mask(
         feather: Feather/blur amount at mask edges in pixels (default 5).
         output_path: Where to save the output.
     """
-    _validate_input_path(input_path)
-    _validate_input_path(mask_path)
+    input_path = _validate_input_path(input_path)
+    mask_path = _validate_input_path(mask_path)
     _require_filter("alphamerge", "Advanced masking")
     output = output_path or _auto_output(input_path, "masked")
 

--- a/mcp_video/engine_merge.py
+++ b/mcp_video/engine_merge.py
@@ -42,15 +42,15 @@ def merge(
         raise InputFileError("", "No clips provided for merge")
     if len(clips) == 1:
         # Single clip — nothing to merge, just copy to output
-        _validate_input_path(clips[0])
-        output = output_path or _auto_output(clips[0], "merged")
-        input_ext = os.path.splitext(clips[0])[1].lower()
+        clip = _validate_input_path(clips[0])
+        output = output_path or _auto_output(clip, "merged")
+        input_ext = os.path.splitext(clip)[1].lower()
         output_ext = os.path.splitext(output)[1].lower()
         if output_path is not None and input_ext != output_ext:
             # Remux via FFmpeg to ensure correct container format
-            _run_ffmpeg(["-i", clips[0], "-c", "copy", *_movflags_args(output), output])
+            _run_ffmpeg(["-i", clip, "-c", "copy", *_movflags_args(output), output])
         else:
-            shutil.copy2(clips[0], output)
+            shutil.copy2(clip, output)
         info = probe(output)
         return EditResult(
             output_path=output,
@@ -62,8 +62,7 @@ def merge(
             elapsed_ms=0.0,
         )
 
-    for c in clips:
-        c = _validate_input_path(c)
+    clips = [_validate_input_path(c) for c in clips]
 
     # Check if all clips have same resolution — if not, normalize
     infos = [probe(c) for c in clips]

--- a/mcp_video/engine_merge.py
+++ b/mcp_video/engine_merge.py
@@ -63,7 +63,7 @@ def merge(
         )
 
     for c in clips:
-        _validate_input_path(c)
+        c = _validate_input_path(c)
 
     # Check if all clips have same resolution — if not, normalize
     infos = [probe(c) for c in clips]

--- a/mcp_video/engine_metadata.py
+++ b/mcp_video/engine_metadata.py
@@ -17,7 +17,7 @@ def read_metadata(input_path: str) -> MetadataResult:
     Args:
         input_path: Path to the input file.
     """
-    _validate_input_path(input_path)
+    input_path = _validate_input_path(input_path)
     data = _run_ffprobe_json(input_path)
 
     # Extract tags from format
@@ -53,7 +53,7 @@ def write_metadata(
         metadata: Dict of tag key-value pairs (e.g. {"title": "My Video", "artist": "Me"}).
         output_path: Where to save the output. If None, overwrites in place with a temp file.
     """
-    _validate_input_path(input_path)
+    input_path = _validate_input_path(input_path)
     if not metadata:
         raise MCPVideoError(
             "No metadata provided",

--- a/mcp_video/engine_overlay.py
+++ b/mcp_video/engine_overlay.py
@@ -45,8 +45,8 @@ def overlay_video(
         duration: How long the overlay is visible (seconds).
         output_path: Where to save the output.
     """
-    _validate_input_path(background_path)
-    _validate_input_path(overlay_path)
+    background_path = _validate_input_path(background_path)
+    overlay_path = _validate_input_path(overlay_path)
     _require_filter("overlay", "Video overlay")
     _validate_dimensions(width, height)
     safe_opacity = _validate_opacity(opacity)

--- a/mcp_video/engine_preview.py
+++ b/mcp_video/engine_preview.py
@@ -15,7 +15,7 @@ def preview(
     scale_factor: int = 4,
 ) -> EditResult:
     """Generate a fast low-resolution preview for quick review."""
-    _validate_input_path(input_path)
+    input_path = _validate_input_path(input_path)
     if scale_factor < 1:
         raise MCPVideoError("scale_factor must be at least 1", code="invalid_scale_factor")
     info = probe(input_path)

--- a/mcp_video/engine_probe.py
+++ b/mcp_video/engine_probe.py
@@ -87,7 +87,7 @@ def probe(path: str) -> VideoInfo:
     Results are cached by (path, mtime, size) so repeated calls on the
     same unmodified file skip the ffprobe subprocess.
     """
-    _validate_input_path(path)
+    path = _validate_input_path(path)
     key = _cache_key(path)
 
     cached = _probe_cache.get(key)

--- a/mcp_video/engine_resize.py
+++ b/mcp_video/engine_resize.py
@@ -19,7 +19,7 @@ def resize(
     output_path: str | None = None,
 ) -> EditResult:
     """Resize a video. Use aspect_ratio for preset sizes (e.g. '9:16')."""
-    _validate_input_path(input_path)
+    input_path = _validate_input_path(input_path)
 
     info = probe(input_path)
     if info.width == 0 or info.height == 0:

--- a/mcp_video/engine_reverse.py
+++ b/mcp_video/engine_reverse.py
@@ -25,7 +25,7 @@ def reverse(
         input_path: Path to the input video.
         output_path: Where to save the output. Auto-generated if omitted.
     """
-    _validate_input_path(input_path)
+    input_path = _validate_input_path(input_path)
     output = output_path or _auto_output(input_path, "reversed")
 
     input_info = probe(input_path)

--- a/mcp_video/engine_rotate.py
+++ b/mcp_video/engine_rotate.py
@@ -30,7 +30,7 @@ def rotate(
         flip_horizontal: Mirror horizontally.
         flip_vertical: Mirror vertically.
     """
-    _validate_input_path(input_path)
+    input_path = _validate_input_path(input_path)
 
     if angle not in (0, 90, 180, 270):
         raise MCPVideoError("angle must be 0, 90, 180, or 270", code="invalid_angle")

--- a/mcp_video/engine_speed.py
+++ b/mcp_video/engine_speed.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from .defaults import DEFAULT_AUDIO_BITRATE, DEFAULT_CRF, DEFAULT_PRESET
 from .ffmpeg_helpers import _validate_input_path
 from .engine_probe import probe
-from .engine_runtime_utils import _auto_output, _movflags_args, _run_ffmpeg, _timed_operation
+from .engine_runtime_utils import _auto_output, _movflags_args, _run_ffmpeg, _sanitize_ffmpeg_number, _timed_operation
 from .errors import MCPVideoError
 from .limits import MAX_SPEED_CHAIN_COUNT
 from .models import EditResult
@@ -17,7 +17,8 @@ def speed(
     output_path: str | None = None,
 ) -> EditResult:
     """Change playback speed. factor > 1 = faster, < 1 = slower."""
-    _validate_input_path(input_path)
+    input_path = _validate_input_path(input_path)
+    factor = _sanitize_ffmpeg_number(factor, "factor")
     if factor <= 0:
         raise MCPVideoError("Speed factor must be positive")
 

--- a/mcp_video/engine_split_screen.py
+++ b/mcp_video/engine_split_screen.py
@@ -30,8 +30,8 @@ def split_screen(
         layout: 'side-by-side' or 'top-bottom'.
         output_path: Where to save the output.
     """
-    _validate_input_path(left_path)
-    _validate_input_path(right_path)
+    left_path = _validate_input_path(left_path)
+    right_path = _validate_input_path(right_path)
     output = output_path or _auto_output(left_path, f"split_{layout}")
 
     left_info = probe(left_path)

--- a/mcp_video/engine_stabilize.py
+++ b/mcp_video/engine_stabilize.py
@@ -39,7 +39,7 @@ def stabilize(
         zooming: Zoom percentage to avoid black borders.
         output_path: Optional output video path.
     """
-    _validate_input_path(input_path)
+    input_path = _validate_input_path(input_path)
     _require_filter("vidstabdetect", "Video stabilization")
     output = output_path or _auto_output(input_path, "stabilized")
 

--- a/mcp_video/engine_storyboard.py
+++ b/mcp_video/engine_storyboard.py
@@ -18,7 +18,7 @@ def storyboard(
     frame_count: int = 8,
 ) -> StoryboardResult:
     """Extract key frames and create a storyboard grid for human review."""
-    _validate_input_path(input_path)
+    input_path = _validate_input_path(input_path)
     if frame_count < 1:
         raise MCPVideoError("frame_count must be at least 1", code="invalid_frame_count")
     dur = get_duration(input_path)

--- a/mcp_video/engine_subtitle_generate.py
+++ b/mcp_video/engine_subtitle_generate.py
@@ -23,7 +23,7 @@ def generate_subtitles(
     burn: bool = False,
 ) -> SubtitleResult:
     """Generate SRT subtitles from text entries and optionally burn into video."""
-    _validate_input_path(input_path)
+    input_path = _validate_input_path(input_path)
     _validate_entries(entries)
 
     srt_file = _write_srt(entries, input_path, output_path)

--- a/mcp_video/engine_subtitles.py
+++ b/mcp_video/engine_subtitles.py
@@ -22,8 +22,8 @@ def subtitles(
     style: str = "FontSize=22,PrimaryColour=&Hffffff&,OutlineColour=&H000000&,Outline=2,Shadow=1",
 ) -> EditResult:
     """Burn subtitles (SRT/VTT) into a video."""
-    _validate_input_path(input_path)
-    _validate_input_path(subtitle_path)
+    input_path = _validate_input_path(input_path)
+    subtitle_path = _validate_input_path(subtitle_path)
     _require_filter("subtitles", "Subtitle burn-in")
     output = output_path or _auto_output(input_path, "subtitled")
 

--- a/mcp_video/engine_text.py
+++ b/mcp_video/engine_text.py
@@ -37,7 +37,7 @@ def add_text(
     preset: str | None = None,
 ) -> EditResult:
     """Overlay text on a video."""
-    _validate_input_path(input_path)
+    input_path = _validate_input_path(input_path)
     _require_filter("drawtext", "Text overlay")
     if not text or not text.strip():
         raise MCPVideoError(

--- a/mcp_video/engine_thumbnail.py
+++ b/mcp_video/engine_thumbnail.py
@@ -14,7 +14,7 @@ def thumbnail(
     output_path: str | None = None,
 ) -> ThumbnailResult:
     """Extract a single frame from a video."""
-    _validate_input_path(input_path)
+    input_path = _validate_input_path(input_path)
 
     if timestamp is None:
         # Grab frame at 10% of video duration

--- a/mcp_video/engine_transcode.py
+++ b/mcp_video/engine_transcode.py
@@ -13,7 +13,7 @@ from .engine_runtime_utils import _auto_output, _movflags_args, _run_ffmpeg
 
 def normalize(input_path: str, output_path: str | None = None) -> str:
     """Normalize a video to H.264 video + AAC audio for reliable editing."""
-    _validate_input_path(input_path)
+    input_path = _validate_input_path(input_path)
     output = output_path or _auto_output(input_path, "normalized")
     _run_ffmpeg(
         [

--- a/mcp_video/engine_watermark.py
+++ b/mcp_video/engine_watermark.py
@@ -9,7 +9,6 @@ from .engine_runtime_utils import (
     _quality_args,
     _resolve_position,
     _run_ffmpeg,
-    _sanitize_ffmpeg_number,
     _timed_operation,
 )
 from .ffmpeg_helpers import _validate_input_path

--- a/mcp_video/engine_watermark.py
+++ b/mcp_video/engine_watermark.py
@@ -9,6 +9,7 @@ from .engine_runtime_utils import (
     _quality_args,
     _resolve_position,
     _run_ffmpeg,
+    _sanitize_ffmpeg_number,
     _timed_operation,
 )
 from .ffmpeg_helpers import _validate_input_path
@@ -26,8 +27,8 @@ def watermark(
     preset: str | None = None,
 ) -> EditResult:
     """Add an image watermark to a video."""
-    _validate_input_path(input_path)
-    _validate_input_path(image_path)
+    input_path = _validate_input_path(input_path)
+    image_path = _validate_input_path(image_path)
     output = output_path or _auto_output(input_path, "watermarked")
 
     # Position expressions for the overlay

--- a/mcp_video/quality_guardrails.py
+++ b/mcp_video/quality_guardrails.py
@@ -641,7 +641,7 @@ def quality_check(video: str, fail_on_warning: bool = False) -> dict[str, Any]:
     Returns:
         Quality report dictionary
     """
-    _validate_input_path(video)
+    video = _validate_input_path(video)
     guardrails = VisualQualityGuardrails()
     report = guardrails.generate_report(video)
 

--- a/mcp_video/server_tools_advanced.py
+++ b/mcp_video/server_tools_advanced.py
@@ -60,7 +60,7 @@ def video_filter(
             MCPVideoError(f"Invalid preset: {preset}", error_type="validation_error", code="invalid_parameter")
         )
     try:
-        _validate_input_path(input_path)
+        input_path = _validate_input_path(input_path)
         return _result(
             apply_filter(
                 input_path,
@@ -89,7 +89,7 @@ def video_reverse(
         output_path: Where to save the output. Auto-generated if omitted.
     """
     try:
-        _validate_input_path(input_path)
+        input_path = _validate_input_path(input_path)
         return _result(reverse(input_path, output_path=output_path))
     except MCPVideoError as e:
         return _error_result(e)
@@ -115,7 +115,7 @@ def video_chroma_key(
         output_path: Where to save the output. Auto-generated if omitted.
     """
     try:
-        _validate_input_path(input_path)
+        input_path = _validate_input_path(input_path)
         _validate_chroma_color(color)
     except MCPVideoError as e:
         return _error_result(e)
@@ -159,7 +159,7 @@ def video_blur(
         output_path: Where to save the output. Auto-generated if omitted.
     """
     try:
-        _validate_input_path(input_path)
+        input_path = _validate_input_path(input_path)
         return _result(
             apply_filter(
                 input_path,
@@ -188,7 +188,7 @@ def video_color_grade(
         output_path: Where to save the output. Auto-generated if omitted.
     """
     try:
-        _validate_input_path(input_path)
+        input_path = _validate_input_path(input_path)
         return _result(
             apply_filter(
                 input_path,
@@ -219,7 +219,7 @@ def video_normalize_audio(
         output_path: Where to save the output. Auto-generated if omitted.
     """
     try:
-        _validate_input_path(input_path)
+        input_path = _validate_input_path(input_path)
         if not -70 <= target_lufs <= -5:
             return _error_result(
                 MCPVideoError(
@@ -289,8 +289,8 @@ def video_overlay(
             MCPVideoError(f"Invalid preset: {preset}", error_type="validation_error", code="invalid_parameter")
         )
     try:
-        _validate_input_path(background_path)
-        _validate_input_path(overlay_path)
+        background_path = _validate_input_path(background_path)
+        overlay_path = _validate_input_path(overlay_path)
         if not 0 <= opacity <= 1:
             return _error_result(
                 MCPVideoError(
@@ -344,8 +344,8 @@ def video_split_screen(
             )
         )
     try:
-        _validate_input_path(left_path)
-        _validate_input_path(right_path)
+        left_path = _validate_input_path(left_path)
+        right_path = _validate_input_path(right_path)
         return _result(split_screen(left_path, right_path=right_path, layout=layout, output_path=output_path))
     except MCPVideoError as e:
         return _error_result(e)
@@ -367,7 +367,7 @@ def video_detect_scenes(
         min_scene_duration: Minimum scene duration in seconds (default 1.0).
     """
     try:
-        _validate_input_path(input_path)
+        input_path = _validate_input_path(input_path)
         if not 0 <= threshold <= 1:
             return _error_result(
                 MCPVideoError(
@@ -454,7 +454,7 @@ def video_export_frames(
             )
         )
     try:
-        _validate_input_path(input_path)
+        input_path = _validate_input_path(input_path)
         return _result(export_frames(input_path, output_dir=output_dir, fps=fps, format=format))
     except MCPVideoError as e:
         return _error_result(e)
@@ -484,7 +484,7 @@ def video_generate_subtitles(
             )
         )
     try:
-        _validate_input_path(input_path)
+        input_path = _validate_input_path(input_path)
         return _result(generate_subtitles(entries, input_path, burn=burn))
     except MCPVideoError as e:
         return _error_result(e)
@@ -506,8 +506,8 @@ def video_compare_quality(
         metrics: Metrics to compute (default: ['psnr', 'ssim']).
     """
     try:
-        _validate_input_path(original_path)
-        _validate_input_path(distorted_path)
+        original_path = _validate_input_path(original_path)
+        distorted_path = _validate_input_path(distorted_path)
         return _result(compare_quality(original_path, distorted_path, metrics=metrics))
     except MCPVideoError as e:
         return _error_result(e)
@@ -525,7 +525,7 @@ def video_read_metadata(
         input_path: Absolute path to the video or audio file.
     """
     try:
-        _validate_input_path(input_path)
+        input_path = _validate_input_path(input_path)
         return _result(read_metadata(input_path))
     except MCPVideoError as e:
         return _error_result(e)
@@ -547,7 +547,7 @@ def video_write_metadata(
         output_path: Where to save the output. Auto-generated if omitted.
     """
     try:
-        _validate_input_path(input_path)
+        input_path = _validate_input_path(input_path)
         return _result(write_metadata(input_path, metadata=metadata, output_path=output_path))
     except MCPVideoError as e:
         return _error_result(e)
@@ -571,7 +571,7 @@ def video_stabilize(
         output_path: Where to save the output. Auto-generated if omitted.
     """
     try:
-        _validate_input_path(input_path)
+        input_path = _validate_input_path(input_path)
         if smoothing < 0:
             return _error_result(
                 MCPVideoError(
@@ -611,8 +611,8 @@ def video_apply_mask(
         output_path: Where to save the output. Auto-generated if omitted.
     """
     try:
-        _validate_input_path(input_path)
-        _validate_input_path(mask_path)
+        input_path = _validate_input_path(input_path)
+        mask_path = _validate_input_path(mask_path)
         if feather < 0:
             return _error_result(
                 MCPVideoError(
@@ -640,7 +640,7 @@ def video_audio_waveform(
         bins: Number of time segments to analyze (default 50).
     """
     try:
-        _validate_input_path(input_path)
+        input_path = _validate_input_path(input_path)
         if bins < 1 or bins > 1000:
             return _error_result(
                 MCPVideoError(
@@ -721,7 +721,7 @@ def video_extract_frame(
         output_path: Where to save the frame image. Auto-generated if omitted.
     """
     try:
-        _validate_input_path(input_path)
+        input_path = _validate_input_path(input_path)
         return _result(thumbnail(input_path, timestamp=timestamp, output_path=output_path))
     except MCPVideoError as e:
         return _error_result(e)

--- a/mcp_video/server_tools_ai.py
+++ b/mcp_video/server_tools_ai.py
@@ -53,7 +53,7 @@ def video_ai_remove_silence(
             )
         )
     try:
-        _validate_input_path(input_path)
+        input_path = _validate_input_path(input_path)
         from .ai_engine import ai_remove_silence
 
         return _result(ai_remove_silence(input_path, output_path, silence_threshold, min_silence_duration, keep_margin))
@@ -80,7 +80,7 @@ def video_ai_transcribe(
             )
         )
     try:
-        _validate_input_path(input_path)
+        input_path = _validate_input_path(input_path)
         from .ai_engine import ai_transcribe
 
         return _result(ai_transcribe(input_path, output_srt, model, language))
@@ -151,7 +151,7 @@ def video_analyze(
         from .ai_engine.download import _is_url
 
         if not _is_url(input_path):
-            _validate_input_path(input_path)
+            input_path = _validate_input_path(input_path)
         from .ai_engine import analyze_video
 
         return analyze_video(
@@ -192,7 +192,7 @@ def video_ai_scene_detect(
             )
         )
     try:
-        _validate_input_path(input_path)
+        input_path = _validate_input_path(input_path)
         from .ai_engine import ai_scene_detect
 
         return _result(ai_scene_detect(input_path, threshold, use_ai))
@@ -227,7 +227,7 @@ def video_ai_stem_separation(
             )
         )
     try:
-        _validate_input_path(input_path)
+        input_path = _validate_input_path(input_path)
         from .ai_engine import ai_stem_separation
 
         return _result(ai_stem_separation(input_path, output_dir, stems, model))
@@ -262,7 +262,7 @@ def video_ai_upscale(
             )
         )
     try:
-        _validate_input_path(input_path)
+        input_path = _validate_input_path(input_path)
         from .ai_engine import ai_upscale
 
         return _result(ai_upscale(input_path, output_path, scale, model))
@@ -289,9 +289,9 @@ def video_ai_color_grade(
             )
         )
     try:
-        _validate_input_path(input_path)
+        input_path = _validate_input_path(input_path)
         if reference_path is not None:
-            _validate_input_path(reference_path)
+            reference_path = _validate_input_path(reference_path)
         from .ai_engine import ai_color_grade
 
         return _result(ai_color_grade(input_path, output_path, reference_path, style))
@@ -316,7 +316,7 @@ def video_quality_check(
         fail_on_warning: If True, treat warnings as failures
     """
     try:
-        _validate_input_path(input_path)
+        input_path = _validate_input_path(input_path)
         from .quality_guardrails import quality_check
 
         return _result(quality_check(input_path, fail_on_warning))
@@ -343,7 +343,7 @@ def video_design_quality_check(
         strict: If True, treat warnings as errors
     """
     try:
-        _validate_input_path(input_path)
+        input_path = _validate_input_path(input_path)
         from .design_quality import design_quality_check
 
         return _result(design_quality_check(input_path, auto_fix=auto_fix, strict=strict))
@@ -368,7 +368,7 @@ def video_fix_design_issues(
         output_path: Absolute path for output (auto-generated if omitted)
     """
     try:
-        _validate_input_path(input_path)
+        input_path = _validate_input_path(input_path)
         from .design_quality import fix_design_issues
 
         return _result(fix_design_issues(input_path, output_path))

--- a/mcp_video/server_tools_audio.py
+++ b/mcp_video/server_tools_audio.py
@@ -373,7 +373,7 @@ def audio_effects(
                 )
             )
     try:
-        _validate_input_path(input_path)
+        input_path = _validate_input_path(input_path)
         from .audio_engine import audio_effects as _effects
 
         return _result(_effects(input_path=input_path, output=output_path, effects=effects))
@@ -404,7 +404,7 @@ def video_add_generated_audio(
         Dict with success status and output_path.
     """
     try:
-        _validate_input_path(input_path)
+        input_path = _validate_input_path(input_path)
         if not isinstance(audio_config, dict) or not audio_config:
             raise MCPVideoError(
                 "audio_config must be a non-empty dict",
@@ -445,7 +445,7 @@ def video_audio_spatial(
             )
         )
     try:
-        _validate_input_path(input_path)
+        input_path = _validate_input_path(input_path)
         from .ai_engine import audio_spatial
 
         return _result(audio_spatial(input_path, output_path, positions, method))

--- a/mcp_video/server_tools_basic.py
+++ b/mcp_video/server_tools_basic.py
@@ -20,7 +20,7 @@ def video_info(input_path: str) -> dict[str, Any]:
         input_path: Absolute path to the video file.
     """
     try:
-        _validate_input_path(input_path)
+        input_path = _validate_input_path(input_path)
         info = probe(input_path)
         return {"success": True, "info": info.model_dump()}
     except MCPVideoError as e:
@@ -47,7 +47,7 @@ def video_trim(
         output_path: Where to save the trimmed video. Auto-generated if omitted.
     """
     try:
-        _validate_input_path(input_path)
+        input_path = _validate_input_path(input_path)
         return _result(trim(input_path, start=start, duration=duration, end=end, output_path=output_path))
     except MCPVideoError as e:
         return _error_result(e)
@@ -168,7 +168,7 @@ def video_add_text(
             MCPVideoError(f"Invalid preset: {preset}", error_type="validation_error", code="invalid_parameter")
         )
     try:
-        _validate_input_path(input_path)
+        input_path = _validate_input_path(input_path)
         if size < 8 or size > 500:
             return _error_result(
                 MCPVideoError(
@@ -223,8 +223,8 @@ def video_add_audio(
         output_path: Where to save the output. Auto-generated if omitted.
     """
     try:
-        _validate_input_path(video_path)
-        _validate_input_path(audio_path)
+        video_path = _validate_input_path(video_path)
+        audio_path = _validate_input_path(audio_path)
         if not 0 <= volume <= 2.0:
             return _error_result(
                 MCPVideoError(
@@ -319,7 +319,7 @@ def video_resize(
             )
         )
     try:
-        _validate_input_path(input_path)
+        input_path = _validate_input_path(input_path)
         return _result(
             resize(
                 input_path,
@@ -360,7 +360,7 @@ def video_convert(
             )
         )
     try:
-        _validate_input_path(input_path)
+        input_path = _validate_input_path(input_path)
         return _result(
             convert(
                 input_path,
@@ -397,7 +397,7 @@ def video_speed(
             )
         )
     try:
-        _validate_input_path(input_path)
+        input_path = _validate_input_path(input_path)
         return _result(speed(input_path, factor=factor, output_path=output_path))
     except MCPVideoError as e:
         return _error_result(e)

--- a/mcp_video/server_tools_effects.py
+++ b/mcp_video/server_tools_effects.py
@@ -39,7 +39,7 @@ def effect_vignette(
         Dict with success status and output_path.
     """
     try:
-        _validate_input_path(input_path)
+        input_path = _validate_input_path(input_path)
         if not (0.0 <= intensity <= 1.0):
             raise MCPVideoError(
                 f"intensity must be between 0.0 and 1.0, got {intensity}",
@@ -89,7 +89,7 @@ def effect_chromatic_aberration(
         Dict with success status and output_path.
     """
     try:
-        _validate_input_path(input_path)
+        input_path = _validate_input_path(input_path)
         if intensity < 0:
             raise MCPVideoError(
                 f"intensity must be non-negative, got {intensity}",
@@ -128,7 +128,7 @@ def effect_scanlines(
         Dict with success status and output_path.
     """
     try:
-        _validate_input_path(input_path)
+        input_path = _validate_input_path(input_path)
         if line_height < 1:
             raise MCPVideoError(
                 f"line_height must be at least 1, got {line_height}",
@@ -179,7 +179,7 @@ def effect_noise(
         Dict with success status and output_path.
     """
     try:
-        _validate_input_path(input_path)
+        input_path = _validate_input_path(input_path)
         if not (0.0 <= intensity <= 1.0):
             raise MCPVideoError(
                 f"intensity must be between 0.0 and 1.0, got {intensity}",
@@ -224,7 +224,7 @@ def effect_glow(
         Dict with success status and output_path.
     """
     try:
-        _validate_input_path(input_path)
+        input_path = _validate_input_path(input_path)
         if not (0.0 <= intensity <= 1.0):
             raise MCPVideoError(
                 f"intensity must be between 0.0 and 1.0, got {intensity}",
@@ -333,8 +333,8 @@ def video_layout_pip(
         Dict with success status and output_path.
     """
     try:
-        _validate_input_path(main_path)
-        _validate_input_path(pip_path)
+        main_path = _validate_input_path(main_path)
+        pip_path = _validate_input_path(pip_path)
         if not (0.0 < size <= 1.0):
             raise MCPVideoError(
                 f"size must be between 0.0 and 1.0, got {size}",
@@ -402,7 +402,7 @@ def video_text_animated(
         Dict with success status and output_path.
     """
     try:
-        _validate_input_path(input_path)
+        input_path = _validate_input_path(input_path)
         if not (8 <= size <= 500):
             raise MCPVideoError(
                 f"size must be between 8 and 500, got {size}",
@@ -460,8 +460,8 @@ def video_text_subtitles(
             )
         )
     try:
-        _validate_input_path(input_path)
-        _validate_input_path(subtitles_path)
+        input_path = _validate_input_path(input_path)
+        subtitles_path = _validate_input_path(subtitles_path)
         from .effects_engine import text_subtitles as _subs
 
         return _result(_subs(input_path, subtitles_path, output_path, style))
@@ -587,7 +587,7 @@ def video_info_detailed(
         Dict with duration, fps, resolution, bitrate, has_audio, scene_changes.
     """
     try:
-        _validate_input_path(input_path)
+        input_path = _validate_input_path(input_path)
         from .effects_engine import video_info_detailed as _info
 
         return _result(_info(input_path))
@@ -622,7 +622,7 @@ def video_auto_chapters(
             )
         )
     try:
-        _validate_input_path(input_path)
+        input_path = _validate_input_path(input_path)
         from .effects_engine import auto_chapters as _chapters
 
         return _result(_chapters(input_path, threshold))
@@ -671,8 +671,8 @@ def transition_glitch(
             )
         )
     try:
-        _validate_input_path(clip1_path)
-        _validate_input_path(clip2_path)
+        clip1_path = _validate_input_path(clip1_path)
+        clip2_path = _validate_input_path(clip2_path)
         from .transitions_engine import transition_glitch
 
         output = output_path or _auto_output(clip1_path, "transition")
@@ -709,8 +709,8 @@ def transition_pixelate(
             )
         )
     try:
-        _validate_input_path(clip1_path)
-        _validate_input_path(clip2_path)
+        clip1_path = _validate_input_path(clip1_path)
+        clip2_path = _validate_input_path(clip2_path)
         from .transitions_engine import transition_pixelate
 
         return _result(transition_pixelate(clip1_path, clip2_path, output_path, duration, pixel_size))
@@ -746,8 +746,8 @@ def transition_morph(
             )
         )
     try:
-        _validate_input_path(clip1_path)
-        _validate_input_path(clip2_path)
+        clip1_path = _validate_input_path(clip1_path)
+        clip2_path = _validate_input_path(clip2_path)
         from .transitions_engine import transition_morph
 
         return _result(transition_morph(clip1_path, clip2_path, output_path, duration, mesh_size))

--- a/mcp_video/server_tools_image.py
+++ b/mcp_video/server_tools_image.py
@@ -24,7 +24,7 @@ def image_extract_colors(
         n_colors: Number of dominant colors to extract (1-20, default 5).
     """
     try:
-        _validate_input_path(image_path)
+        image_path = _validate_input_path(image_path)
         from .image_engine import extract_colors
 
         return _result(extract_colors(image_path, n_colors=n_colors))
@@ -51,7 +51,7 @@ def image_generate_palette(
         n_colors: Number of dominant colors to base palette on (default 5).
     """
     try:
-        _validate_input_path(image_path)
+        image_path = _validate_input_path(image_path)
         from .image_engine import generate_palette
 
         return _result(generate_palette(image_path, harmony=harmony, n_colors=n_colors))
@@ -78,7 +78,7 @@ def image_analyze_product(
         n_colors: Number of dominant colors to extract (default 5).
     """
     try:
-        _validate_input_path(image_path)
+        image_path = _validate_input_path(image_path)
         from .image_engine import analyze_product
 
         return _result(analyze_product(image_path, use_ai=use_ai, n_colors=n_colors))

--- a/mcp_video/server_tools_media.py
+++ b/mcp_video/server_tools_media.py
@@ -38,7 +38,7 @@ def video_thumbnail(
         output_path: Where to save the frame image. Auto-generated if omitted.
     """
     try:
-        _validate_input_path(input_path)
+        input_path = _validate_input_path(input_path)
         return _result(thumbnail(input_path, timestamp=timestamp, output_path=output_path))
     except MCPVideoError as e:
         return _error_result(e)
@@ -60,7 +60,7 @@ def video_preview(
         scale_factor: Downscale factor (4 = 1/4 resolution).
     """
     try:
-        _validate_input_path(input_path)
+        input_path = _validate_input_path(input_path)
         MAX_SCALE_FACTOR = 16
         if scale_factor < 2:
             return _error_result(
@@ -99,7 +99,7 @@ def video_storyboard(
         frame_count: Number of key frames to extract.
     """
     try:
-        _validate_input_path(input_path)
+        input_path = _validate_input_path(input_path)
         MAX_FRAME_COUNT = 100
         if frame_count is not None and (frame_count < 1 or frame_count > MAX_FRAME_COUNT):
             return _error_result(
@@ -130,8 +130,8 @@ def video_subtitles(
         output_path: Where to save the output. Auto-generated if omitted.
     """
     try:
-        _validate_input_path(input_path)
-        _validate_input_path(subtitle_path)
+        input_path = _validate_input_path(input_path)
+        subtitle_path = _validate_input_path(subtitle_path)
         return _result(subtitles(input_path, subtitle_path=subtitle_path, output_path=output_path))
     except MCPVideoError as e:
         return _error_result(e)
@@ -187,8 +187,8 @@ def video_watermark(
             MCPVideoError(f"Invalid preset: {preset}", error_type="validation_error", code="invalid_parameter")
         )
     try:
-        _validate_input_path(input_path)
-        _validate_input_path(image_path)
+        input_path = _validate_input_path(input_path)
+        image_path = _validate_input_path(image_path)
         return _result(
             watermark(
                 input_path,
@@ -231,7 +231,7 @@ def video_export(
             )
         )
     try:
-        _validate_input_path(input_path)
+        input_path = _validate_input_path(input_path)
         return _result(
             export_video(
                 input_path,
@@ -266,7 +266,7 @@ def video_crop(
         output_path: Where to save the output. Auto-generated if omitted.
     """
     try:
-        _validate_input_path(input_path)
+        input_path = _validate_input_path(input_path)
         return _result(crop(input_path, width=width, height=height, x=x, y=y, output_path=output_path))
     except MCPVideoError as e:
         return _error_result(e)
@@ -292,7 +292,7 @@ def video_rotate(
         output_path: Where to save the output. Auto-generated if omitted.
     """
     try:
-        _validate_input_path(input_path)
+        input_path = _validate_input_path(input_path)
         return _result(
             rotate(
                 input_path,
@@ -336,7 +336,7 @@ def video_fade(
             MCPVideoError(f"Invalid preset: {preset}", error_type="validation_error", code="invalid_parameter")
         )
     try:
-        _validate_input_path(input_path)
+        input_path = _validate_input_path(input_path)
         if fade_in < 0:
             return _error_result(
                 MCPVideoError(
@@ -455,7 +455,7 @@ def video_extract_audio(
             )
         )
     try:
-        _validate_input_path(input_path)
+        input_path = _validate_input_path(input_path)
         result = extract_audio(input_path, output_path=output_path, format=format)
         if not os.path.isfile(result):
             return _error_result(

--- a/mcp_video/server_tools_remotion.py
+++ b/mcp_video/server_tools_remotion.py
@@ -90,7 +90,7 @@ def remotion_render(
             )
         )
     try:
-        _validate_input_path(project_path)
+        project_path = _validate_input_path(project_path)
         from .remotion_engine import render
 
         return _result(
@@ -125,7 +125,7 @@ def remotion_compositions(
         project_path: Absolute path to the Remotion project directory.
     """
     try:
-        _validate_input_path(project_path)
+        project_path = _validate_input_path(project_path)
         from .remotion_engine import compositions
 
         return _result(compositions(project_path))
@@ -155,7 +155,7 @@ def remotion_studio(
             )
         )
     try:
-        _validate_input_path(project_path)
+        project_path = _validate_input_path(project_path)
         from .remotion_engine import studio
 
         return _result(studio(project_path, port=port))
@@ -183,7 +183,7 @@ def remotion_still(
         image_format: Image format (png, jpeg, webp). Default png.
     """
     try:
-        _validate_input_path(project_path)
+        project_path = _validate_input_path(project_path)
         from .remotion_engine import still
 
         return _result(
@@ -252,7 +252,7 @@ def remotion_scaffold_template(
             )
         )
     try:
-        _validate_input_path(project_path)
+        project_path = _validate_input_path(project_path)
         from .remotion_engine import scaffold_template
 
         return _result(scaffold_template(project_path, spec, slug))
@@ -274,7 +274,7 @@ def remotion_validate(
         composition_id: Optional specific composition ID to validate.
     """
     try:
-        _validate_input_path(project_path)
+        project_path = _validate_input_path(project_path)
         from .remotion_engine import validate
 
         return _result(validate(project_path, composition_id=composition_id))
@@ -309,7 +309,7 @@ def remotion_to_mcpvideo(
             )
         )
     try:
-        _validate_input_path(project_path)
+        project_path = _validate_input_path(project_path)
         from .remotion_engine import render_and_post
 
         return _result(render_and_post(project_path, composition_id, post_process, output_path=output_path))

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -106,6 +106,52 @@ class TestMerge:
         # Probed output should be a valid video in the requested container
         assert info.duration > 0
 
+
+    def test_merge_persists_validated_multi_clip_paths(self, monkeypatch, tmp_path):
+        import types
+
+        import mcp_video.engine_merge as engine_merge
+
+        original_a = str(tmp_path / "a-link.mp4")
+        original_b = str(tmp_path / "b-link.mp4")
+        resolved_a = str(tmp_path / "a-real.mp4")
+        resolved_b = str(tmp_path / "b-real.mp4")
+        output = str(tmp_path / "merged.mp4")
+        seen_probe_paths = []
+
+        def fake_validate(path):
+            return {original_a: resolved_a, original_b: resolved_b}[path]
+
+        def fake_probe(path):
+            seen_probe_paths.append(path)
+            return types.SimpleNamespace(
+                duration=1.0,
+                resolution="320x240",
+                width=320,
+                height=240,
+                codec="h264",
+                size_mb=1.0,
+            )
+
+        def fake_run_ffmpeg(args):
+            concat_file = args[args.index("-i") + 1]
+            with open(concat_file, encoding="utf-8") as f:
+                concat_data = f.read()
+            assert resolved_a in concat_data
+            assert resolved_b in concat_data
+            assert original_a not in concat_data
+            assert original_b not in concat_data
+
+        monkeypatch.setattr(engine_merge, "_validate_input_path", fake_validate)
+        monkeypatch.setattr(engine_merge, "probe", fake_probe)
+        monkeypatch.setattr(engine_merge, "_run_ffmpeg", fake_run_ffmpeg)
+
+        result = engine_merge.merge([original_a, original_b], output_path=output)
+
+        assert result.output_path == output
+        assert seen_probe_paths[:2] == [resolved_a, resolved_b]
+
+
     def test_merge_no_clips_raises(self):
         with pytest.raises(InputFileError):
             merge([])


### PR DESCRIPTION
- All callers now use the resolved path returned by _validate_input_path() instead of discarding it (TOCTOU fix)
- Sanitize numeric parameters with _sanitize_ffmpeg_number() before interpolating into FFmpeg filter strings in:
  - engine_fade.py (fade_in, fade_out)
  - engine_speed.py (factor)
  - engine_frames.py (fps)
  - engine_watermark.py (opacity)
  - effects_engine/core.py (intensity, radius, line_height, opacity, flicker, threshold)

Fixes P0 #3-4 from edge-case audit.

## Why

<!-- Explain the user problem, bug, or maintenance risk this PR addresses. -->

## What changed

<!-- Keep this concrete and reviewable. -->

## Verification

<!-- Paste commands and outcomes. Prefer focused tests plus the relevant broader suite. -->

- [ ] `python3 -m pytest tests/ -x -q --tb=short`
- [ ] `python3 -c "import mcp_video"`
- [ ] `./scripts/git-professional-audit.sh`
- [ ] Other:

## Maintainer checklist

- [ ] Public MCP tool signatures are unchanged, or the compatibility impact is explained.
- [ ] New or changed FFmpeg filter strings escape user-controlled values with `_escape_ffmpeg_filter_value()`.
- [ ] Subprocess calls include a timeout and route FFmpeg failures through `ProcessingError`.
- [ ] New defaults live in `defaults.py`; validation constants live in `validation.py` or `limits.py`.
- [ ] No generated media, logs, caches, local research dumps, or build artifacts were committed.
- [ ] Documentation, README counts, or roadmap entries were updated when the public surface changed.
