### PR TITLE
docs: update docs, workflows, and client for v1.2.3 changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 <p align="center">
   <a href="https://pypi.org/project/mcp-video/"><img src="https://img.shields.io/pypi/v/mcp-video.svg" alt="PyPI"></a>
   <a href="https://github.com/pastorsimon1798/mcp-video/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/pastorsimon1798/mcp-video/.github/workflows/ci.yml?branch=master&label=CI" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tools-83%20MCP%20tools-orange.svg" alt="Tools">
+  <img src="https://img.shields.io/badge/tools-81%20MCP%20tools-orange.svg" alt="Tools">
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue.svg" alt="License">
   <img src="https://img.shields.io/badge/python-3.11+-blue.svg" alt="Python">
 </p>
@@ -144,15 +144,23 @@ mcp-video template tiktok video.mp4 --caption "Check this out!"
 
 | Category | Count | Highlights |
 |----------|-------|------------|
-| **Core Video** | 40 | trim, merge, text, audio, resize, convert, filters, stabilize, chroma key, subtitles, watermark, batch |
-| **AI-Powered** | 8 | transcribe (Whisper), scene detect, stem separation (Demucs), upscale, color grade |
+| **Core Video** | 26 | trim, merge, text, audio, resize, convert, filters, stabilize, chroma key, subtitles, watermark, batch |
+| **AI-Powered** | 10 | transcribe (Whisper), scene detect, stem separation (Demucs), upscale, color grade |
 | **Remotion** | 8 | create project, scaffold, render, studio preview, pipeline |
-| **Audio Synthesis** | 6 | generate waveforms, presets, sequences, effects — pure NumPy |
+| **Audio Synthesis** | 7 | generate waveforms, presets, sequences, effects, spatial audio — pure NumPy |
 | **Visual Effects** | 5 | vignette, chromatic aberration, scanlines, noise, glow |
 | **Transitions** | 3 | glitch, pixelate, morph |
-| **Layout & Motion** | 7 | grid, pip, animated text, counters, progress bars, auto-chapters |
-| **Quality** | 3 | brightness/contrast/audio checks, design analysis, auto-fix |
+| **Layout & Motion** | 6 | grid, pip, animated text, counters, progress bars, auto-chapters |
+| **Analysis** | 8 | scene detect, thumbnail, preview, storyboard, quality compare, metadata, waveform |
 | **Image Analysis** | 3 | color extraction, palette generation, product analysis |
+| **Meta** | 1 | `search_tools` — keyword search across all tools |
+
+**Tool discovery:**
+```python
+from mcp_video import Client
+editor = Client()
+results = editor.search_tools("subtitle")  # Find subtitle-related tools
+```
 
 ---
 
@@ -262,13 +270,33 @@ Structured, actionable errors with auto-fix suggestions:
 
 ---
 
+## Workflows
+
+ICM-style staged pipelines for common productions — with `CONTEXT.md` stage contracts, `references/` factory config, and runnable `workflow.py` scripts.
+
+```bash
+cd workflows/01-social-media-clip
+python workflow.py /path/to/video.mp4
+```
+
+| Workflow | Stages | Description |
+|----------|--------|-------------|
+| `01-social-media-clip` | 5 | Landscape → TikTok / Short / Reel |
+| `02-podcast-clip` | 6 | Highlight with chapters + burned captions |
+| `03-explainer-video` | 7 | Branded explainer from scratch |
+
+See [`workflows/CONTEXT.md`](workflows/CONTEXT.md) for the routing table.
+
 ## Architecture
 
 ```
 mcp_video/
-  client.py              # Python Client API
-  server.py              # MCP server (81 tools + 4 resources)
+  client/                # Python Client API (mixins per domain)
+  client/meta.py         # Client discovery mixin (search_tools)
+  server.py              # MCP server (81 tools + 4 resources + search_tools meta-tool)
+  server_tools_*.py      # Tool registration by category
   engine.py              # Core FFmpeg engine
+  engine_*.py            # Specialized engines (thumbnail, edit, probe, etc.)
   models.py              # Pydantic models
   errors.py              # Error hierarchy + FFmpeg stderr parser
   ffmpeg_helpers.py      # Shared FFmpeg utilities
@@ -279,6 +307,11 @@ mcp_video/
   remotion_engine.py     # Remotion CLI wrapper
   image_engine.py        # Image color analysis
   quality_guardrails.py  # Automated quality checks
+workflows/               # ICM staged pipelines
+  CONTEXT.md             # Layer 1 routing table
+  01-social-media-clip/  # Stage contract + runnable script
+  02-podcast-clip/       # Stage contract + runnable script
+  03-explainer-video/    # Stage contract + runnable script
 ```
 
 ---

--- a/docs/AI_AGENT_DISCOVERY.md
+++ b/docs/AI_AGENT_DISCOVERY.md
@@ -19,12 +19,18 @@ This document is the short, explicit discovery map for agents, answer engines, a
 
 ## Best Entry Points
 
-- `README.md` - install, quick start, tools, CLI, Python client.
+- `README.md` - install, quick start, tools, CLI, Python client, workflows.
+- `CLAUDE.md` - Layer 0 identity: what this project is, where to find staged pipelines.
 - `llms.txt` - compact machine-readable project map.
-- `mcp_video/server.py` - MCP tool registration layer.
+- `mcp_video/server.py` - MCP tool registration layer (81 tools + search_tools meta-tool).
 - `mcp_video/engine.py` - core FFmpeg operations.
 - `mcp_video/client.py` - Python client.
+- `mcp_video/client/meta.py` - Client-side tool discovery (`search_tools`).
 - `mcp_video/__main__.py` - CLI.
+- `workflows/CONTEXT.md` - Layer 1 routing: which ICM workflow to use.
+- `workflows/01-social-media-clip/CONTEXT.md` - Stage contract for social clip production.
+- `workflows/02-podcast-clip/CONTEXT.md` - Stage contract for podcast highlight production.
+- `workflows/03-explainer-video/CONTEXT.md` - Stage contract for explainer video production.
 - `server.json` - MCP Registry metadata for the PyPI package.
 - `CONTRIBUTING.md` - contribution and testing rules.
 - `SECURITY.md` - private vulnerability reporting.
@@ -70,6 +76,8 @@ Cursor:
 - Do not break existing MCP tool signatures.
 - Do not move business logic into `server.py`; keep it in engine modules.
 - Do not add dependencies just to wrap a single command.
+- Do not write output next to source files; use temp directories or explicit output paths.
+- Do not claim ICM folder structure is used for core code; it is layered on top (`workflows/`).
 
 ## Registry And Directory Targets
 

--- a/docs/PYTHON_CLIENT.md
+++ b/docs/PYTHON_CLIENT.md
@@ -48,6 +48,7 @@ editor = Client()
 | `generate_subtitles(entries, output?, burn?)` | `SubtitleResult` | Create SRT subtitles |
 | `audio_waveform(video, bins?)` | `WaveformResult` | Extract audio waveform |
 | `batch(inputs, operation, params?)` | `dict` | Apply operation to multiple files |
+| `search_tools(query)` | `dict` | Search MCP tools by keyword — returns matching names, descriptions, required params |
 | `extract_colors(image_path, n_colors?)` | `ColorExtractionResult` | Extract dominant colors |
 | `generate_palette(image_path, harmony?, n_colors?)` | `PaletteResult` | Generate color harmony palette |
 | `analyze_product(image_path, use_ai?, n_colors?)` | `ProductAnalysisResult` | Extract colors + optional AI description |

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -4,7 +4,23 @@
 
 ---
 
-## Core Editing (27 tools)
+## Meta / Discovery (1 tool)
+
+| Tool | Description |
+|------|-------------|
+| `search_tools` | Search all registered MCP tools by keyword. Returns matching tool names, descriptions, and required parameters. Use this when you need to find the right tool without loading all 81 descriptions into context. |
+
+**Python Client:**
+```python
+from mcp_video import Client
+editor = Client()
+results = editor.search_tools("subtitle")
+# Returns: {"success": True, "count": 3, "tools": [...]}
+```
+
+---
+
+## Core Editing (26 tools)
 
 | Tool | Description |
 |------|-------------|
@@ -81,7 +97,7 @@ Create videos programmatically using [Remotion](https://www.remotion.dev/) — a
 
 ---
 
-## Audio Synthesis (6 tools)
+## Audio Synthesis (7 tools)
 
 Generate audio from code — no external audio files needed. Pure NumPy, no extra dependencies.
 

--- a/llms.txt
+++ b/llms.txt
@@ -36,11 +36,14 @@ claude mcp add mcp-video -- uvx mcp-video
 ## Important Files
 
 - `README.md` - user documentation, install guide, tool list, CLI and Python examples.
+- `CLAUDE.md` - Layer 0 identity file for agent context routing.
 - `docs/AI_AGENT_DISCOVERY.md` - agent and answer-engine discovery map.
-- `mcp_video/server.py` - MCP tool registration layer.
+- `mcp_video/server.py` - MCP tool registration layer (81 tools + search_tools meta-tool).
 - `mcp_video/engine.py` - core FFmpeg editing operations.
 - `mcp_video/client.py` - Python client API.
+- `mcp_video/client/meta.py` - Client-side tool discovery (`search_tools`).
 - `mcp_video/__main__.py` - CLI command surface.
+- `workflows/CONTEXT.md` - Layer 1 routing: which ICM workflow to use.
 - `server.json` - MCP Registry metadata for `io.github.pastorsimon1798/mcp-video`.
 - `mcp_video/ffmpeg_helpers.py` - shared FFmpeg subprocess, path, duration, SRT, and escaping helpers.
 - `mcp_video/limits.py` - resource limits.
@@ -55,6 +58,9 @@ claude mcp add mcp-video -- uvx mcp-video
 - Keep subprocess timeouts.
 - Preserve public MCP tool signatures.
 - Do not commit generated media, local caches, virtualenvs, rendered output, or workspace state.
+- Use `search_tools("keyword")` to discover tools instead of loading all 81 descriptions into context.
+- Use `workflows/` for staged productions; read `CONTEXT.md` before starting.
+- Write temporary frames to temp directories, not next to source files.
 
 ## Canonical Links
 

--- a/mcp_video/client/effects.py
+++ b/mcp_video/client/effects.py
@@ -185,6 +185,16 @@ class ClientEffectsMixin:
 
         return text_subtitles(video=video, subtitles=subtitles, output=output, style=style)
 
+    def subtitles_styled(
+        self,
+        video: str,
+        subtitles: str,
+        output: str,
+        style: dict | None = None,
+    ) -> str:
+        """Burn subtitles from SRT/VTT with styling (alias for text_subtitles)."""
+        return self.text_subtitles(video, subtitles, output, style)
+
     # ------------------------------------------------------------------
     # Motion Graphics
     # ------------------------------------------------------------------

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.pastorsimon1798/mcp-video",
   "title": "mcp-video",
   "description": "Video editing MCP server for AI agents using FFmpeg and Remotion structured tools.",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "repository": {
     "url": "https://github.com/pastorsimon1798/mcp-video",
     "source": "github"
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "mcp-video",
-      "version": "1.2.2",
+      "version": "1.2.3",
       "transport": {
         "type": "stdio"
       }

--- a/workflows/01-social-media-clip/workflow.py
+++ b/workflows/01-social-media-clip/workflow.py
@@ -38,7 +38,7 @@ def main() -> None:
         INPUT_VIDEO,
         start=f"{int(start // 60):02d}:{int(start % 60):02d}",
         duration=f"{int(clip_duration)}",
-        output_path=os.path.join(OUTPUT_DIR, "01_trimmed.mp4"),
+        output=os.path.join(OUTPUT_DIR, "01_trimmed.mp4"),
     )
     print(f"   -> {trimmed.output_path} ({clip_duration:.1f}s)")
 
@@ -47,7 +47,7 @@ def main() -> None:
     vertical = client.resize(
         trimmed.output_path,
         aspect_ratio="9:16",
-        output_path=os.path.join(OUTPUT_DIR, "02_vertical.mp4"),
+        output=os.path.join(OUTPUT_DIR, "02_vertical.mp4"),
     )
     print(f"   -> {vertical.output_path}")
 
@@ -61,7 +61,7 @@ def main() -> None:
         color="#CCFF00",
         start_time=0,
         duration=3,
-        output_path=os.path.join(OUTPUT_DIR, "03_captioned.mp4"),
+        output=os.path.join(OUTPUT_DIR, "03_captioned.mp4"),
     )
     print(f"   -> {hooked.output_path}")
 
@@ -70,7 +70,7 @@ def main() -> None:
     normalized = client.normalize_audio(
         hooked.output_path,
         target_lufs=-14.0,
-        output_path=os.path.join(OUTPUT_DIR, "04_normalized.mp4"),
+        output=os.path.join(OUTPUT_DIR, "04_normalized.mp4"),
     )
     print(f"   -> {normalized.output_path}")
 
@@ -80,7 +80,7 @@ def main() -> None:
         normalized.output_path,
         format="mp4",
         quality="high",
-        output_path=os.path.join(OUTPUT_DIR, "final_clip.mp4"),
+        output=os.path.join(OUTPUT_DIR, "final_clip.mp4"),
     )
     print(f"   -> {final.output_path}")
 

--- a/workflows/02-podcast-clip/workflow.py
+++ b/workflows/02-podcast-clip/workflow.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""
+Podcast Clip Workflow for mcp-video.
+
+Extracts a highlight from a podcast episode with auto-chapters and burned captions.
+
+Usage:
+    python workflow.py /path/to/episode.mp4
+
+The script runs 6 stages and outputs the final clip to output/final_clip.mp4.
+"""
+
+import json
+import os
+import sys
+
+from mcp_video import Client
+
+client = Client()
+
+INPUT_VIDEO = sys.argv[1] if len(sys.argv) > 1 else input("Path to episode: ").strip()
+OUTPUT_DIR = os.path.join(os.path.dirname(__file__), "output")
+os.makedirs(OUTPUT_DIR, exist_ok=True)
+
+
+def _save_scenes(scenes_result, path: str) -> None:
+    with open(path, "w") as f:
+        json.dump(scenes_result.model_dump(), f, indent=2)
+
+
+def _save_chapters(chapters, path: str) -> None:
+    with open(path, "w") as f:
+        json.dump([{"time": t, "title": title} for t, title in chapters], f, indent=2)
+
+
+def _stage_detect(video: str) -> str:
+    print("\n[1/6] Detecting scenes...")
+    scenes = client.detect_scenes(video, threshold=0.3)
+    path = os.path.join(OUTPUT_DIR, "01_scenes.json")
+    _save_scenes(scenes, path)
+    print(f"   -> {path} ({scenes.scene_count} scenes)")
+    return path
+
+
+def _stage_chapters(video: str) -> str:
+    print("\n[2/6] Generating chapter markers...")
+    chapters = client.auto_chapters(video, threshold=0.3)
+    path = os.path.join(OUTPUT_DIR, "02_chapters.json")
+    _save_chapters(chapters, path)
+    print(f"   -> {path} ({len(chapters)} chapters)")
+    return path
+
+
+def _stage_trim(video: str) -> str:
+    print("\n[3/6] Trimming highlight segment...")
+    info = client.info(video)
+    start = 30
+    clip_duration = min(60, max(30, info.duration - start))
+    trimmed = client.trim(
+        video,
+        start=f"{int(start // 60):02d}:{int(start % 60):02d}",
+        duration=f"{int(clip_duration)}",
+        output=os.path.join(OUTPUT_DIR, "03_highlight.mp4"),
+    )
+    print(f"   -> {trimmed.output_path} ({clip_duration:.1f}s)")
+    return trimmed.output_path
+
+
+def _stage_transcribe(video: str) -> str:
+    print("\n[4/6] Transcribing audio...")
+    srt_path = os.path.join(OUTPUT_DIR, "04_transcript.srt")
+    result = client.ai_transcribe(video, output_srt=srt_path)
+    print(f"   -> {srt_path} ({len(result['segments'])} segments)")
+    return srt_path
+
+
+def _stage_captions(video: str, srt_path: str) -> str:
+    print("\n[5/6] Burning captions into video...")
+    captioned = client.subtitles_styled(
+        video,
+        subtitles=srt_path,
+        output=os.path.join(OUTPUT_DIR, "05_captioned.mp4"),
+        style={"font_size": 32, "font_color": "white", "outline": True},
+    )
+    print(f"   -> {captioned}")
+    return captioned
+
+
+def _stage_export(video: str) -> str:
+    print("\n[6/6] Exporting final clip...")
+    final = client.convert(
+        video,
+        format="mp4",
+        quality="high",
+        output=os.path.join(OUTPUT_DIR, "final_clip.mp4"),
+    )
+    print(f"   -> {final.output_path}")
+    return final.output_path
+
+
+def main() -> None:
+    print("=" * 60)
+    print("02-podcast-clip workflow")
+    print("=" * 60)
+
+    _stage_detect(INPUT_VIDEO)
+    _stage_chapters(INPUT_VIDEO)
+    highlight = _stage_trim(INPUT_VIDEO)
+    srt = _stage_transcribe(highlight)
+    captioned = _stage_captions(highlight, srt)
+    _stage_export(captioned)
+
+    print("\n" + "=" * 60)
+    print("Workflow complete! Upload output/final_clip.mp4")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    main()

--- a/workflows/03-explainer-video/workflow.py
+++ b/workflows/03-explainer-video/workflow.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""
+Explainer Video Workflow for mcp-video.
+
+Builds a branded explainer video from scratch using synthesized audio, scenes,
+effects, and transitions — using only mcp-video client methods.
+
+Usage:
+    python workflow.py
+
+The script runs 7 stages and outputs the final video to output/final_video.mp4.
+"""
+
+import os
+
+from PIL import Image, ImageDraw, ImageFont
+
+from mcp_video import Client
+
+client = Client()
+
+OUTPUT_DIR = os.path.join(os.path.dirname(__file__), "output")
+os.makedirs(OUTPUT_DIR, exist_ok=True)
+TMP_DIR = os.path.join(OUTPUT_DIR, "tmp")
+os.makedirs(TMP_DIR, exist_ok=True)
+
+SCENES = [
+    {"color": "#1a1a2e", "text": "Meet mcp-video", "duration": 5},
+    {"color": "#16213e", "text": "Edit video with AI agents", "duration": 5},
+    {"color": "#0f3460", "text": "81 MCP tools at your command", "duration": 5},
+    {"color": "#533483", "text": "Built on FFmpeg + Remotion", "duration": 5},
+]
+
+FPS = 30
+WIDTH, HEIGHT = 1920, 1080
+
+
+def _create_scene_image(color: str, text: str, output: str) -> str:
+    """Create a branded scene image using Pillow."""
+    img = Image.new("RGB", (WIDTH, HEIGHT), color)
+    draw = ImageDraw.Draw(img)
+    try:
+        font = ImageFont.truetype("/System/Library/Fonts/Helvetica.ttc", 64)
+    except OSError:
+        font = ImageFont.load_default()
+    bbox = draw.textbbox((0, 0), text, font=font)
+    text_w = bbox[2] - bbox[0]
+    text_h = bbox[3] - bbox[1]
+    x = (WIDTH - text_w) // 2
+    y = (HEIGHT - text_h) // 2
+    draw.rectangle(
+        [x - 20, y - 10, x + text_w + 20, y + text_h + 10],
+        fill="black",
+    )
+    draw.text((x, y), text, fill="white", font=font)
+    img.save(output)
+    return output
+
+
+def _stage_soundtrack() -> str:
+    print("\n[1/7] Generating soundtrack...")
+    drone = client.audio_preset(
+        "drone-tech",
+        os.path.join(TMP_DIR, "drone.wav"),
+        duration=20,
+        intensity=0.4,
+    )
+    chime = client.audio_preset(
+        "chime-success",
+        os.path.join(TMP_DIR, "chime.wav"),
+        intensity=0.6,
+    )
+    soundtrack = client.audio_compose(
+        tracks=[
+            {"file": drone, "volume": 0.3, "start": 0},
+            {"file": chime, "volume": 0.8, "start": 0},
+            {"file": chime, "volume": 0.8, "start": 5},
+            {"file": chime, "volume": 0.8, "start": 10},
+            {"file": chime, "volume": 0.8, "start": 15},
+        ],
+        duration=20,
+        output=os.path.join(OUTPUT_DIR, "01_soundtrack.wav"),
+    )
+    print(f"   -> {soundtrack}")
+    return soundtrack
+
+
+def _stage_scenes() -> list[str]:
+    print("\n[2/7] Creating scene videos...")
+    scene_clips = []
+    for i, scene in enumerate(SCENES):
+        img_path = os.path.join(TMP_DIR, f"scene_{i:02d}.png")
+        _create_scene_image(scene["color"], scene["text"], img_path)
+        frame_count = int(scene["duration"] * FPS)
+        images = [img_path] * frame_count
+        video_path = os.path.join(TMP_DIR, f"scene_{i:02d}.mp4")
+        result = client.create_from_images(images, output=video_path, fps=FPS)
+        scene_clips.append(result.output_path)
+        print(f"   -> {result.output_path}")
+    return scene_clips
+
+
+def _stage_effects(scene_clips: list[str]) -> list[str]:
+    print("\n[3/7] Applying effects...")
+    fx_clips = []
+    for i, clip in enumerate(scene_clips):
+        out = os.path.join(TMP_DIR, f"scene_{i:02d}_fx.mp4")
+        if i % 2 == 0:
+            client.effect_vignette(clip, out, intensity=0.4)
+        else:
+            client.effect_glow(clip, out, intensity=0.3)
+        fx_clips.append(out)
+        print(f"   -> {out}")
+    return fx_clips
+
+
+def _stage_transitions(fx_clips: list[str]) -> list[str]:
+    print("\n[4/7] Creating transitions...")
+    transition_clips = []
+    for i in range(len(fx_clips) - 1):
+        out = os.path.join(TMP_DIR, f"transition_{i:02d}.mp4")
+        if i % 3 == 0:
+            client.transition_glitch(fx_clips[i], fx_clips[i + 1], out, duration=0.5)
+        elif i % 3 == 1:
+            client.transition_pixelate(fx_clips[i], fx_clips[i + 1], out, duration=0.5)
+        else:
+            client.transition_morph(fx_clips[i], fx_clips[i + 1], out, duration=0.5)
+        transition_clips.append(out)
+        print(f"   -> {out}")
+    return transition_clips
+
+
+def _stage_assemble(fx_clips: list[str]) -> str:
+    print("\n[5/7] Assembling scenes with transitions...")
+    assembled = client.merge(
+        clips=fx_clips,
+        output=os.path.join(OUTPUT_DIR, "05_assembled.mp4"),
+        transitions=["fade", "pixelize", "dissolve"],
+        transition_duration=0.5,
+    )
+    print(f"   -> {assembled.output_path}")
+    return assembled.output_path
+
+
+def _stage_audio_mix(video: str, soundtrack: str) -> str:
+    print("\n[6/7] Mixing audio...")
+    mixed = client.add_audio(
+        video=video,
+        audio=soundtrack,
+        mix=True,
+        volume=0.8,
+        output=os.path.join(OUTPUT_DIR, "06_mixed.mp4"),
+    )
+    print(f"   -> {mixed.output_path}")
+    return mixed.output_path
+
+
+def _stage_export(video: str) -> str:
+    print("\n[7/7] Exporting final video...")
+    final = client.convert(
+        video,
+        format="mp4",
+        quality="high",
+        output=os.path.join(OUTPUT_DIR, "final_video.mp4"),
+    )
+    print(f"   -> {final.output_path}")
+    return final.output_path
+
+
+def main() -> None:
+    print("=" * 60)
+    print("03-explainer-video workflow")
+    print("=" * 60)
+
+    soundtrack = _stage_soundtrack()
+    scene_clips = _stage_scenes()
+    fx_clips = _stage_effects(scene_clips)
+    _stage_transitions(fx_clips)
+    assembled = _stage_assemble(fx_clips)
+    mixed = _stage_audio_mix(assembled, soundtrack)
+    _stage_export(mixed)
+
+    print("\n" + "=" * 60)
+    print("Workflow complete! Review output/final_video.mp4")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Documentation and workflow updates to match the v1.2.3 release changes.

### Documentation Updates
- **README.md**: Fixed badge 83→81, added `search_tools` + `Client.search_tools()`, added Workflows section with ICM routing
- **docs/TOOLS.md**: Added Meta/Discovery section for `search_tools`, fixed category counts
- **docs/PYTHON_CLIENT.md**: Added `search_tools` method
- **docs/AI_AGENT_DISCOVERY.md**: Added `search_tools`, `workflows/`, `CLAUDE.md` entry points
- **llms.txt**: Added `search_tools`, `workflows/`, `CLAUDE.md` references, safety rules
- **server.json**: Bumped version 1.2.2→1.2.3

### Client Updates
- **client/effects.py**: Added `subtitles_styled()` alias for `text_subtitles()` to match MCP tool rename

### Workflow Updates (ICM Alignment)
- **workflows/01-social-media-clip/workflow.py**: Fixed client method args (`output_path` → `output`)
- **workflows/02-podcast-clip/workflow.py**: Added runnable 6-stage workflow (detect → chapters → trim → transcribe → captions → export)
- **workflows/03-explainer-video/workflow.py**: Added runnable 7-stage workflow using only mcp-video client + Pillow (no raw FFmpeg)

### Verification
- **817 tests passed**, ruff clean, repo readiness passed
- All 3 workflows executed end-to-end on real MP4s
- `search_tools` works via both `Client` and MCP server module
