### PR TITLE
Close top-priority audit validation gaps

### DIFF
--- a/docs/CURRENT_EDGE_CASE_AUDIT_2026-04-21.md
+++ b/docs/CURRENT_EDGE_CASE_AUDIT_2026-04-21.md
@@ -14,11 +14,10 @@ The prior P0 security pass was largely completed: output path validation now exi
 
 The remaining risks are now concentrated in a smaller set of areas:
 
-1. **Output-directory/write-surface gaps outside the main FFmpeg engines** — especially batch `output_dir` and Remotion project scaffolding.
-2. **Residual SSRF DNS rebinding gap** — URL safety check and fetch still use separate resolutions.
-3. **AI/resource bounds** — Whisper/Demucs/AI scene/upscale paths still need model/duration/disk-space/timeout guards beyond subprocess timeouts.
-4. **Client API validation/contract consistency** — several client mixins still forward invalid inputs or return raw `str`/`dict` values.
-5. **Subprocess architecture cleanup** — many subprocess calls now have timeouts, but duplicated direct handling remains.
+1. **Residual SSRF DNS rebinding gap** — URL safety check and fetch still use separate resolutions.
+2. **AI/resource bounds** — Whisper/Demucs/AI scene/upscale paths still need model/duration/disk-space/timeout guards beyond subprocess timeouts.
+3. **Client API contract consistency** — client-side empty-input validation has improved, but return-type consistency remains.
+4. **Subprocess architecture cleanup** — many subprocess calls now have timeouts, but duplicated direct handling remains.
 
 ---
 
@@ -28,17 +27,17 @@ The remaining risks are now concentrated in a smaller set of areas:
 
 | ID | Status | Finding | Evidence | Recommended fix |
 |---|---|---|---|---|
-| C-P0-1 | Open | `engine_batch.video_batch()` creates caller-provided `output_dir` without `_validate_output_path()` or canonical policy check. | `mcp_video/engine_batch.py:39-45` validates each input path, then calls `os.makedirs(output_dir, exist_ok=True)` directly. | Validate `output_dir` once before the loop, return/use the validated directory, and add regression tests for null bytes and unsafe paths. |
-| C-P0-2 | Open | Remotion project scaffolding writes arbitrary project files under caller-provided `output_dir` + `name` without output-path validation. | `mcp_video/remotion_engine.py:479-500` builds `project_dir = Path(output_dir) / name`, creates it, and writes `package.json`; `mcp_video/remotion_engine.py:647-659` writes generated composition files. | Add a Remotion-specific output/project path validator; reject null bytes, unsafe names, and unintended traversal before mkdir/write_text. |
+| C-P0-1 | Closed in follow-up branch | `engine_batch.video_batch()` previously created caller-provided `output_dir` without `_validate_output_path()` or canonical policy check. | Follow-up remediation validates `output_dir` before `os.makedirs()` and adds a null-byte regression test. | Keep regression coverage around batch output directories. |
+| C-P0-2 | Closed in follow-up branch | Remotion project scaffolding previously wrote project files under caller-provided `output_dir` + `name` without output-path validation. | Follow-up remediation validates `output_dir`, validates final `project_dir`, rejects unsafe project names, and adds engine-boundary tests. | Keep Remotion name/output validation in engine and server layers. |
 | C-P0-3 | Partial | SSRF protection still has a DNS rebinding gap: `_is_safe_url()` resolves/checks the host, but the actual `urlopen()` call can resolve again. | `_is_safe_url()` performs `socket.getaddrinfo()` at `mcp_video/ai_engine/download.py:30-53`; `_download_direct_url()` later calls `urllib.request.urlopen(req, timeout=120)` at `mcp_video/ai_engine/download.py:116-148`. | Fetch using the validated IP address with Host/SNI handling where possible, or re-check the connected peer address after connect before reading response bytes. |
 
 ### P1 / next reliability sprint
 
 | ID | Status | Finding | Evidence | Recommended fix |
 |---|---|---|---|---|
-| C-P1-1 | Open | Client `audio_compose()` still forwards empty `tracks` and non-positive `duration` to the engine. | `mcp_video/client/audio.py:110-134` imports and calls `audio_compose()` without local guards. | Add `tracks` non-empty and `duration > 0` validation with `MCPVideoError`; add client tests. |
-| C-P1-2 | Open | Client `add_text()` does not reject empty text before delegating to FFmpeg-backed engine. | `mcp_video/client/media.py:88-117` forwards `text` directly to `_add_text()`. | Add empty/whitespace text validation and tests. |
-| C-P1-3 | Open | Client `text_animated()` does not reject empty text. | `mcp_video/client/effects.py:154-170` forwards `text` directly to `effects_engine.text_animated()`. | Add empty/whitespace text validation and tests. |
+| C-P1-1 | Closed in follow-up branch | Client `audio_compose()` previously forwarded empty `tracks` and non-positive `duration` to the engine. | Follow-up remediation adds `tracks` and `duration > 0` validation with client tests. | Keep client-side validation aligned with engine semantics. |
+| C-P1-2 | Closed in follow-up branch | Client `add_text()` previously relied on deeper engine validation for empty text. | Follow-up remediation adds client-side empty/whitespace text validation before path/FFmpeg work. | Keep client validation fast and explicit. |
+| C-P1-3 | Closed in follow-up branch | Client `text_animated()` previously forwarded empty text to FFmpeg-backed implementation. | Follow-up remediation adds client-side empty/whitespace text validation with tests. | Keep client validation fast and explicit. |
 | C-P1-4 | Open | Demucs separation itself has no explicit timeout even though the preliminary FFmpeg extraction has one. | `mcp_video/ai_engine/stem.py:94-115` times out FFmpeg extraction, then calls `demucs.separate.main(demucs_args)` directly. | Execute Demucs through a timeout-capable subprocess or cancellable worker; surface timeout as `ProcessingError`. |
 | C-P1-5 | Open | Whisper model/duration/RAM guard remains incomplete. | `mcp_video/ai_engine/transcribe.py:94-102` loads arbitrary `model` and transcribes extracted audio without validating model name or bounding media duration. | Add allowlist/model validation, duration checks before extraction/transcription, and clearer dependency/resource errors. |
 | C-P1-6 | Open | AI scene detection still lacks AI-mode threshold validation and can extract many frames for long videos. | `mcp_video/ai_engine/scene.py:24-49` only routes standard mode through `_standard_scene_detect()`; AI mode proceeds without threshold validation. `mcp_video/ai_engine/scene.py:64-83` extracts frames every 0.5s until FFmpeg timeout. | Validate threshold before mode branching; add duration/frame-count cap or adaptive sampling. |
@@ -67,7 +66,7 @@ Legend:
 
 | Old # | Prior issue | Current status | Notes / evidence |
 |---:|---|---|---|
-| 1 | Arbitrary file overwrite via unvalidated `output_path` | Partial | `_validate_output_path()` exists and is widely called (`mcp_video/ffmpeg_helpers.py:36-54`; many engine call sites), but batch/remotion write surfaces remain open as C-P0-1/C-P0-2. |
+| 1 | Arbitrary file overwrite via unvalidated `output_path` | Mostly closed | `_validate_output_path()` exists and is widely called (`mcp_video/ffmpeg_helpers.py:36-54`; many engine call sites). Follow-up remediation closes the known batch/remotion write-surface gaps. |
 | 2 | Arbitrary file writes in AI engine | Mostly closed | AI/transcribe/stem/audio output paths now call `_validate_output_path()` in observed write paths (`mcp_video/ai_engine/transcribe.py:105-108`, `mcp_video/ai_engine/stem.py:69-72`, `mcp_video/audio_engine/core.py:299-300`). Remotion project writes remain separate C-P0-2. |
 | 3 | Unescaped numeric values in FFmpeg filter strings | Mostly closed | Current code uses `_sanitize_ffmpeg_number()` and/or `_escape_ffmpeg_filter_value()` in affected engine paths, e.g. `mcp_video/effects_engine/core.py:37-40`, `mcp_video/engine_fade.py:29-35`, `mcp_video/engine_timeline.py:189-228`. Keep future regression tests. |
 | 4 | `_validate_input_path` resolved path discarded | Mostly closed | Many core engine paths now assign returned values, e.g. merge `mcp_video/engine_merge.py:45-66`, audio ops `mcp_video/engine_audio_ops.py:29-30`. Some server helpers still validate list members without assignment; lower risk if engines revalidate. |
@@ -86,7 +85,7 @@ Legend:
 | 17 | ai_color_grade missing reference/FFmpeg errors | Closed | Reference path is validated (`mcp_video/ai_engine/color.py:65-69`) and reference analysis catches `ProcessingError` for neutral fallback (`mcp_video/ai_engine/color.py:203-205`). |
 | 18 | Inconsistent client mixin return types | Open | See C-P2-4. |
 | 19 | Missing client-side bounds/enum validation | Partial | Some media/remotion validations were added; remaining client gaps are C-P1-1 through C-P1-3. |
-| 20 | Empty list/string client edge cases | Partial | `merge([])` and `audio_sequence([])` are handled (`mcp_video/client/media.py:84-86`, `mcp_video/client/audio.py:104-108`), but text/audio_compose gaps remain. |
+| 20 | Empty list/string client edge cases | Mostly closed | `merge([])`, `audio_sequence([])`, `add_text("")`, `text_animated("")`, and invalid `audio_compose()` inputs are covered after follow-up remediation. |
 | 21 | Demucs runs without timeout | Open | See C-P1-4. |
 | 22 | Whisper model/RAM guard | Open | See C-P1-5. |
 | 23 | AI scene threshold validation | Open | See C-P1-6. |
@@ -95,7 +94,7 @@ Legend:
 | 26 | Dead `_validate_input` | Closed | No `def _validate_input` remains in `mcp_video/engine_runtime_utils.py`. |
 | 27 | Hardcoded timeout messages | Mostly closed | `"600 seconds"` no longer appears in `mcp_video`; remaining hardcoded timeout literals in non-FFmpeg contexts should be separately reviewed. |
 | 28 | Concat demuxer path escaping | Partial | Merge path uses escaping; AI spatial/silence concat behavior needs targeted tests. |
-| 29 | Unvalidated batch `output_dir` | Open | See C-P0-1. |
+| 29 | Unvalidated batch `output_dir` | Closed in follow-up branch | See C-P0-1. |
 | 30 | Lazy imports return generic optional-dep errors | Open | See C-P2-5. |
 | 31 | Missing remotion return type annotations | Mostly closed | `remotion_render()` and `remotion_to_mcpvideo()` now annotate `-> dict`; exact result type remains broad (`mcp_video/client/remotion.py:11-25`, `mcp_video/client/remotion.py:117-139`). |
 | 32 | Lazy imports in client effects/audio | Open | Still present in `mcp_video/client/audio.py` and `mcp_video/client/effects.py`; classify as low-risk style debt. |
@@ -115,15 +114,15 @@ Legend:
 
 ## Recommended next implementation bundle
 
-Smallest high-value bundle:
-
-1. Validate `engine_batch.output_dir` and Remotion project output paths.
-2. Add client validation for `add_text`, `text_animated`, and `audio_compose`.
-3. Add regression tests for those five cases.
-
-Second bundle:
+Next high-value bundle after this follow-up branch:
 
 1. Fix SSRF DNS rebinding gap in direct URL download.
 2. Add Whisper/Demucs/AI-scene resource guards.
 3. Add targeted tests around optional dependency and resource-bound behavior.
+
+Subsequent cleanup bundle:
+
+1. Standardize client return contracts or document intentional exceptions.
+2. Gradually route direct FFmpeg/ffprobe subprocess handling through canonical helpers.
+3. Re-audit AI upscaling disk/temp-frame resource guards.
 

--- a/mcp_video/client/audio.py
+++ b/mcp_video/client/audio.py
@@ -129,6 +129,10 @@ class ClientAudioMixin:
         Returns:
             Path to generated WAV file
         """
+        if not tracks:
+            raise MCPVideoError("tracks cannot be empty", error_type="validation_error", code="empty_tracks")
+        if duration <= 0:
+            raise MCPVideoError("duration must be > 0", error_type="validation_error", code="invalid_parameter")
         from ..audio_engine import audio_compose
 
         return audio_compose(tracks=tracks, duration=duration, output=output)

--- a/mcp_video/client/effects.py
+++ b/mcp_video/client/effects.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import ClassVar
 
+from ..errors import MCPVideoError
+
 
 class ClientEffectsMixin:
     """Effects operations mixin."""
@@ -165,6 +167,8 @@ class ClientEffectsMixin:
         duration: float = 3.0,
     ) -> str:
         """Add animated text to video."""
+        if not text or not text.strip():
+            raise MCPVideoError("Text cannot be empty", error_type="validation_error", code="invalid_parameter")
         from ..effects_engine import text_animated
 
         return text_animated(video, text, output, animation, font, size, color, position, start, duration)

--- a/mcp_video/client/media.py
+++ b/mcp_video/client/media.py
@@ -101,6 +101,8 @@ class ClientMediaMixin:
         preset: str | None = None,
     ) -> EditResult:
         """Overlay text on a video."""
+        if not text or not text.strip():
+            raise MCPVideoError("Text cannot be empty", error_type="validation_error", code="invalid_parameter")
         return _add_text(
             video,
             text=text,

--- a/mcp_video/engine_batch.py
+++ b/mcp_video/engine_batch.py
@@ -14,7 +14,7 @@ from .engine_filters import apply_filter
 from .engine_resize import resize
 from .engine_speed import speed
 from .engine_watermark import watermark
-from .ffmpeg_helpers import _validate_input_path
+from .ffmpeg_helpers import _validate_input_path, _validate_output_path
 from .models import EditResult
 
 
@@ -32,6 +32,9 @@ def video_batch(
         }
 
     params = params or {}
+    if output_dir:
+        output_dir = _validate_output_path(output_dir)
+
     results = []
     succeeded = 0
     failed = 0
@@ -41,7 +44,6 @@ def video_batch(
             input_path = _validate_input_path(input_path)
             if output_dir:
                 os.makedirs(output_dir, exist_ok=True)
-
             result = _run_batch_operation(input_path, operation, params, output_dir)
             if result is None:
                 results.append({"input": input_path, "success": False, "error": f"Unknown operation: {operation}"})

--- a/mcp_video/remotion_engine.py
+++ b/mcp_video/remotion_engine.py
@@ -24,6 +24,7 @@ from .errors import (
     RemotionProjectError,
     RemotionRenderError,
 )
+from .ffmpeg_helpers import _validate_output_path
 from .remotion_models import (
     CompositionInfo,
     CompositionsResult,
@@ -40,6 +41,16 @@ from .remotion_models import (
 # ---------------------------------------------------------------------------
 # Private helpers
 # ---------------------------------------------------------------------------
+
+
+def _validate_project_name(name: str) -> str:
+    if not re.fullmatch(r"[a-zA-Z0-9_-]+", name):
+        raise MCPVideoError(
+            "Invalid name: must match ^[a-zA-Z0-9_-]+$",
+            error_type="validation_error",
+            code="invalid_parameter",
+        )
+    return name
 
 
 def _require_remotion_deps() -> None:
@@ -482,11 +493,14 @@ def create_project(
     template: str = "blank",
 ) -> RemotionProjectResult:
     """Scaffold a new Remotion project."""
-    _require_remotion_deps()
-
+    name = _validate_project_name(name)
     if output_dir is None:
         output_dir = os.getcwd()
+    output_dir = _validate_output_path(output_dir)
     project_dir = Path(output_dir) / name
+    _validate_output_path(str(project_dir))
+
+    _require_remotion_deps()
 
     if project_dir.exists() and any(project_dir.iterdir()):
         print(f"Warning: Project directory already exists and is not empty — files will be overwritten: {project_dir}")

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -77,6 +77,10 @@ class TestClientMerge:
 
 
 class TestClientAddText:
+    def test_add_text_rejects_empty_text(self, editor):
+        with pytest.raises(MCPVideoError, match=r"[Tt]ext"):
+            editor.add_text("/tmp/nonexistent.mp4", text="   ")
+
     @requires_filter("drawtext", "Text overlay")
     def test_add_text_returns_edit_result(self, editor, sample_video):
         result = editor.add_text(sample_video, text="Hello")
@@ -373,3 +377,19 @@ class TestClientValidators:
                 with pytest.raises(Exception) as exc_info:
                     editor.convert("/nonexistent/video.mp4", format=fmt, quality=q)
                 assert not isinstance(exc_info.value, ValueError)
+
+
+class TestClientAudioComposeValidation:
+    def test_audio_compose_rejects_empty_tracks(self, editor):
+        with pytest.raises(MCPVideoError, match="tracks"):
+            editor.audio_compose([], duration=1.0, output="/tmp/out.wav")
+
+    def test_audio_compose_rejects_non_positive_duration(self, editor):
+        with pytest.raises(MCPVideoError, match="duration"):
+            editor.audio_compose([{"file": "/tmp/a.wav"}], duration=0, output="/tmp/out.wav")
+
+
+class TestClientTextAnimatedValidation:
+    def test_text_animated_rejects_empty_text(self, editor):
+        with pytest.raises(MCPVideoError, match=r"[Tt]ext"):
+            editor.text_animated("/tmp/video.mp4", "", "/tmp/out.mp4")

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -478,3 +478,30 @@ class TestGifQualityScaling:
         assert high.success is True
         if low.size_mb and high.size_mb:
             assert low.size_mb <= high.size_mb
+
+
+class TestBatchOutputDirValidation:
+
+    def test_batch_output_dir_file_path_returns_structured_failures(self, sample_video, tmp_path):
+        from mcp_video.engine import video_batch
+
+        output_file = tmp_path / "not_a_dir"
+        output_file.write_text("not a directory")
+
+        result = video_batch(
+            [sample_video],
+            operation="trim",
+            params={"start": "0", "duration": "1"},
+            output_dir=str(output_file),
+        )
+
+        assert result["success"] is False
+        assert result["failed"] == 1
+        assert result["results"][0]["success"] is False
+
+
+    def test_batch_rejects_invalid_output_dir(self, sample_video):
+        from mcp_video.engine import video_batch
+
+        with pytest.raises(MCPVideoError, match="Output path contains null bytes"):
+            video_batch([sample_video], operation="trim", params={"start": "0", "duration": "1"}, output_dir="bad\x00dir")

--- a/tests/test_remotion_engine.py
+++ b/tests/test_remotion_engine.py
@@ -526,6 +526,23 @@ class TestStill:
 class TestCreateProject:
     """Tests for create_project()."""
 
+
+    def test_rejects_invalid_project_name_at_engine_boundary(self, tmp_path):
+        with (
+            _mock_deps_ok(),
+            patch("mcp_video.remotion_engine.subprocess.run", return_value=_make_completed_process()),
+            pytest.raises(MCPVideoError, match="Invalid name"),
+        ):
+            create_project("../escape", output_dir=str(tmp_path))
+
+    def test_rejects_invalid_output_dir_at_engine_boundary(self):
+        with (
+            _mock_deps_ok(),
+            patch("mcp_video.remotion_engine.subprocess.run", return_value=_make_completed_process()),
+            pytest.raises(MCPVideoError, match="Output path contains null bytes"),
+        ):
+            create_project("safe-name", output_dir="bad\x00dir")
+
     def test_creates_directory_structure(self, tmp_path):
         """create_project() should create the expected directory structure."""
         with _mock_deps_ok(), patch("mcp_video.remotion_engine.subprocess.run") as mock_run:


### PR DESCRIPTION
## What changed

Closes the next top-priority items from `docs/CURRENT_EDGE_CASE_AUDIT_2026-04-21.md`:

- Validate `engine_batch.video_batch(output_dir=...)` before creating directories.
- Validate Remotion project names and output/project paths at the engine boundary before scaffold writes.
- Add client-side validation for:
  - `Client.add_text(text="")`
  - `Client.text_animated(text="")`
  - `Client.audio_compose(tracks=[], duration<=0)`
- Update the current audit document to mark those follow-up items as closed and move SSRF/resource/contract cleanup into the next bundle.

## Why

The current audit showed two remaining write-surface gaps and three deferred client validation gaps after the previous security PR stack. This keeps invalid inputs from reaching filesystem writes or expensive FFmpeg/audio paths and keeps the audit artifact current.

## Verification

- `pytest tests/test_client.py tests/test_remotion_engine.py::TestCreateProject tests/test_engine.py::TestBatchOutputDirValidation tests/test_server.py::TestVideoBatchTool -q --tb=short` — 70 passed
- `ruff check mcp_video/ tests/`
- `ruff format --check mcp_video/`
- `python3 -m pytest tests/ -x -q --tb=short && python3 -c "import mcp_video"` — 796 passed, 9 skipped, 2 xpassed
