### PR TITLE
Guard AI scene and spatial edge cases

### DIFF
--- a/docs/CURRENT_EDGE_CASE_AUDIT_2026-04-21.md
+++ b/docs/CURRENT_EDGE_CASE_AUDIT_2026-04-21.md
@@ -15,7 +15,7 @@ The prior P0 security pass was largely completed: output path validation now exi
 The remaining risks are now concentrated in a smaller set of areas:
 
 1. **Residual SSRF DNS rebinding gap** — URL safety check and fetch still use separate resolutions.
-2. **AI/resource bounds** — Whisper/Demucs/AI scene/upscale paths still need model/duration/disk-space/timeout guards beyond subprocess timeouts.
+2. **AI/resource bounds** — Whisper/Demucs/upscale paths still need model/duration/disk-space/timeout guards beyond subprocess timeouts.
 3. **Client API contract consistency** — client-side empty-input validation has improved, but return-type consistency remains.
 4. **Subprocess architecture cleanup** — many subprocess calls now have timeouts, but duplicated direct handling remains.
 
@@ -40,8 +40,8 @@ The remaining risks are now concentrated in a smaller set of areas:
 | C-P1-3 | Closed in follow-up branch | Client `text_animated()` previously forwarded empty text to FFmpeg-backed implementation. | Follow-up remediation adds client-side empty/whitespace text validation with tests. | Keep client validation fast and explicit. |
 | C-P1-4 | Open | Demucs separation itself has no explicit timeout even though the preliminary FFmpeg extraction has one. | `mcp_video/ai_engine/stem.py:94-115` times out FFmpeg extraction, then calls `demucs.separate.main(demucs_args)` directly. | Execute Demucs through a timeout-capable subprocess or cancellable worker; surface timeout as `ProcessingError`. |
 | C-P1-5 | Open | Whisper model/duration/RAM guard remains incomplete. | `mcp_video/ai_engine/transcribe.py:94-102` loads arbitrary `model` and transcribes extracted audio without validating model name or bounding media duration. | Add allowlist/model validation, duration checks before extraction/transcription, and clearer dependency/resource errors. |
-| C-P1-6 | Open | AI scene detection still lacks AI-mode threshold validation and can extract many frames for long videos. | `mcp_video/ai_engine/scene.py:24-49` only routes standard mode through `_standard_scene_detect()`; AI mode proceeds without threshold validation. `mcp_video/ai_engine/scene.py:64-83` extracts frames every 0.5s until FFmpeg timeout. | Validate threshold before mode branching; add duration/frame-count cap or adaptive sampling. |
-| C-P1-7 | Open | Spatial audio simple path can crash on empty positions and gives unclear behavior for missing audio. | `mcp_video/ai_engine/spatial.py:159-166` sorts positions then indexes `sorted_positions[-1]` in the fallback path. | Reject empty `positions` before processing; probe/validate audio stream before pan/concat workflow. |
+| C-P1-6 | Closed in follow-up branch | AI scene detection previously lacked AI-mode threshold validation and could extract unbounded frames for long videos. | Follow-up remediation validates threshold before mode branching, enforces the global video-duration limit, and caps AI frame extraction with `MAX_AI_SCENE_FRAMES`. | Keep threshold and frame-cap regression tests. |
+| C-P1-7 | Closed in follow-up branch | Spatial audio simple path previously had unclear no-audio behavior and a private empty-position crash path. | Follow-up remediation validates audio streams before pan filters and rejects empty positions inside `_apply_simple_spatial()`. | Keep no-audio and empty-position regression tests. |
 
 ### P2 / robustness and cleanup
 
@@ -88,7 +88,7 @@ Legend:
 | 20 | Empty list/string client edge cases | Mostly closed | `merge([])`, `audio_sequence([])`, `add_text("")`, `text_animated("")`, and invalid `audio_compose()` inputs are covered after follow-up remediation. |
 | 21 | Demucs runs without timeout | Open | See C-P1-4. |
 | 22 | Whisper model/RAM guard | Open | See C-P1-5. |
-| 23 | AI scene threshold validation | Open | See C-P1-6. |
+| 23 | AI scene threshold validation | Closed in follow-up branch | See C-P1-6. |
 | 24 | `_generate_thumbnail_base64` missing input validation | Closed | Thumbnail helper validates and uses named timeout (`mcp_video/engine_runtime_utils.py:439-463`). |
 | 25 | Hardcoded thumbnail timeout | Closed | `DOCTOR_COMMAND_TIMEOUT` is used for thumbnail probe generation (`mcp_video/engine_runtime_utils.py:26`, `mcp_video/engine_runtime_utils.py:463`). |
 | 26 | Dead `_validate_input` | Closed | No `def _validate_input` remains in `mcp_video/engine_runtime_utils.py`. |
@@ -105,10 +105,10 @@ Legend:
 | 37 | `_sanitize_params` over-sanitizes future string params | Open | Current `engine_filters.py` still sanitizes every key except `preset`; future string params would fail. |
 | 38 | Duplicated subprocess handling | Open | See C-P2-1. |
 | 39 | Subprocess.Popen policy violation | Partial | `engine_runtime_utils.py` uses `Popen` with `wait(timeout=...)`; `remotion_engine.py` still uses `Popen`. See C-P2-3. |
-| 40 | AI scene temp bloat | Open | See C-P1-6. |
+| 40 | AI scene temp bloat | Closed in follow-up branch | See C-P1-6. |
 | 41 | AI upscale disk-space guard | Open | Needs targeted check for temp-frame path. |
-| 42 | Spatial no-audio check | Open | See C-P1-7. |
-| 43 | Spatial empty positions crash | Open | See C-P1-7. |
+| 42 | Spatial no-audio check | Closed in follow-up branch | See C-P1-7. |
+| 43 | Spatial empty positions crash | Closed in follow-up branch | See C-P1-7. |
 
 ---
 
@@ -117,7 +117,7 @@ Legend:
 Next high-value bundle after this follow-up branch:
 
 1. Fix SSRF DNS rebinding gap in direct URL download.
-2. Add Whisper/Demucs/AI-scene resource guards.
+2. Add Whisper/Demucs/upscale resource guards.
 3. Add targeted tests around optional dependency and resource-bound behavior.
 
 Subsequent cleanup bundle:

--- a/mcp_video/ai_engine/scene.py
+++ b/mcp_video/ai_engine/scene.py
@@ -13,12 +13,29 @@ import subprocess
 import tempfile
 from pathlib import Path
 
-from ..errors import InputFileError, ProcessingError
+from ..errors import InputFileError, MCPVideoError, ProcessingError
 from ..ffmpeg_helpers import _run_ffprobe_json
-from ..limits import DEFAULT_FFMPEG_TIMEOUT
+from ..limits import DEFAULT_FFMPEG_TIMEOUT, MAX_AI_SCENE_FRAMES, MAX_VIDEO_DURATION
 from .spatial import _standard_scene_detect
 
 logger = logging.getLogger(__name__)
+
+
+def _validate_scene_threshold(threshold: float) -> float:
+    if not isinstance(threshold, (int, float)) or not (0.0 <= threshold <= 1.0):
+        raise MCPVideoError(
+            f"threshold must be between 0.0 and 1.0, got {threshold}",
+            error_type="validation_error",
+            code="invalid_parameter",
+        )
+    return float(threshold)
+
+
+def _parse_duration(value: object) -> float:
+    try:
+        return float(value or 0)
+    except (TypeError, ValueError):
+        return 0.0
 
 
 def ai_scene_detect(
@@ -36,6 +53,7 @@ def ai_scene_detect(
     Returns:
         List of scene changes with timestamps and frame numbers
     """
+    threshold = _validate_scene_threshold(threshold)
     if not use_ai:
         # Standard FFmpeg scene detection
         return _standard_scene_detect(video, threshold)
@@ -56,13 +74,19 @@ def ai_scene_detect(
 
     # Step 1: Get video duration and frame rate
     info = _run_ffprobe_json(str(video_path))
-    duration = float(info.get("format", {}).get("duration", 0))
+    duration = _parse_duration(info.get("format", {}).get("duration", 0))
 
     if duration == 0:
         return []
+    if duration > MAX_VIDEO_DURATION:
+        raise MCPVideoError(
+            f"Video duration ({duration:.0f}s) exceeds maximum of {MAX_VIDEO_DURATION}s",
+            error_type="validation_error",
+            code="duration_too_long",
+        )
 
-    # Step 2: Extract frames at regular intervals (every 0.5 seconds)
-    frame_interval = 0.5  # seconds
+    # Step 2: Extract frames at a bounded interval.
+    frame_interval = max(0.5, duration / MAX_AI_SCENE_FRAMES)
     scenes = []
 
     with tempfile.TemporaryDirectory() as tmpdir:

--- a/mcp_video/ai_engine/spatial.py
+++ b/mcp_video/ai_engine/spatial.py
@@ -16,10 +16,21 @@ import tempfile
 from pathlib import Path
 
 from ..errors import InputFileError, MCPVideoError, ProcessingError
-from ..ffmpeg_helpers import _get_video_duration, _validate_output_path
+from ..ffmpeg_helpers import _get_video_duration, _run_ffprobe_json, _validate_output_path
 from ..limits import DEFAULT_FFMPEG_TIMEOUT
+from ..engine_runtime_utils import _get_audio_stream
 
 logger = logging.getLogger(__name__)
+
+
+def _require_audio_stream(video: str) -> None:
+    data = _run_ffprobe_json(video)
+    if _get_audio_stream(data) is None:
+        raise MCPVideoError(
+            "Input video must contain an audio stream for spatial audio",
+            error_type="validation_error",
+            code="missing_audio_stream",
+        )
 
 
 def _standard_scene_detect(video: str, threshold: float) -> list[dict]:
@@ -90,6 +101,8 @@ def audio_spatial(
     if not positions:
         raise MCPVideoError("At least one position must be provided", error_type="validation_error")
 
+    _require_audio_stream(str(video_path))
+
     # Validate method
     valid_methods = ("hrtf", "vbap", "simple")
     if method not in valid_methods:
@@ -156,6 +169,9 @@ def _apply_simple_spatial(
     Returns:
         Path to output video
     """
+    if not positions:
+        raise MCPVideoError("At least one position must be provided", error_type="validation_error")
+
     # Sort positions by time
     sorted_positions = sorted(positions, key=lambda p: p.get("time", 0))
 

--- a/mcp_video/limits.py
+++ b/mcp_video/limits.py
@@ -11,6 +11,7 @@ DOCTOR_COMMAND_TIMEOUT = 10  # Short version/probe commands should not hang
 FFPROBE_TIMEOUT = 30  # Metadata probes should fail quickly
 MAX_BATCH_SIZE = 50
 MAX_EXPORT_FRAMES_FPS = 60
+MAX_AI_SCENE_FRAMES = 600
 
 # Audio limits
 MAX_AUDIO_DURATION = 3600  # 1 hour

--- a/tests/test_ai_features.py
+++ b/tests/test_ai_features.py
@@ -465,6 +465,91 @@ def test_ai_scene_detect_missing_file_does_not_create_parent_dir(tmp_path, monke
     assert not missing_video.parent.exists()
 
 
+
+
+def test_ai_scene_detect_ai_mode_rejects_invalid_threshold(sample_video, monkeypatch):
+    """AI mode should validate threshold before doing expensive frame extraction."""
+    from mcp_video.ai_engine import ai_scene_detect
+
+    imagehash_module = types.ModuleType("imagehash")
+    image_module = types.ModuleType("PIL.Image")
+    pil_module = types.ModuleType("PIL")
+    pil_module.Image = image_module
+    monkeypatch.setitem(sys.modules, "imagehash", imagehash_module)
+    monkeypatch.setitem(sys.modules, "PIL", pil_module)
+    monkeypatch.setitem(sys.modules, "PIL.Image", image_module)
+
+    with pytest.raises(MCPVideoError, match="threshold"):
+        ai_scene_detect(sample_video, threshold=5.0, use_ai=True)
+
+
+def test_ai_scene_detect_caps_ai_frame_extraction_rate(tmp_path, monkeypatch):
+    """Long AI scene scans should increase frame interval instead of extracting unbounded frames."""
+    from mcp_video.ai_engine import ai_scene_detect
+    from mcp_video.limits import MAX_AI_SCENE_FRAMES
+
+    video = tmp_path / "video.mp4"
+    video.write_bytes(b"not a real video; subprocess is mocked")
+
+    imagehash_module = types.ModuleType("imagehash")
+    image_module = types.ModuleType("PIL.Image")
+    pil_module = types.ModuleType("PIL")
+    pil_module.Image = image_module
+    monkeypatch.setitem(sys.modules, "imagehash", imagehash_module)
+    monkeypatch.setitem(sys.modules, "PIL", pil_module)
+    monkeypatch.setitem(sys.modules, "PIL.Image", image_module)
+    monkeypatch.setattr("mcp_video.ai_engine.scene._run_ffprobe_json", lambda _path: {"format": {"duration": "1200"}})
+
+    seen_cmds = []
+
+    def fake_run(cmd, capture_output, text, timeout):
+        seen_cmds.append(cmd)
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    assert ai_scene_detect(str(video), threshold=0.3, use_ai=True) == []
+
+    vf_arg = seen_cmds[0][seen_cmds[0].index("-vf") + 1]
+    expected_interval = 1200 / MAX_AI_SCENE_FRAMES
+    assert vf_arg.startswith(f"fps=1/{expected_interval}")
+
+
+
+
+def test_require_audio_stream_propagates_probe_errors(monkeypatch):
+    from mcp_video.ai_engine.spatial import _require_audio_stream
+    from mcp_video.errors import ProcessingError
+
+    expected = ProcessingError("ffprobe video.mp4", 1, "corrupt input")
+    monkeypatch.setattr("mcp_video.ai_engine.spatial._run_ffprobe_json", lambda _video: (_ for _ in ()).throw(expected))
+
+    with pytest.raises(ProcessingError, match="corrupt input"):
+        _require_audio_stream("video.mp4")
+
+
+@requires_ffmpeg
+def test_spatial_audio_rejects_video_without_audio(sample_video_no_audio, tmp_path):
+    """Spatial audio should fail clearly before FFmpeg pan filters when audio is absent."""
+    from mcp_video.ai_engine import audio_spatial
+
+    with pytest.raises(MCPVideoError, match="audio stream"):
+        audio_spatial(
+            sample_video_no_audio,
+            str(tmp_path / "out.mp4"),
+            [{"time": 0, "azimuth": 0, "elevation": 0}],
+        )
+
+
+def test_apply_simple_spatial_rejects_empty_positions(monkeypatch, tmp_path):
+    from mcp_video.ai_engine.spatial import _apply_simple_spatial
+
+    monkeypatch.setattr("mcp_video.ai_engine.spatial._get_video_duration", lambda _video: 1.0)
+
+    with pytest.raises(MCPVideoError, match="position"):
+        _apply_simple_spatial("input.mp4", str(tmp_path / "out.mp4"), [])
+
+
 # ---------------------------------------------------------------------------
 # ai_color_grade Tests
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What changed

Closes the AI scene/spatial P1 items from `docs/CURRENT_EDGE_CASE_AUDIT_2026-04-21.md`:

- Validate `ai_scene_detect(..., use_ai=True)` threshold before expensive AI-mode work.
- Add `MAX_AI_SCENE_FRAMES` and use it to cap AI scene frame extraction rate for long videos.
- Reuse `MAX_VIDEO_DURATION` in AI scene mode.
- Fail spatial audio clearly when the input has no audio stream.
- Reject empty positions inside `_apply_simple_spatial()` as well as the public `audio_spatial()` boundary.
- Update the audit doc to mark those items closed and leave SSRF/Whisper/Demucs/upscale as the next resource-guard bundle.

## Verification

- `pytest tests/test_ai_features.py -q --tb=short` — 47 passed, 10 skipped
- `ruff check mcp_video/ tests/`
- `ruff format --check mcp_video/`
- `python3 -m pytest tests/ -x -q --tb=short && python3 -c "import mcp_video"` — 801 passed, 9 skipped, 2 xpassed
