### PR TITLE
feat: client-side validation and return type annotations

### DIFF
--- a/mcp_video/client/audio.py
+++ b/mcp_video/client/audio.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from ..errors import MCPVideoError
+
 from typing import Literal
 
 from ..engine import (
@@ -99,6 +101,8 @@ class ClientAudioMixin:
         Returns:
             Path to generated WAV file
         """
+        if not sequence:
+            raise MCPVideoError("sequence cannot be empty", error_type="validation_error", code="empty_sequence")
         from ..audio_engine import audio_sequence
 
         return audio_sequence(sequence=sequence, output=output)

--- a/mcp_video/client/effects.py
+++ b/mcp_video/client/effects.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import ClassVar
 
+from ..errors import MCPVideoError
+
 
 class ClientEffectsMixin:
     """Effects operations mixin."""

--- a/mcp_video/client/effects.py
+++ b/mcp_video/client/effects.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from typing import ClassVar
 
-from ..errors import MCPVideoError
 
 
 class ClientEffectsMixin:

--- a/mcp_video/client/effects.py
+++ b/mcp_video/client/effects.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from typing import ClassVar
 
 
-
 class ClientEffectsMixin:
     """Effects operations mixin."""
 

--- a/mcp_video/client/media.py
+++ b/mcp_video/client/media.py
@@ -37,6 +37,7 @@ from ..engine import (
     watermark as _watermark,
     write_metadata as _write_metadata,
 )
+from ..errors import MCPVideoError
 from ..models import (
     EditResult,
     ImageSequenceResult,
@@ -80,6 +81,8 @@ class ClientMediaMixin:
                 the last type is repeated. Example: ["fade", "dissolve", "fade"].
             transition_duration: Duration of each transition in seconds.
         """
+        if not clips:
+            raise MCPVideoError("clips cannot be empty", error_type="validation_error", code="empty_clips")
         return _merge(clips, output_path=output, transitions=transitions, transition_duration=transition_duration)
 
     def add_text(
@@ -146,6 +149,10 @@ class ClientMediaMixin:
         output: str | None = None,
     ) -> EditResult:
         """Resize a video or change aspect ratio."""
+        if width is not None and width <= 0:
+            raise MCPVideoError("width must be > 0", error_type="validation_error", code="invalid_parameter")
+        if height is not None and height <= 0:
+            raise MCPVideoError("height must be > 0", error_type="validation_error", code="invalid_parameter")
         return _resize(
             video,
             width=width,
@@ -193,6 +200,8 @@ class ClientMediaMixin:
         output: str | None = None,
     ) -> EditResult:
         """Change playback speed."""
+        if factor <= 0:
+            raise MCPVideoError("factor must be > 0", error_type="validation_error", code="invalid_parameter")
         return _speed(video, factor=factor, output_path=output)
 
     def thumbnail(
@@ -482,6 +491,8 @@ class ClientMediaMixin:
         fps: float = 30.0,
     ) -> EditResult:
         """Create a video from a sequence of images."""
+        if not images:
+            raise MCPVideoError("images cannot be empty", error_type="validation_error", code="empty_images")
         return _create_from_images(images, output_path=output, fps=fps)
 
     def export_frames(

--- a/mcp_video/client/remotion.py
+++ b/mcp_video/client/remotion.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from ..errors import MCPVideoError
+
 
 class ClientRemotionMixin:
     """Remotion operations mixin."""
@@ -20,7 +22,7 @@ class ClientRemotionMixin:
         frames: str | None = None,
         props: dict | None = None,
         scale: float | None = None,
-    ):
+    ) -> dict:
         """Render a Remotion composition to video."""
         from ..remotion_engine import render
 
@@ -69,7 +71,7 @@ class ClientRemotionMixin:
         name: str,
         output_dir: str | None = None,
         template: str = "blank",
-    ) -> dict:  # already has dict, keeping
+    ) -> dict:
         """Scaffold a new Remotion project.
 
         Args:
@@ -80,6 +82,8 @@ class ClientRemotionMixin:
         Returns:
             dict with key "project_path" (str): absolute path to the new project
         """
+        if not name:
+            raise MCPVideoError("name cannot be empty", error_type="validation_error", code="empty_name")
         from ..remotion_engine import create_project
 
         return create_project(name, output_dir=output_dir, template=template)


### PR DESCRIPTION
## What changed

- `media.py`: reject empty `clips` in `merge()`, non-positive `width`/`height` in `resize()`, non-positive `factor` in `speed()`, and empty `images` in `create_from_images()`.
- `audio.py`: reject empty `sequence` in `audio_sequence()`.
- `remotion.py`: add missing return type annotation to `remotion_render()` and reject empty project names in `remotion_create_project()`.
- `client/effects.py`: lint/format cleanup only; no `text_animated()` validation is included in this PR.

## Deferred / not included

The earlier PR description overstated the scope. This PR does **not** add validation for `add_text()`, `audio_compose()`, or `text_animated()`; those should be handled in a separate focused branch if still desired.

Fixes P1 #18 (partial), P2 #19-20 from edge-case audit.

## Verification

- [x] `ruff check mcp_video/ tests/`
- [x] `ruff format --check mcp_video/`
- [x] `python3 -m pytest tests/ -x -q --tb=short`
- [x] `python3 -c "import mcp_video"`
- [ ] `./scripts/git-professional-audit.sh`

## Maintainer checklist

- [x] Public MCP tool signatures are unchanged, or the compatibility impact is explained.
- [x] New or changed FFmpeg filter strings escape user-controlled values with `_escape_ffmpeg_filter_value()`.
- [x] Subprocess calls include a timeout and route FFmpeg failures through `ProcessingError`.
- [x] New defaults live in `defaults.py`; validation constants live in `validation.py` or `limits.py`.
- [x] No generated media, logs, caches, local research dumps, or build artifacts were committed.
- [x] Documentation, README counts, or roadmap entries were updated when the public surface changed.
