### PR TITLE
ci: migrate to self-hosted runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   changes:
     name: Change detection
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, macOS, ARM64]
     outputs:
       code: ${{ steps.classify.outputs.code }}
       docker: ${{ steps.classify.outputs.docker }}
@@ -47,7 +47,7 @@ jobs:
 
   repository-readiness:
     name: Repository readiness
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, macOS, ARM64]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
@@ -58,7 +58,7 @@ jobs:
 
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, macOS, ARM64]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
@@ -73,7 +73,7 @@ jobs:
 
   package-surface:
     name: Package surface
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, macOS, ARM64]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
@@ -89,7 +89,7 @@ jobs:
   test:
     name: Test (Python 3.12)
     needs: changes
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, macOS, ARM64]
     steps:
       - name: Skip tests
         if: github.event_name == 'pull_request' && needs.changes.outputs.code != 'true'
@@ -114,7 +114,7 @@ jobs:
   compatibility:
     name: Compatibility (Python ${{ matrix.python-version }})
     needs: changes
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, macOS, ARM64]
     strategy:
       fail-fast: false
       matrix:
@@ -143,7 +143,7 @@ jobs:
   docker:
     name: Docker build
     needs: changes
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, macOS, ARM64]
     steps:
       - uses: actions/checkout@v6
       - name: Skip Docker build

--- a/.github/workflows/integration-smoke.yml
+++ b/.github/workflows/integration-smoke.yml
@@ -22,7 +22,7 @@ on:
 jobs:
   base-cli-and-doctor:
     name: Base CLI and doctor
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, macOS, ARM64]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
@@ -58,7 +58,7 @@ jobs:
 
   ffmpeg-smoke:
     name: FFmpeg operation smoke
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, macOS, ARM64]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
@@ -80,7 +80,7 @@ jobs:
 
   image-extra-smoke:
     name: Image extra smoke
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, macOS, ARM64]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
@@ -108,7 +108,7 @@ jobs:
 
   ai-module-smoke:
     name: AI module metadata smoke
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, macOS, ARM64]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -17,7 +17,7 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, macOS, ARM64]
     steps:
       - uses: actions/checkout@v6
       - name: Check forbidden tracked artifacts

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   surface-audit:
     name: Check tracked release surface
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, macOS, ARM64]
     steps:
       - uses: actions/checkout@v6
       - name: Check forbidden tracked artifacts
@@ -20,7 +20,7 @@ jobs:
   build:
     name: Build package
     needs: surface-audit
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, macOS, ARM64]
     steps:
       - uses: actions/checkout@v6
         with:
@@ -45,7 +45,7 @@ jobs:
   publish:
     name: Publish to PyPI
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, macOS, ARM64]
     environment: pypi
     permissions:
       contents: read


### PR DESCRIPTION
Switch from GitHub-hosted to self-hosted macOS ARM64 runner to conserve Actions minutes.