### PR TITLE
chore: v1.2.6 follow-up — deprecation, workflow, docs

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,6 +4,26 @@ v1.2.6 shipped. 90 MCP tools, 905 tests, Hyperframes integration, Remotion depre
 
 ---
 
+## 📋 Planned for v1.3.0
+
+### Revideo Integration — RESEARCHED, DEFERRED
+
+Revideo (MIT licensed, canvas-based) was evaluated as a Remotion replacement. However, Revideo lacks a standalone CLI for external project rendering — it requires running `npm run render` inside the project directory via a TypeScript `render.ts` script. This architecture does not map cleanly to the engine → server → client → CLI pattern used by Hyperframes and Remotion.
+
+**Decision:** Defer Revideo integration. Hyperframes (HTML-native, Apache 2.0) covers the code-to-video use case well. If demand emerges, reconsider.
+
+### Remotion Removal Timeline
+
+- **v1.2.x (current):** Remotion tools emit `DeprecationWarning`
+- **v1.3.0:** Remotion tools moved to optional extra `mcp-video[remotion]`; warnings upgraded to `FutureWarning`
+- **v2.0.0:** Remotion integration removed entirely (breaking change)
+
+### Documentation
+- [ ] Add usage examples to `docs/PYTHON_CLIENT.md` for AI, audio synthesis, and effects pipelines
+- [ ] Add `04-hyperframes-video` workflow template
+
+---
+
 ## ✅ Completed in v1.2.5 (2026-04-27)
 
 ### Hyperframes Integration

--- a/docs/PYTHON_CLIENT.md
+++ b/docs/PYTHON_CLIENT.md
@@ -20,6 +20,87 @@ Analysis methods return report models or dictionaries.
 
 ---
 
+## Usage Examples
+
+### Pipeline chaining
+
+```python
+from mcp_video import Client
+
+client = Client()
+
+# Chain operations — each step receives the previous output_path
+result = client.pipeline(
+    [
+        {"op": "trim", "start": "00:00:10", "duration": "00:00:30"},
+        {"op": "resize", "aspect_ratio": "9:16"},
+        {"op": "add_text", "text": "Subscribe!", "position": "bottom-center", "size": 48},
+        {"op": "normalize_audio", "target_lufs": -14},
+        {"op": "export", "quality": "high"},
+    ],
+    output_path="final.mp4",
+)
+print(result.output_path)
+```
+
+### AI analysis + extract highlights
+
+```python
+info = client.analyze_video("interview.mp4")
+scenes = info["scenes"]  # Auto-detected scene changes
+
+# Extract a thumbnail from each scene
+for i, (start, end) in enumerate(scenes[:5]):
+    client.thumbnail("interview.mp4", timestamp=start, output=f"scene_{i}.jpg")
+```
+
+### Generate audio and composite
+
+```python
+# Create a tech drone + success chimes
+drone = client.audio_preset("drone-tech", "drone.wav", duration=20, intensity=0.3)
+chime = client.audio_preset("chime-success", "chime.wav", intensity=0.6)
+
+soundtrack = client.audio_compose(
+    tracks=[
+        {"file": drone, "volume": 0.3, "start": 0},
+        {"file": chime, "volume": 0.8, "start": 5},
+        {"file": chime, "volume": 0.8, "start": 15},
+    ],
+    duration=20,
+    output="soundtrack.wav",
+)
+```
+
+### Effects chain
+
+```python
+client.effect_vignette("raw.mp4", "vignette.mp4", intensity=0.4)
+client.effect_glow("vignette.mp4", "glow.mp4", intensity=0.3)
+client.transition_glitch("scene1.mp4", "scene2.mp4", "glitch.mp4", duration=0.5)
+```
+
+### Hyperframes workflow
+
+```python
+# Scaffold, render, post-process
+project = client.hyperframes_init("my-video", template="warm-grain")
+client.hyperframes_validate(project.project_path)
+render = client.hyperframes_render(project.project_path, output="base.mp4")
+client.add_text(render.output_path, text="EPISODE 1", position="top-center", output="final.mp4")
+```
+
+### Quality gate before publishing
+
+```python
+checkpoint = client.release_checkpoint("final.mp4", min_score=0.8)
+print(checkpoint["thumbnail"])      # Review thumbnail
+print(checkpoint["storyboard"])     # Review key frames
+print(checkpoint["quality_score"])  # Must pass min_score
+```
+
+---
+
 ## Core Editing Methods
 
 | Method | Returns | Description |

--- a/explainer-video/package-lock.json
+++ b/explainer-video/package-lock.json
@@ -2306,9 +2306,9 @@
       "license": "ISC"
     },
     "node_modules/postcss": {
-      "version": "8.5.1",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.1.tgz",
-      "integrity": "sha512-6oz2beyjc5VMn/KV1pPw8fliQkhBXrVn1Z3TVyqZxU8kZpzEKhBdmCFqI6ZbmGtamQvQGuU1sgPTk8ZrXDD7jQ==",
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
       "funding": [
         {
           "type": "opencollective",
@@ -2325,7 +2325,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.8",
+        "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/explainer-video/package.json
+++ b/explainer-video/package.json
@@ -17,5 +17,8 @@
   "devDependencies": {
     "@types/react": "^19.2.14",
     "typescript": "^6.0.3"
+  },
+  "overrides": {
+    "postcss": ">=8.5.10"
   }
 }

--- a/mcp_video/client/remotion.py
+++ b/mcp_video/client/remotion.py
@@ -6,11 +6,7 @@ import warnings
 
 from ..errors import MCPVideoError
 
-_REMOTION_DEPRECATION_MSG = (
-    "Remotion integration is deprecated and will be removed in a future version. "
-    "Please migrate to Hyperframes (HTML-native, fully open source under Apache 2.0) "
-    "or Revideo (Canvas-based, MIT licensed)."
-)
+_REMOTION_DEPRECATION_MSG = "Remotion is deprecated. Migrate to Hyperframes or Revideo."
 
 
 def _warn_remotion_deprecated() -> None:

--- a/mcp_video/server_tools_remotion.py
+++ b/mcp_video/server_tools_remotion.py
@@ -13,11 +13,7 @@ from .validation import VALID_CODECS, VALID_REMOTION_TEMPLATES
 from .ffmpeg_helpers import _validate_project_path
 
 
-_REMOTION_DEPRECATION_MSG = (
-    "Remotion integration is deprecated and will be removed in a future version. "
-    "Please migrate to Hyperframes (HTML-native, fully open source under Apache 2.0) "
-    "or Revideo (Canvas-based, MIT licensed)."
-)
+_REMOTION_DEPRECATION_MSG = "Remotion is deprecated. Migrate to Hyperframes or Revideo."
 
 
 def _warn_remotion_deprecated() -> None:

--- a/tests/test_remotion_deprecation.py
+++ b/tests/test_remotion_deprecation.py
@@ -24,49 +24,49 @@ class TestRemotionClientDeprecation:
     @patch("mcp_video.remotion_engine.render")
     def test_remotion_render_warns(self, mock_render, client):
         mock_render.return_value = {"output_path": "/tmp/out.mp4"}
-        with pytest.warns(DeprecationWarning, match="Remotion integration is deprecated"):
+        with pytest.warns(DeprecationWarning, match="Remotion is deprecated"):
             client.remotion_render("/tmp/proj", "Comp")
 
     @patch("mcp_video.remotion_engine.compositions")
     def test_remotion_compositions_warns(self, mock_compositions, client):
         mock_compositions.return_value = []
-        with pytest.warns(DeprecationWarning, match="Remotion integration is deprecated"):
+        with pytest.warns(DeprecationWarning, match="Remotion is deprecated"):
             client.remotion_compositions("/tmp/proj")
 
     @patch("mcp_video.remotion_engine.studio")
     def test_remotion_studio_warns(self, mock_studio, client):
         mock_studio.return_value = {"url": "http://localhost:3000"}
-        with pytest.warns(DeprecationWarning, match="Remotion integration is deprecated"):
+        with pytest.warns(DeprecationWarning, match="Remotion is deprecated"):
             client.remotion_studio("/tmp/proj")
 
     @patch("mcp_video.remotion_engine.still")
     def test_remotion_still_warns(self, mock_still, client):
         mock_still.return_value = {"output_path": "/tmp/frame.png"}
-        with pytest.warns(DeprecationWarning, match="Remotion integration is deprecated"):
+        with pytest.warns(DeprecationWarning, match="Remotion is deprecated"):
             client.remotion_still("/tmp/proj", "Comp")
 
     @patch("mcp_video.remotion_engine.create_project")
     def test_remotion_create_project_warns(self, mock_create, client):
         mock_create.return_value = {"project_path": "/tmp/proj"}
-        with pytest.warns(DeprecationWarning, match="Remotion integration is deprecated"):
+        with pytest.warns(DeprecationWarning, match="Remotion is deprecated"):
             client.remotion_create_project("my-project")
 
     @patch("mcp_video.remotion_engine.scaffold_template")
     def test_remotion_scaffold_template_warns(self, mock_scaffold, client):
         mock_scaffold.return_value = None
-        with pytest.warns(DeprecationWarning, match="Remotion integration is deprecated"):
+        with pytest.warns(DeprecationWarning, match="Remotion is deprecated"):
             client.remotion_scaffold_template("/tmp/proj", {}, "test")
 
     @patch("mcp_video.remotion_engine.validate")
     def test_remotion_validate_warns(self, mock_validate, client):
         mock_validate.return_value = {"valid": True}
-        with pytest.warns(DeprecationWarning, match="Remotion integration is deprecated"):
+        with pytest.warns(DeprecationWarning, match="Remotion is deprecated"):
             client.remotion_validate("/tmp/proj")
 
     @patch("mcp_video.remotion_engine.render_and_post")
     def test_remotion_to_mcpvideo_warns(self, mock_pipeline, client):
         mock_pipeline.return_value = {"final_output": "/tmp/out.mp4"}
-        with pytest.warns(DeprecationWarning, match="Remotion integration is deprecated"):
+        with pytest.warns(DeprecationWarning, match="Remotion is deprecated"):
             client.remotion_to_mcpvideo("/tmp/proj", "Comp", [])
 
 
@@ -79,7 +79,7 @@ class TestRemotionServerToolDeprecation:
         mock_render.return_value = MagicMock()
         from mcp_video.server_tools_remotion import remotion_render
 
-        with pytest.warns(DeprecationWarning, match="Remotion integration is deprecated"):
+        with pytest.warns(DeprecationWarning, match="Remotion is deprecated"):
             remotion_render("/tmp/proj", "Comp")
 
     @patch("mcp_video.server_tools_remotion._validate_project_path", return_value="/tmp/proj")
@@ -88,5 +88,5 @@ class TestRemotionServerToolDeprecation:
         mock_compositions.return_value = MagicMock()
         from mcp_video.server_tools_remotion import remotion_compositions
 
-        with pytest.warns(DeprecationWarning, match="Remotion integration is deprecated"):
+        with pytest.warns(DeprecationWarning, match="Remotion is deprecated"):
             remotion_compositions("/tmp/proj")

--- a/workflows/04-hyperframes-video/CONTEXT.md
+++ b/workflows/04-hyperframes-video/CONTEXT.md
@@ -1,0 +1,36 @@
+# 04-hyperframes-video
+
+Create a video from scratch using Hyperframes (HTML-native, Apache 2.0), then post-process with mcp-video.
+
+## Inputs
+
+| Source | File/Location | Description |
+|---|---|---|
+| Project name | User provided | Name for the new Hyperframes project |
+| Template | User provided | `blank`, `warm-grain`, or `swiss-grid` |
+| Blocks | User provided | Optional blocks from Hyperframes catalog |
+| Post-process | User provided | mcp-video filters, resize, text overlay, etc. |
+
+## Process
+
+1. **01-init**: Use `hyperframes_init` to scaffold a new project
+2. **02-blocks**: Use `hyperframes_add_block` to install catalog blocks (optional)
+3. **03-validate**: Use `hyperframes_validate` to check project structure
+4. **04-render**: Use `hyperframes_render` to generate the base video
+5. **05-post-process**: Use mcp-video tools (resize, add_text, watermark, export)
+
+## Outputs
+
+| Artifact | Location | Format |
+|---|---|---|
+| Hyperframes project | `output/{project_name}/` | HTML/TypeScript project |
+| Base render | `output/04_render.mp4` | Raw Hyperframes output |
+| Final video | `output/final_video.mp4` | Post-processed MP4 |
+
+## Quality gates
+
+- [ ] Project validates without errors
+- [ ] Render completes successfully
+- [ ] Post-processed video meets target specs (resolution, duration)
+- [ ] Text overlays are readable
+- [ ] Audio is present and normalized

--- a/workflows/04-hyperframes-video/workflow.py
+++ b/workflows/04-hyperframes-video/workflow.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""
+Hyperframes Video Workflow for mcp-video.
+
+Creates a video from scratch using Hyperframes (HTML-native, Apache 2.0),
+then post-processes with mcp-video client methods.
+
+Requires: Node.js 22+ and npx
+
+Usage:
+    python workflow.py [project_name] [template]
+
+Templates: blank, warm-grain, swiss-grid
+
+The script runs 5 stages and outputs the final video to output/final_video.mp4.
+"""
+
+import os
+import sys
+
+from mcp_video import Client
+
+client = Client()
+
+PROJECT_NAME = sys.argv[1] if len(sys.argv) > 1 else "my-hyperframes-video"
+TEMPLATE = sys.argv[2] if len(sys.argv) > 2 else "blank"
+OUTPUT_DIR = os.path.join(os.path.dirname(__file__), "output")
+os.makedirs(OUTPUT_DIR, exist_ok=True)
+
+
+def main() -> None:
+    print("=" * 60)
+    print("04-hyperframes-video workflow")
+    print("=" * 60)
+
+    # Stage 1: Initialize Hyperframes project
+    print("\n[1/5] Initializing Hyperframes project...")
+    project = client.hyperframes_init(
+        name=PROJECT_NAME,
+        template=TEMPLATE,
+        output_dir=OUTPUT_DIR,
+    )
+    project_path = project.project_path
+    print(f"   -> {project_path}")
+
+    # Stage 2: Add blocks (optional — customize as needed)
+    print("\n[2/5] Adding blocks from catalog...")
+    blocks_to_add = ["text", "image"]  # Customize for your use case
+    for block in blocks_to_add:
+        try:
+            client.hyperframes_add_block(project_path, block)
+            print(f"   -> Added block: {block}")
+        except Exception as e:
+            print(f"   -> Skipped block '{block}': {e}")
+
+    # Stage 3: Validate project
+    print("\n[3/5] Validating project...")
+    validation = client.hyperframes_validate(project_path)
+    if not validation.valid:
+        print(f"   -> Validation failed: {validation.issues}")
+        sys.exit(1)
+    print("   -> Project is valid")
+
+    # Stage 4: Render base video
+    print("\n[4/5] Rendering video with Hyperframes...")
+    render = client.hyperframes_render(
+        project_path=project_path,
+        output=os.path.join(OUTPUT_DIR, "04_render.mp4"),
+        quality="high",
+    )
+    print(f"   -> {render.output_path}")
+
+    # Stage 5: Post-process with mcp-video
+    print("\n[5/5] Post-processing with mcp-video...")
+
+    # Example: add a watermark and export
+    watermarked = client.watermark(
+        video=render.output_path,
+        image="logo.png",  # Replace with your logo path
+        position="bottom-right",
+        opacity=0.7,
+        output=os.path.join(OUTPUT_DIR, "05_watermarked.mp4"),
+    )
+    print(f"   -> Watermarked: {watermarked.output_path}")
+
+    final = client.convert(
+        watermarked.output_path,
+        format="mp4",
+        quality="high",
+        output=os.path.join(OUTPUT_DIR, "final_video.mp4"),
+    )
+    print(f"   -> Final: {final.output_path}")
+
+    print("\n" + "=" * 60)
+    print("Workflow complete! Review output/final_video.mp4")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    main()

--- a/workflows/CONTEXT.md
+++ b/workflows/CONTEXT.md
@@ -7,6 +7,7 @@
 | Turn a long video into a TikTok / Short / Reel | `01-social-media-clip` | 5 | 2-5 min |
 | Extract a podcast highlight with chapters and captions | `02-podcast-clip` | 6 | 5-10 min |
 | Build a branded explainer video from scratch | `03-explainer-video` | 7 | 30-60 min |
+| Create a video with Hyperframes, then post-process | `04-hyperframes-video` | 5 | 10-20 min |
 
 ## How to run a workflow
 

--- a/workflows/README.md
+++ b/workflows/README.md
@@ -9,6 +9,7 @@ ICM-style staged pipelines for common video productions.
 | `01-social-media-clip` | Turn landscape video into TikTok / Short / Reel | 5 |
 | `02-podcast-clip` | Extract highlight with chapters and captions | 6 |
 | `03-explainer-video` | Build branded explainer from scratch | 7 |
+| `04-hyperframes-video` | Create video with Hyperframes, then post-process | 5 |
 
 ## How to use
 


### PR DESCRIPTION
Follow-up improvements after the v1.2.6 release.

### Changes
- **Shorten Remotion deprecation warning** — 183 chars → 55 chars ()
- **Fix deprecation tests** — Update regex to match new warning
- **Fix postcss vulnerability** — Add npm override in explainer-video/package.json
- **Add Hyperframes workflow template** —  with 5-stage pipeline
- **PYTHON_CLIENT.md usage examples** — Pipeline chaining, AI analysis, audio synthesis, effects, Hyperframes workflow, quality gates
- **ROADMAP.md** — Remotion removal timeline (v1.3.0 → v2.0.0), Revideo deferral rationale
- **Workflow routing tables** — Updated README.md and CONTEXT.md

### Verification
- All 905 tests pass
-  clean