### PR TITLE
security: AI engine hardening — OOM guards, silence validation, color…

### DIFF
--- a/mcp_video/ai_engine/color.py
+++ b/mcp_video/ai_engine/color.py
@@ -200,7 +200,7 @@ def _match_reference_colors(video: str, reference: str) -> dict:
             "green": green_adj,
             "blue": blue_adj,
         }
-    except (subprocess.SubprocessError, ValueError, OSError):
+    except (subprocess.SubprocessError, ProcessingError, ValueError, OSError):
         # Fall back to neutral params if analysis fails
         return {"contrast": 1.0, "saturation": 1.0, "gamma": 1.0, "red": 1.0, "green": 1.0, "blue": 1.0}
 

--- a/mcp_video/ai_engine/color.py
+++ b/mcp_video/ai_engine/color.py
@@ -63,6 +63,9 @@ def ai_color_grade(
 
     # If reference provided, analyze and adjust to match
     if reference:
+        from ..ffmpeg_helpers import _validate_input_path
+
+        _validate_input_path(reference)
         params = _match_reference_colors(video, reference)
 
     # Build FFmpeg filter chain
@@ -134,11 +137,13 @@ def _match_reference_colors(video: str, reference: str) -> dict:
 
     def extract_mean_color(video_path: str) -> dict:
         """Extract mean RGB values from video using signalstats filter."""
-        cmd = ["ffmpeg", "-i", video_path, "-vf", "signalstats=out=JSON:stat=tout+vrep+brng", "-f", "null", "-"]
+        cmd = ["ffmpeg", "-i", video_path, "-vf", "signalstats", "-f", "null", "-"]
         try:
             result = subprocess.run(cmd, capture_output=True, text=True, timeout=DEFAULT_FFMPEG_TIMEOUT)
         except subprocess.TimeoutExpired:
             raise ProcessingError("Operation timed out after 600 seconds") from None
+        if result.returncode != 0:
+            raise ProcessingError(" ".join(cmd), result.returncode, result.stderr)
 
         # Default values if extraction fails
         mean_rgb = {"r": 128, "g": 128, "b": 128}

--- a/mcp_video/ai_engine/silence.py
+++ b/mcp_video/ai_engine/silence.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from ..errors import InputFileError, MCPVideoError, ProcessingError
 from ..ffmpeg_helpers import _run_ffprobe_json
 from ..limits import DEFAULT_FFMPEG_TIMEOUT
+from ..engine_runtime_utils import _sanitize_ffmpeg_number
 
 logger = logging.getLogger(__name__)
 
@@ -31,6 +32,21 @@ def _detect_silence_regions(
     Returns:
         List of (start, end) tuples for silent regions.
     """
+    silence_threshold = _sanitize_ffmpeg_number(silence_threshold, "silence_threshold")
+    min_silence_duration = _sanitize_ffmpeg_number(min_silence_duration, "min_silence_duration")
+    if silence_threshold > 0:
+        raise MCPVideoError(
+            f"silence_threshold must be <= 0 dB, got {silence_threshold}",
+            error_type="validation_error",
+            code="invalid_parameter",
+        )
+    if min_silence_duration <= 0:
+        raise MCPVideoError(
+            f"min_silence_duration must be > 0, got {min_silence_duration}",
+            error_type="validation_error",
+            code="invalid_parameter",
+        )
+
     # Run silencedetect filter
     cmd = [
         "ffmpeg",
@@ -82,6 +98,13 @@ def _build_keep_segments(
     Returns:
         List of (start, end) tuples for segments to keep.
     """
+    keep_margin = _sanitize_ffmpeg_number(keep_margin, "keep_margin")
+    if keep_margin < 0:
+        raise MCPVideoError(
+            f"keep_margin must be >= 0, got {keep_margin}",
+            error_type="validation_error",
+            code="invalid_parameter",
+        )
     if not silence_regions:
         # No silence detected, keep entire video
         return [(0, video_duration)]

--- a/mcp_video/ai_engine/upscale.py
+++ b/mcp_video/ai_engine/upscale.py
@@ -293,7 +293,7 @@ def ai_upscale(
             scale=scale,
             model_path=None,  # Auto-download
             model=rrdb_net,
-            tile=0,  # No tiling - process whole image
+            tile=256,  # Process in 256x256 tiles to limit memory usage
             tile_pad=10,
             pre_pad=0,
             half=False,  # Use FP32

--- a/tests/test_ai_features.py
+++ b/tests/test_ai_features.py
@@ -540,6 +540,28 @@ class TestColorGrade:
                 assert os.path.exists(result), f"Output not created for style: {style}"
                 assert os.path.getsize(result) > 0, f"Output is empty for style: {style}"
 
+
+    def test_reference_color_analysis_failure_falls_back_to_neutral(self, monkeypatch):
+        """Reference matching should remain best-effort when FFmpeg analysis fails."""
+        import subprocess
+
+        from mcp_video.ai_engine.color import _match_reference_colors
+
+        def fake_run(cmd, capture_output, text, timeout):
+            return subprocess.CompletedProcess(cmd, 1, "", "signalstats unavailable")
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        assert _match_reference_colors("input.mp4", "reference.mp4") == {
+            "contrast": 1.0,
+            "saturation": 1.0,
+            "gamma": 1.0,
+            "red": 1.0,
+            "green": 1.0,
+            "blue": 1.0,
+        }
+
+
     @requires_ffmpeg
     def test_color_grade_with_reference(self):
         """Test color grading with reference video."""


### PR DESCRIPTION
… grade fixes

- upscale.py: Enable 256x256 tiling in RealESRGANer (was tile=0, causing full-frame OOM on 4K content)
- silence.py: Validate silence_threshold <= 0 dB, min_silence_duration > 0, keep_margin >= 0 with _sanitize_ffmpeg_number
- color.py: Validate reference path before _match_reference_colors; check FFmpeg returncode in extract_mean_color; fix signalstats filter syntax (removed invalid out=JSON parameter)

Fixes P0 #8, P1 #9, #16-17 from edge-case audit.

## Why

<!-- Explain the user problem, bug, or maintenance risk this PR addresses. -->

## What changed

<!-- Keep this concrete and reviewable. -->

## Verification

<!-- Paste commands and outcomes. Prefer focused tests plus the relevant broader suite. -->

- [ ] `python3 -m pytest tests/ -x -q --tb=short`
- [ ] `python3 -c "import mcp_video"`
- [ ] `./scripts/git-professional-audit.sh`
- [ ] Other:

## Maintainer checklist

- [ ] Public MCP tool signatures are unchanged, or the compatibility impact is explained.
- [ ] New or changed FFmpeg filter strings escape user-controlled values with `_escape_ffmpeg_filter_value()`.
- [ ] Subprocess calls include a timeout and route FFmpeg failures through `ProcessingError`.
- [ ] New defaults live in `defaults.py`; validation constants live in `validation.py` or `limits.py`.
- [ ] No generated media, logs, caches, local research dumps, or build artifacts were committed.
- [ ] Documentation, README counts, or roadmap entries were updated when the public surface changed.
