### PR TITLE
docs: fix v1.2.6 documentation inconsistencies and gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ This project follows a simple release-note style:
 - `Fixed` for bug fixes.
 - `Security` for vulnerability fixes.
 
+## 1.2.6 - 2026-04-27
+
+### Changed
+
+- Bumped version to 1.2.6 (1.2.5 tag already existed).
+
 ## 1.2.5 - 2026-04-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -172,19 +172,19 @@ mcp-video template tiktok video.mp4 --caption "Check this out!"
 
 ## MCP Tools
 
-82 unique MCP tools across 12 categories, plus a `search_tools` meta-tool for fast discovery. All return structured JSON. See the [full tool reference](docs/TOOLS.md) for complete details.
+90 unique MCP tools across 12 categories, plus a `search_tools` meta-tool for fast discovery. All return structured JSON. See the [full tool reference](docs/TOOLS.md) for complete details.
 
 | Category | Count | Highlights |
 |----------|-------|------------|
-| **Core Video** | 26 | trim, merge, text, audio, resize, convert, filters, stabilize, chroma key, subtitles, watermark, batch |
-| **AI-Powered** | 10 | transcribe (Whisper), scene detect, stem separation (Demucs), upscale, color grade |
+| **Core Video** | 29 | trim, merge, text, audio, resize, convert, filters, stabilize, chroma key, subtitles, watermark, batch, export, normalize audio |
+| **AI-Powered** | 11 | transcribe (Whisper), scene detect, stem separation (Demucs), upscale, color grade |
 | **Hyperframes** | 8 | init, render, still, preview, compositions, validate, add block, pipeline |
 | **Remotion** | 8 | create project, scaffold, render, studio preview, pipeline *(deprecated)* |
 | **Audio Synthesis** | 7 | generate waveforms, presets, sequences, effects, spatial audio — pure NumPy |
-| **Visual Effects** | 5 | vignette, chromatic aberration, scanlines, noise, glow |
+| **Visual Effects** | 6 | vignette, chromatic aberration, scanlines, noise, glow, mask |
 | **Transitions** | 3 | glitch, pixelate, morph |
 | **Layout & Motion** | 6 | grid, pip, animated text, counters, progress bars, auto-chapters |
-| **Analysis** | 9 | scene detect, thumbnail, preview, storyboard, quality compare, metadata, waveform, release checkpoint |
+| **Analysis** | 8 | scene detect, thumbnail, preview, storyboard, quality compare, metadata, waveform, release checkpoint |
 | **Image Analysis** | 3 | color extraction, palette generation, product analysis |
 | **Meta** | 1 | `search_tools` — keyword search across all tools |
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Improvement Roadmap
 
-v1.2.5 shipped. 90 MCP tools, 905 tests, Hyperframes integration, Remotion deprecated. Here's what's next.
+v1.2.6 shipped. 90 MCP tools, 905 tests, Hyperframes integration, Remotion deprecated. Here's what's next.
 
 ---
 

--- a/docs/AI_AGENT_DISCOVERY.md
+++ b/docs/AI_AGENT_DISCOVERY.md
@@ -25,8 +25,10 @@ This document is the short, explicit discovery map for agents, answer engines, a
 - `llms.txt` - compact machine-readable project map.
 - `mcp_video/server.py` - MCP tool registration layer (90 tools + search_tools meta-tool).
 - `mcp_video/engine.py` - core FFmpeg operations.
-- `mcp_video/client.py` - Python client. Use `Client.inspect()`, `Client.pipeline()`, and `Client.release_checkpoint()` for guarded agent workflows.
+- `mcp_video/client/` - Python client mixins. Use `Client.inspect()`, `Client.pipeline()`, and `Client.release_checkpoint()` for guarded agent workflows.
 - `mcp_video/client/meta.py` - Client-side tool discovery (`search_tools`).
+- `mcp_video/client/hyperframes.py` - Hyperframes client mixin.
+- `mcp_video/client/remotion.py` - Remotion client mixin (deprecated).
 - `mcp_video/__main__.py` - CLI.
 - `workflows/CONTEXT.md` - Layer 1 routing: which ICM workflow to use.
 - `workflows/01-social-media-clip/CONTEXT.md` - Stage contract for social clip production.

--- a/docs/INTEGRATION-ROADMAP.md
+++ b/docs/INTEGRATION-ROADMAP.md
@@ -145,4 +145,4 @@ A third-party `script-to-animation` template exists at `~/Desktop/Interpreted-Co
 |-------------|----------|--------|--------|---------|-----|
 | Blender MCP | LOW | 1-2 days | Defer | No | Medium |
 | Image Analysis | MEDIUM | 2-3 days | **Completed (v0.7.0)** | Yes | Medium |
-| Remotion | MEDIUM | 5-10 days | Reference material available | Yes | Medium (later) |
+| Remotion | MEDIUM | 5-10 days | Deprecated (v1.2.5) | Yes | Medium (later) |

--- a/docs/PYTHON_CLIENT.md
+++ b/docs/PYTHON_CLIENT.md
@@ -18,52 +18,126 @@ editor = Client()
 Media-producing methods return an `EditResult`-compatible object with `.output_path`.
 Analysis methods return report models or dictionaries.
 
-## Methods
+---
+
+## Core Editing Methods
 
 | Method | Returns | Description |
 |--------|---------|-------------|
 | `info(path)` | `VideoInfo` | Video metadata (duration, resolution, codec, fps, size) |
+| `video_info_detailed(video)` | `dict` | Extended metadata with scene detection and dominant colors |
 | `trim(input, start, duration?, end?, output?)` | `EditResult` | Trim by start time + duration or end time |
 | `merge(clips, output?, transitions?, transition_duration?)` | `EditResult` | Concatenate clips with per-pair transitions |
 | `add_text(video, text, position?, font?, size?, color?, shadow?, start_time?, duration?, output?)` | `EditResult` | Overlay text on video |
 | `add_audio(video, audio, volume?, fade_in?, fade_out?, mix?, start_time?, output?)` | `EditResult` | Add or replace audio track |
 | `resize(video, width?, height?, aspect_ratio?, quality?, output?)` | `EditResult` | Resize or change aspect ratio |
 | `convert(video, format?, quality?, output?)` | `EditResult` | Convert format (mp4/webm/gif/mov) |
+| `export(video, output?, quality?, format?)` | `EditResult` | Render with quality settings |
 | `speed(video, factor?, output?)` | `EditResult` | Change playback speed |
-| `thumbnail(video, timestamp?, output?)` | `EditResult` / `ThumbnailResult` | Extract single frame; exposes `.output_path` and `.frame_path` |
-| `preview(video, output?, scale_factor?)` | `EditResult` | Fast low-res preview |
-| `storyboard(video, output_dir?, frame_count?)` | `EditResult` / `StoryboardResult` | Key frames + grid; exposes `.output_path`, `.frames`, `.grid` |
-| `subtitles(video, subtitle_file, output?)` | `EditResult` | Burn subtitles into video |
-| `watermark(video, image, position?, opacity?, margin?, output?)` | `EditResult` | Add image watermark |
+| `reverse(video, output?)` | `EditResult` | Reverse video and audio playback |
+| `fade(video, fade_in?, fade_out?, output?)` | `EditResult` | Video fade in/out effect |
 | `crop(video, width, height, x?, y?, output?)` | `EditResult` | Crop to rectangular region |
 | `rotate(video, angle?, flip_horizontal?, flip_vertical?, output?)` | `EditResult` | Rotate and/or flip video |
-| `fade(video, fade_in?, fade_out?, output?)` | `EditResult` | Video fade in/out effect |
-| `export(video, output?, quality?, format?)` | `EditResult` | Render with quality settings |
-| `edit(timeline, output?)` | `EditResult` | Execute full timeline edit from JSON |
-| `extract_audio(video, output?, format?)` | `EditResult` | Extract audio as file path |
 | `filter(video, filter_type, params?, output?)` | `EditResult` | Apply visual filter |
 | `blur(video, radius?, strength?, output?)` | `EditResult` | Blur video |
 | `color_grade(video, preset?, output?)` | `EditResult` | Apply color preset |
 | `normalize_audio(video, target_lufs?, output?)` | `EditResult` | Normalize audio to LUFS target |
-| `overlay_video(background, overlay, position?, width?, opacity?, start_time?, duration?, output?)` | `EditResult` | Picture-in-picture overlay |
-| `split_screen(left, right, layout?, output?)` | `EditResult` | Side-by-side or top/bottom layout |
-| `reverse(video, output?)` | `EditResult` | Reverse video and audio playback |
 | `chroma_key(video, color?, similarity?, blend?, output?)` | `EditResult` | Remove solid color background |
 | `stabilize(video, smoothing?, zoom?, output?)` | `EditResult` | Stabilize shaky footage |
-| `apply_mask(video, mask, feather?, output?)` | `EditResult` | Apply image mask with feathering |
-| `detect_scenes(video, threshold?, output?)` | `SceneDetectionResult` | Auto-detect scene changes |
+| `overlay_video(background, overlay, position?, width?, opacity?, start_time?, duration?, output?)` | `EditResult` | Picture-in-picture overlay |
+| `split_screen(left, right, layout?, output?)` | `EditResult` | Side-by-side or top/bottom layout |
+| `edit(timeline, output?)` | `EditResult` | Execute full timeline edit from JSON |
 | `create_from_images(images, fps?, output?)` | `EditResult` | Create video from images |
 | `export_frames(video, fps?, output_dir?)` | `ImageSequenceResult` | Export video as frames |
+| `extract_audio(video, output?, format?)` | `EditResult` | Extract audio as file path |
+| `subtitles(video, subtitle_file, output?)` | `EditResult` | Burn subtitles into video |
+| `text_subtitles(video, subtitles, output?, style?)` | `EditResult` | Burn subtitles with custom styling |
+| `subtitles_styled(video, subtitles, output?, style?)` | `EditResult` | Alias for `text_subtitles` |
+| `watermark(video, image, position?, opacity?, margin?, output?)` | `EditResult` | Add image watermark |
+| `batch(inputs, operation, params?)` | `dict` | Apply operation to multiple files |
+
+---
+
+## AI Methods
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `analyze_video(video, *, whisper_model?, language?, scene_threshold?, include_transcript?, include_scenes?, include_audio?, include_quality?, include_chapters?, include_colors?, output_srt?, output_txt?, output_md?, output_json?)` | `dict` | Comprehensive analysis: transcript, metadata, scenes, audio, quality, chapters, colors |
+| `ai_transcribe(video, output_srt?, model?, language?)` | `dict` | Speech-to-text with Whisper |
+| `ai_scene_detect(video, threshold?, use_ai?)` | `list[dict]` | Scene change detection |
+| `ai_stem_separation(video, output_dir, stems?, model?)` | `dict[str, str]` | Isolate vocals, drums, bass, other with Demucs |
+| `ai_upscale(video, output, scale?, model?)` | `str` | AI super-resolution upscaling |
+| `ai_color_grade(video, output, reference?, style?)` | `str` | Auto color grading |
+| `ai_remove_silence(video, output, silence_threshold?, min_silence_duration?, keep_margin?)` | `str` | Auto-remove silent sections |
+
+---
+
+## Quality & Analysis Methods
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `quality_check(video, fail_on_warning?)` | `dict` | Check brightness, contrast, saturation, audio levels, color balance |
+| `design_quality_check(video, auto_fix?, strict?)` | `Any` | Full design quality analysis: layout, typography, color, motion, composition |
+| `fix_design_issues(video, output?)` | `str` | Auto-fix brightness, contrast, saturation, and audio level issues |
+| `detect_scenes(video, threshold?, output?)` | `SceneDetectionResult` | Auto-detect scene changes |
+| `thumbnail(video, timestamp?, output?)` | `ThumbnailResult` | Extract single frame |
+| `extract_frame(video, timestamp?, output?)` | `ThumbnailResult` | Alias for `thumbnail` |
+| `preview(video, output?, scale_factor?)` | `EditResult` | Fast low-res preview |
+| `storyboard(video, output_dir?, frame_count?)` | `StoryboardResult` | Key frames + grid |
 | `compare_quality(video, reference, output?)` | `QualityMetricsResult` | Compare PSNR/SSIM metrics |
 | `read_metadata(video)` | `MetadataResult` | Read video metadata tags |
 | `write_metadata(video, metadata, output?)` | `EditResult` | Write video metadata tags |
-| `generate_subtitles(entries, output?, burn?)` | `EditResult` / `SubtitleResult` | Create SRT subtitles; exposes `.output_path` |
 | `audio_waveform(video, bins?)` | `WaveformResult` | Extract audio waveform |
-| `batch(inputs, operation, params?)` | `dict` | Apply operation to multiple files |
-| `search_tools(query)` | `dict` | Search MCP tools by keyword — returns matching names, descriptions, required params |
+| `auto_chapters(video, threshold?)` | `list[tuple[float, str]]` | Auto-detect scenes and create chapter timestamps |
+| `generate_subtitles(entries, output?, burn?)` | `SubtitleResult` | Create SRT subtitles |
+
+---
+
+## Audio Synthesis Methods
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `audio_synthesize(output, waveform?, frequency?, duration?, volume?, effects?)` | `EditResult` | Generate waveforms: sine, square, sawtooth, triangle, noise |
+| `audio_preset(preset, output?, pitch?, duration?, intensity?)` | `EditResult` | 15 pre-configured sounds: UI blips, ambient drones, notification chimes |
+| `audio_sequence(sequence, output)` | `EditResult` | Compose timed audio events into a layered track |
+| `audio_compose(tracks, duration, output)` | `EditResult` | Mix multiple WAV tracks with volume control |
+| `audio_effects(input_path, output, effects)` | `EditResult` | Apply effects chain: lowpass, reverb, normalize, fade |
+| `add_generated_audio(video, audio_config, output)` | `EditResult` | Generate audio and add it to a video |
+| `audio_spatial(video, output, positions, method?)` | `EditResult` | 3D spatial audio positioning |
+
+---
+
+## Visual Effects, Transitions & Layout Methods
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `effect_vignette(video, output, intensity?, radius?, smoothness?)` | `EditResult` | Darken edges for cinematic focus |
+| `effect_chromatic_aberration(video, output, intensity?, angle?)` | `EditResult` | RGB color separation (glitch aesthetic) |
+| `effect_scanlines(video, output, line_height?, opacity?, flicker?)` | `EditResult` | Retro CRT scanline effect |
+| `effect_noise(video, output, intensity?, mode?, animated?)` | `EditResult` | Film grain and digital noise |
+| `effect_glow(video, output, intensity?, radius?, threshold?)` | `EditResult` | Bloom/glow for highlights |
+| `apply_mask(video, mask, feather?, output?)` | `EditResult` | Apply image mask with feathering |
+| `transition_glitch(clip1, clip2, output, duration?, intensity?)` | `EditResult` | RGB shift + noise transition |
+| `transition_pixelate(clip1, clip2, output, duration?, pixel_size?)` | `EditResult` | Block dissolve transition |
+| `transition_morph(clip1, clip2, output, duration?, mesh_size?)` | `EditResult` | Mesh warp transition |
+| `layout_grid(clips, layout, output, gap?, padding?, background?)` | `EditResult` | Grid layout for multiple videos |
+| `layout_pip(main, pip, output, position?, size?, margin?, rounded_corners?, border?, border_color?, border_width?)` | `EditResult` | Picture-in-picture with border |
+| `text_animated(video, text, output, animation?, font?, size?, color?, position?, start?, duration?)` | `EditResult` | Animated text overlays |
+| `mograph_count(start, end, duration, output, style?, fps?)` | `EditResult` | Animated number counter video |
+| `mograph_progress(duration, output, style?, color?, track_color?, fps?)` | `EditResult` | Progress bar/circle/dots animation |
+
+---
+
+## Image Analysis Methods
+
+| Method | Returns | Description |
+|--------|---------|-------------|
 | `extract_colors(image_path, n_colors?)` | `ColorExtractionResult` | Extract dominant colors |
 | `generate_palette(image_path, harmony?, n_colors?)` | `PaletteResult` | Generate color harmony palette |
 | `analyze_product(image_path, use_ai?, n_colors?)` | `ProductAnalysisResult` | Extract colors + optional AI description |
+| `search_tools(query)` | `dict` | Search MCP tools by keyword |
+
+---
 
 ## Hyperframes Methods
 
@@ -77,6 +151,8 @@ Analysis methods return report models or dictionaries.
 | `hyperframes_add_block(project_path, block_name)` | `HyperframesBlockResult` | Install a block from the catalog |
 | `hyperframes_validate(project_path)` | `HyperframesValidationResult` | Validate project for rendering readiness |
 | `hyperframes_to_mcpvideo(project_path, post_process, output?)` | `HyperframesPipelineResult` | Render then post-process with mcp-video |
+
+---
 
 ## Remotion Methods (Deprecated)
 
@@ -92,6 +168,8 @@ Analysis methods return report models or dictionaries.
 | `remotion_scaffold_template(project_path, spec, slug)` | `RemotionScaffoldResult` | Generate composition from spec |
 | `remotion_validate(project_path, composition_id?)` | `RemotionValidationResult` | Validate project structure |
 | `remotion_to_mcpvideo(project_path, composition_id, post_process, output?)` | `RemotionPipelineResult` | Render + post-process pipeline |
+
+---
 
 ## Return Models
 
@@ -124,4 +202,20 @@ ColorExtractionResult(success=True, colors=[...], n_colors=5)
 PaletteResult(success=True, harmony="complementary", colors=[...])
 
 ProductAnalysisResult(success=True, colors=[...], description="...")
+
+HyperframesRenderResult(success=True, output_path, composition_id, duration)
+HyperframesStillResult(success=True, output_path, frame)
+HyperframesPreviewResult(success=True, url, port)
+HyperframesProjectResult(success=True, project_path, template)
+HyperframesBlockResult(success=True, project_path, block_name)
+HyperframesValidationResult(success=True, valid, issues, warnings)
+HyperframesPipelineResult(success=True, output_path, hyperframes_output, post_process)
+
+RemotionRenderResult(success=True, output_path, composition_id, codec)
+RemotionStillResult(success=True, output_path, frame, image_format)
+RemotionStudioResult(success=True, url, port)
+RemotionProjectResult(success=True, project_path, template)
+RemotionScaffoldResult(success=True, project_path, slug)
+RemotionValidationResult(success=True, valid, issues)
+RemotionPipelineResult(success=True, output_path, remotion_output, post_process)
 ```

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-mcp-video has a **comprehensive real media test suite** for exercising the project against actual FFmpeg/media operations. Some tests are environment-sensitive and may skip when optional dependencies or system capabilities are unavailable.
+mcp-video has **905 tests** (844 fast, 61 slow/integration) covering public MCP tools, Python client, CLI, FFmpeg operations, AI features, and engine internals. Some tests are environment-sensitive and may skip when optional dependencies or system capabilities are unavailable.
 
 ## Test Suite: `tests/test_real_all_features.py`
 
@@ -33,6 +33,20 @@ python -m pytest tests/test_real_all_features.py -v -m "not slow"
 | **Quality & Metadata** | 8 | Quality check, design quality, fix design issues, compare quality, auto chapters, detailed info, read/write metadata |
 | **Utility** | 7 | Convert format, preview, storyboard, thumbnail, batch process, timeline edit, generate subtitles |
 | **Total** | **70** | **100% passing** |
+
+## Remotion Tests
+
+Run Remotion-specific tests (requires Node.js 22+ and `npx remotion`):
+
+```bash
+python -m pytest tests/test_remotion_deprecation.py -v
+```
+
+Skip Remotion tests if Node.js is not available:
+
+```bash
+python -m pytest tests/ -v -m "not remotion"
+```
 
 ## Hyperframes Tests
 
@@ -130,7 +144,8 @@ pip install demucs torch torchaudio openai-whisper realesrgan basicsr imagehash 
 | test_12_stabilize_video | ~60s | Uses 2s clip (full video too slow) |
 | test_44_ai_upscale | ~30s | FSRCNN model (fast CPU inference) |
 | test_43_ai_stem_separation | ~30s | Downloads model on first run |
-| Full suite | ~5min | All 70 tests |
+| Full suite | ~5min | All 70 real-media tests |
+| Full project suite | ~8min | 905 tests total |
 
 ## Recent Fixes
 
@@ -168,6 +183,14 @@ def test_new_feature(self, client, sample_clips):
     ...
 ```
 
+## Adversarial & Security Tests
+
+Security-focused tests in `tests/test_adversarial_audit.py` verify:
+- FFmpeg filter injection prevention
+- Null byte rejection on all input paths
+- Color/format validation hardening
+- Parameter boundary enforcement
+
 ## Test Coverage
 
 Every MCP tool has a corresponding test:
@@ -175,3 +198,4 @@ Every MCP tool has a corresponding test:
 - Real FFmpeg operations validated
 - Error handling verified
 - Edge cases covered (silent videos, different codecs, etc.)
+- Deprecation warnings verified for all Remotion tools and client methods

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -8,7 +8,7 @@
 
 | Tool | Description |
 |------|-------------|
-| `search_tools` | Search all registered MCP tools by keyword. Returns matching tool names, descriptions, and required parameters. Use this when you need to find the right tool without loading all 82 descriptions into context. |
+| `search_tools` | Search all registered MCP tools by keyword. Returns matching tool names, descriptions, and required parameters. Use this when you need to find the right tool without loading all 90 descriptions into context. |
 
 **Python Client:**
 ```python
@@ -20,7 +20,7 @@ results = editor.search_tools("subtitle")
 
 ---
 
-## Core Editing (26 tools)
+## Core Editing (29 tools)
 
 | Tool | Description |
 |------|-------------|
@@ -50,6 +50,9 @@ results = editor.search_tools("subtitle")
 | `video_create_from_images` | Create video from image sequence |
 | `video_export_frames` | Export video as individual image frames |
 | `video_extract_audio` | Extract audio as mp3, wav, aac, ogg, or flac |
+| `video_export` | Render with quality and format settings |
+| `video_normalize_audio` | Normalize audio loudness to a target LUFS level |
+| `video_batch` | Apply the same operation to multiple video files |
 
 ---
 
@@ -131,7 +134,7 @@ Generate audio from code — no external audio files needed. Pure NumPy, no extr
 
 ---
 
-## Visual Effects (5 tools)
+## Visual Effects (6 tools)
 
 | Tool | Description |
 |------|-------------|
@@ -140,6 +143,7 @@ Generate audio from code — no external audio files needed. Pure NumPy, no extr
 | `effect_scanlines` | Retro CRT scanline effect with flicker |
 | `effect_noise` | Film grain and digital noise |
 | `effect_glow` | Bloom/glow for highlights |
+| `video_apply_mask` | Apply image mask with edge feathering |
 
 ---
 


### PR DESCRIPTION
Fixes documentation that became outdated or incomplete after the v1.2.6 release.

### Changes
- **CHANGELOG.md**: Added missing `## 1.2.6` release entry
- **README.md**: Fixed "82 tools" → "90 tools", corrected category counts (Core Video 26→29, AI-Powered 10→11, Visual Effects 5→6, Analysis 9→8)
- **TOOLS.md**: Fixed "82 descriptions" → "90 descriptions", added 4 undocumented tools (`video_export`, `video_normalize_audio`, `video_batch`, `video_apply_mask`)
- **PYTHON_CLIENT.md**: Restructured from 1 table into 7 organized sections. Added 31 previously undocumented methods across AI, Audio Synthesis, Quality & Analysis, Visual Effects/Transitions/Layout, and Core Editing.
- **ROADMAP.md**: Updated shipped version to 1.2.6
- **TESTING.md**: Added Remotion tests section, overall 905 test count, adversarial tests mention
- **AI_AGENT_DISCOVERY.md**: Added client mixin entry points
- **INTEGRATION-ROADMAP.md**: Marked Remotion as deprecated in summary table

### Verification
- All 905 tests pass
- `python3 -c 'import mcp_video'` clean