### PR TITLE
fix: ruff lint errors in hyperframes_engine (Candidate J)

### DIFF
--- a/mcp_video/engine_audio_normalize.py
+++ b/mcp_video/engine_audio_normalize.py
@@ -12,6 +12,7 @@ from .paths import (
     _auto_output,
 )
 from .ffmpeg_helpers import (
+    _build_ffmpeg_cmd,
     _run_ffmpeg,
     _sanitize_ffmpeg_number,
 )
@@ -53,20 +54,13 @@ def normalize_audio(
 
     with _timed_operation() as timing:
         _run_ffmpeg(
-            [
-                "-i",
+            _build_ffmpeg_cmd(
                 input_path,
-                "-af",
-                f"loudnorm=I={safe_target_lufs}:TP={safe_tp}:LRA={safe_lra}",
-                "-c:v",
-                "copy",
-                "-c:a",
-                "aac",
-                "-b:a",
-                "192k",
-                *_movflags_args(output),
-                output,
-            ]
+                output_path=output,
+                video_codec="copy",
+                audio_filter=f"loudnorm=I={safe_target_lufs}:TP={safe_tp}:LRA={safe_lra}",
+                audio_bitrate="192k",
+            )
         )
 
     return _build_edit_result(

--- a/mcp_video/engine_crop.py
+++ b/mcp_video/engine_crop.py
@@ -13,6 +13,7 @@ from .paths import (
     _auto_output,
 )
 from .ffmpeg_helpers import (
+    _build_ffmpeg_cmd,
     _run_ffmpeg,
 )
 from .errors import MCPVideoError
@@ -87,19 +88,12 @@ def crop(
 
     with _timed_operation() as timing:
         _run_ffmpeg(
-            [
-                "-i",
+            _build_ffmpeg_cmd(
                 input_path,
-                "-vf",
-                crop_filter,
-                "-c:v",
-                "libx264",
-                *_quality_args(),
-                "-c:a",
-                "copy",
-                *_movflags_args(output),
-                output,
-            ]
+                output_path=output,
+                video_filter=crop_filter,
+                audio_codec="copy",
+            )
         )
 
     return _build_edit_result(

--- a/mcp_video/engine_edit.py
+++ b/mcp_video/engine_edit.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-from .defaults import DEFAULT_AUDIO_BITRATE, DEFAULT_CRF, DEFAULT_PRESET
+from .ffmpeg_helpers import _build_ffmpeg_cmd
 from .ffmpeg_helpers import _validate_input_path, _validate_output_path
-from .engine_runtime_utils import _build_edit_result, _movflags_args, _timed_operation
+from .engine_runtime_utils import _build_edit_result, _timed_operation
 from .paths import _auto_output
 from .ffmpeg_helpers import _run_ffmpeg
 from .errors import MCPVideoError
@@ -100,37 +100,21 @@ def trim(
                 code="invalid_parameter",
             )
 
-    args = []
+    prefix: list[str] = []
     if not accurate and start:
         # Input seeking — fast but may land on nearest keyframe
-        args.extend(["-ss", str(start)])
-    args.extend(["-i", input_path])
+        prefix.extend(["-ss", str(start)])
+    prefix.extend(["-i", input_path])
     if accurate and start:
         # Output seeking — frame accurate but slower
-        args.extend(["-ss", str(start)])
+        prefix.extend(["-ss", str(start)])
     if duration:
-        args.extend(["-t", str(duration)])
+        prefix.extend(["-t", str(duration)])
     elif end:
-        args.extend(["-to", str(end)])
-    args.extend(
-        [
-            "-c:v",
-            "libx264",
-            "-preset",
-            DEFAULT_PRESET,
-            "-crf",
-            str(DEFAULT_CRF),
-            "-c:a",
-            "aac",
-            "-b:a",
-            DEFAULT_AUDIO_BITRATE,
-            *_movflags_args(output),
-            output,
-        ]
-    )
+        prefix.extend(["-to", str(end)])
 
     with _timed_operation() as timing:
-        _run_ffmpeg(args)
+        _run_ffmpeg(prefix + _build_ffmpeg_cmd(output_path=output))
 
     return _build_edit_result(
         output,

--- a/mcp_video/engine_fade.py
+++ b/mcp_video/engine_fade.py
@@ -13,6 +13,7 @@ from .paths import (
     _auto_output,
 )
 from .ffmpeg_helpers import (
+    _build_ffmpeg_cmd,
     _run_ffmpeg,
     _sanitize_ffmpeg_number,
 )
@@ -51,19 +52,14 @@ def fade(
 
     with _timed_operation() as timing:
         _run_ffmpeg(
-            [
-                "-i",
+            _build_ffmpeg_cmd(
                 input_path,
-                "-vf",
-                vf,
-                "-c:v",
-                "libx264",
-                *_quality_args(crf=crf, preset=preset),
-                "-c:a",
-                "copy",
-                *_movflags_args(output),
-                output,
-            ]
+                output_path=output,
+                video_filter=vf,
+                audio_codec="copy",
+                crf=crf,
+                preset=preset,
+            )
         )
 
     return _build_edit_result(

--- a/mcp_video/engine_filters.py
+++ b/mcp_video/engine_filters.py
@@ -17,6 +17,7 @@ from .paths import (
     _auto_output,
 )
 from .ffmpeg_helpers import (
+    _build_ffmpeg_cmd,
     _run_ffmpeg,
     _sanitize_ffmpeg_number,
 )
@@ -195,38 +196,25 @@ def _run_audio_filter(input_path: str, filter_type: FilterType, filter_string: s
             code="audio_filter_no_audio",
         )
     _run_filter_ffmpeg(
-        [
-            "-i",
+        _build_ffmpeg_cmd(
             input_path,
-            "-af",
-            filter_string,
-            "-c:v",
-            "copy",
-            "-c:a",
-            "aac",
-            "-b:a",
-            DEFAULT_AUDIO_BITRATE,
-            *_movflags_args(output),
-            output,
-        ]
+            output_path=output,
+            video_codec="copy",
+            audio_filter=filter_string,
+        )
     )
 
 
 def _run_video_filter(input_path: str, filter_string: str, output: str, crf: int | None, preset: str | None) -> None:
     _run_filter_ffmpeg(
-        [
-            "-i",
+        _build_ffmpeg_cmd(
             input_path,
-            "-vf",
-            filter_string,
-            "-c:v",
-            "libx264",
-            *_quality_args(crf=crf, preset=preset),
-            "-c:a",
-            "copy",
-            *_movflags_args(output),
-            output,
-        ]
+            output_path=output,
+            video_filter=filter_string,
+            audio_codec="copy",
+            crf=crf,
+            preset=preset,
+        )
     )
 
 

--- a/mcp_video/engine_hls.py
+++ b/mcp_video/engine_hls.py
@@ -6,7 +6,7 @@ import os
 
 from .engine_probe import probe
 from .engine_runtime_utils import _build_edit_result, _timed_operation
-from .ffmpeg_helpers import _run_ffmpeg
+from .ffmpeg_helpers import _build_ffmpeg_cmd, _run_ffmpeg
 from .ffmpeg_helpers import _validate_input_path
 from .models import EditResult
 
@@ -53,31 +53,25 @@ def hls_segment(
             scale_filter = f"scale=-2:{target_h}"
 
             _run_ffmpeg(
-                [
-                    "-i",
+                _build_ffmpeg_cmd(
                     input_path,
-                    "-vf",
-                    scale_filter,
-                    "-c:v",
-                    "libx264",
-                    "-crf",
-                    "23",
-                    "-preset",
-                    "fast",
-                    "-c:a",
-                    "aac",
-                    "-b:a",
-                    "128k",
-                    "-f",
-                    "hls",
-                    "-hls_time",
-                    str(segment_duration),
-                    "-hls_playlist_type",
-                    "vod",
-                    "-hls_segment_filename",
-                    os.path.join(q_dir, "segment_%03d.ts"),
-                    os.path.join(q_dir, "playlist.m3u8"),
-                ]
+                    output_path=os.path.join(q_dir, "playlist.m3u8"),
+                    video_filter=scale_filter,
+                    crf=23,
+                    preset="fast",
+                    audio_bitrate="128k",
+                    movflags=False,
+                    extra=[
+                        "-f",
+                        "hls",
+                        "-hls_time",
+                        str(segment_duration),
+                        "-hls_playlist_type",
+                        "vod",
+                        "-hls_segment_filename",
+                        os.path.join(q_dir, "segment_%03d.ts"),
+                    ],
+                )
             )
 
         # Write a master playlist that references all variants

--- a/mcp_video/engine_mask.py
+++ b/mcp_video/engine_mask.py
@@ -14,6 +14,7 @@ from .paths import (
     _auto_output,
 )
 from .ffmpeg_helpers import (
+    _build_ffmpeg_cmd,
     _run_ffmpeg,
     _sanitize_ffmpeg_number,
 )
@@ -48,25 +49,20 @@ def apply_mask(
 
     with _timed_operation() as timing:
         _run_ffmpeg(
-            [
-                "-i",
+            _build_ffmpeg_cmd(
                 input_path,
-                "-i",
                 mask_path,
-                "-filter_complex",
-                filter_complex,
-                "-map",
-                "[out]",
-                "-map",
-                "0:a?",
-                "-c:v",
-                "libx264",
-                *_quality_args(),
-                "-c:a",
-                "copy",
-                *_movflags_args(output),
-                output,
-            ]
+                output_path=output,
+                audio_codec="copy",
+                extra=[
+                    "-filter_complex",
+                    filter_complex,
+                    "-map",
+                    "[out]",
+                    "-map",
+                    "0:a?",
+                ],
+            )
         )
 
     return _build_edit_result(

--- a/mcp_video/engine_merge.py
+++ b/mcp_video/engine_merge.py
@@ -17,7 +17,7 @@ from .defaults import (
 from .engine_probe import get_duration, probe
 from .engine_runtime_utils import _build_edit_result, _movflags_args, _timed_operation
 from .paths import _auto_output
-from .ffmpeg_helpers import _run_ffmpeg
+from .ffmpeg_helpers import _build_ffmpeg_cmd, _run_ffmpeg
 from .errors import InputFileError, MCPVideoError
 from .ffmpeg_helpers import _escape_ffmpeg_filter_value, _validate_input_path, _validate_output_path
 from .models import EditResult
@@ -47,29 +47,21 @@ def _normalize_clips(
         elif info.rotation == 270:
             vf_parts.insert(0, "transpose=1")
         _run_ffmpeg(
-            [
-                "-i",
+            _build_ffmpeg_cmd(
                 clip,
-                "-vf",
-                ",".join(vf_parts),
-                "-c:v",
-                "libx264",
-                "-preset",
-                DEFAULT_PRESET,
-                "-crf",
-                str(DEFAULT_CRF),
-                "-c:a",
-                "aac",
-                "-b:a",
-                DEFAULT_AUDIO_BITRATE,
-                "-r",
-                str(DEFAULT_FPS),
-                "-ar",
-                str(DEFAULT_SAMPLE_RATE),
-                "-ac",
-                str(DEFAULT_AUDIO_CHANNELS),
-                norm_path,
-            ]
+                output_path=norm_path,
+                video_filter=",".join(vf_parts),
+                crf=DEFAULT_CRF,
+                preset=DEFAULT_PRESET,
+                extra=[
+                    "-r",
+                    str(DEFAULT_FPS),
+                    "-ar",
+                    str(DEFAULT_SAMPLE_RATE),
+                    "-ac",
+                    str(DEFAULT_AUDIO_CHANNELS),
+                ],
+            )
         )
         working.append(norm_path)
     return working
@@ -244,20 +236,33 @@ def _merge_with_transitions(
         map_args = ["-map", "[vout]"]
         audio_codec_args = ["-an"]
 
-    _run_ffmpeg(
-        [
-            *inputs,
-            "-filter_complex",
-            filter_complex,
-            *map_args,
-            "-c:v",
-            "libx264",
-            "-preset",
-            DEFAULT_PRESET,
-            "-crf",
-            str(DEFAULT_CRF),
-            *audio_codec_args,
-            *_movflags_args(output),
-            output,
-        ]
-    )
+    if has_audio:
+        _run_ffmpeg(
+            _build_ffmpeg_cmd(
+                *clips,
+                output_path=output,
+                crf=DEFAULT_CRF,
+                preset=DEFAULT_PRESET,
+                extra=[
+                    "-filter_complex",
+                    filter_complex,
+                    *map_args,
+                ],
+            )
+        )
+    else:
+        _run_ffmpeg(
+            _build_ffmpeg_cmd(
+                *clips,
+                output_path=output,
+                audio_codec=None,
+                crf=DEFAULT_CRF,
+                preset=DEFAULT_PRESET,
+                extra=[
+                    "-an",
+                    "-filter_complex",
+                    filter_complex,
+                    *map_args,
+                ],
+            )
+        )

--- a/mcp_video/engine_overlay.py
+++ b/mcp_video/engine_overlay.py
@@ -17,6 +17,7 @@ from .models import (
     _resolve_position,
 )
 from .ffmpeg_helpers import (
+    _build_ffmpeg_cmd,
     _run_ffmpeg,
     _sanitize_ffmpeg_number,
 )
@@ -67,23 +68,14 @@ def overlay_video(
 
     with _timed_operation() as timing:
         _run_ffmpeg(
-            [
-                "-i",
+            _build_ffmpeg_cmd(
                 background_path,
-                "-i",
                 overlay_path,
-                "-filter_complex",
-                filter_complex,
-                "-c:v",
-                "libx264",
-                *_quality_args(crf=crf, preset=preset),
-                "-c:a",
-                "aac",
-                "-b:a",
-                DEFAULT_AUDIO_BITRATE,
-                *_movflags_args(output),
-                output,
-            ]
+                output_path=output,
+                crf=crf,
+                preset=preset,
+                extra=["-filter_complex", filter_complex],
+            )
         )
 
     return _build_edit_result(

--- a/mcp_video/engine_preview.py
+++ b/mcp_video/engine_preview.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-from .ffmpeg_helpers import _validate_input_path, _validate_output_path
+from .ffmpeg_helpers import _build_ffmpeg_cmd, _validate_input_path, _validate_output_path
 from .engine_probe import probe
-from .engine_runtime_utils import _build_edit_result, _movflags_args, _timed_operation
+from .engine_runtime_utils import _build_edit_result, _timed_operation
 from .paths import _auto_output
 from .ffmpeg_helpers import _run_ffmpeg
 from .errors import MCPVideoError
@@ -30,26 +30,15 @@ def preview(
 
     with _timed_operation() as timing:
         _run_ffmpeg(
-            [
-                "-i",
+            _build_ffmpeg_cmd(
                 input_path,
-                "-vf",
-                f"scale={w}:{h}",
-                "-c:v",
-                "libx264",
-                "-crf",
-                str(PREVIEW_PRESETS["crf"]),
-                "-preset",
-                PREVIEW_PRESETS["preset"],
-                "-c:a",
-                "aac",
-                "-b:a",
-                "64k",
-                "-ac",
-                "2",
-                *_movflags_args(output),
-                output,
-            ]
+                output_path=output,
+                video_filter=f"scale={w}:{h}",
+                crf=PREVIEW_PRESETS["crf"],
+                preset=PREVIEW_PRESETS["preset"],
+                audio_bitrate="64k",
+                extra=["-ac", "2"],
+            )
         )
 
     return _build_edit_result(

--- a/mcp_video/engine_resize.py
+++ b/mcp_video/engine_resize.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
-from .defaults import DEFAULT_AUDIO_BITRATE
+from .ffmpeg_helpers import _build_ffmpeg_cmd
 from .ffmpeg_helpers import _validate_input_path, _validate_output_path
 from .engine_probe import probe
-from .engine_runtime_utils import _build_edit_result, _movflags_args, _timed_operation
+from .engine_runtime_utils import _build_edit_result, _timed_operation
 from .paths import _auto_output
 from .ffmpeg_helpers import _run_ffmpeg
 from .errors import MCPVideoError
@@ -59,24 +59,13 @@ def resize(
 
     with _timed_operation() as timing:
         _run_ffmpeg(
-            [
-                "-i",
+            _build_ffmpeg_cmd(
                 input_path,
-                "-vf",
-                vf,
-                "-c:v",
-                "libx264",
-                "-crf",
-                str(preset["crf"]),
-                "-preset",
-                preset["preset"],
-                "-c:a",
-                "aac",
-                "-b:a",
-                DEFAULT_AUDIO_BITRATE,
-                *_movflags_args(output),
-                output,
-            ]
+                output_path=output,
+                video_filter=vf,
+                crf=preset["crf"],
+                preset=preset["preset"],
+            )
         )
 
     return _build_edit_result(

--- a/mcp_video/engine_reverse.py
+++ b/mcp_video/engine_reverse.py
@@ -2,18 +2,16 @@
 
 from __future__ import annotations
 
-from .defaults import DEFAULT_AUDIO_BITRATE
 from .engine_probe import probe
 from .engine_runtime_utils import (
     _build_edit_result,
-    _movflags_args,
-    _quality_args,
     _timed_operation,
 )
 from .paths import (
     _auto_output,
 )
 from .ffmpeg_helpers import (
+    _build_ffmpeg_cmd,
     _run_ffmpeg,
 )
 from .ffmpeg_helpers import _validate_input_path, _validate_output_path
@@ -36,22 +34,26 @@ def reverse(
 
     input_info = probe(input_path)
 
-    args = ["-i", input_path, "-vf", "reverse"]
-    # Only reverse audio if the input has an audio stream
-    if input_info.audio_codec:
-        args += ["-af", "areverse", "-c:a", "aac", "-b:a", DEFAULT_AUDIO_BITRATE]
-    else:
-        args += ["-an"]
-    args += ["-c:v", "libx264", *_quality_args()]
-
     with _timed_operation() as timing:
-        _run_ffmpeg(
-            args
-            + _movflags_args(output)
-            + [
-                output,
-            ]
-        )
+        if input_info.audio_codec:
+            _run_ffmpeg(
+                _build_ffmpeg_cmd(
+                    input_path,
+                    output_path=output,
+                    video_filter="reverse",
+                    audio_filter="areverse",
+                )
+            )
+        else:
+            _run_ffmpeg(
+                _build_ffmpeg_cmd(
+                    input_path,
+                    output_path=output,
+                    video_filter="reverse",
+                    audio_codec=None,
+                    extra=["-an"],
+                )
+            )
 
     return _build_edit_result(
         output,

--- a/mcp_video/engine_rotate.py
+++ b/mcp_video/engine_rotate.py
@@ -2,17 +2,15 @@
 
 from __future__ import annotations
 
-from .defaults import DEFAULT_AUDIO_BITRATE
 from .engine_runtime_utils import (
     _build_edit_result,
-    _movflags_args,
-    _quality_args,
     _timed_operation,
 )
 from .paths import (
     _auto_output,
 )
 from .ffmpeg_helpers import (
+    _build_ffmpeg_cmd,
     _run_ffmpeg,
 )
 from .ffmpeg_helpers import _validate_input_path, _validate_output_path
@@ -59,21 +57,11 @@ def rotate(
 
     with _timed_operation() as timing:
         _run_ffmpeg(
-            [
-                "-i",
+            _build_ffmpeg_cmd(
                 input_path,
-                "-vf",
-                vf,
-                "-c:v",
-                "libx264",
-                *_quality_args(),
-                "-c:a",
-                "aac",
-                "-b:a",
-                DEFAULT_AUDIO_BITRATE,
-                *_movflags_args(output),
-                output,
-            ]
+                output_path=output,
+                video_filter=vf,
+            )
         )
 
     return _build_edit_result(

--- a/mcp_video/engine_speed.py
+++ b/mcp_video/engine_speed.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
-from .defaults import DEFAULT_AUDIO_BITRATE, DEFAULT_CRF, DEFAULT_PRESET
+from .ffmpeg_helpers import _build_ffmpeg_cmd
 from .ffmpeg_helpers import _validate_input_path, _validate_output_path
 from .engine_probe import probe
-from .engine_runtime_utils import _build_edit_result, _movflags_args, _timed_operation
+from .engine_runtime_utils import _build_edit_result, _timed_operation
 from .paths import _auto_output
 from .ffmpeg_helpers import _run_ffmpeg, _sanitize_ffmpeg_number
 from .errors import MCPVideoError
@@ -64,46 +64,28 @@ def speed(
     with _timed_operation() as timing:
         if has_audio:
             _run_ffmpeg(
-                [
-                    "-i",
+                _build_ffmpeg_cmd(
                     input_path,
-                    "-filter_complex",
-                    f"[0:v]{video_filter}[v];[0:a]{audio_filter}[a]",
-                    "-map",
-                    "[v]",
-                    "-map",
-                    "[a]",
-                    "-c:v",
-                    "libx264",
-                    "-preset",
-                    DEFAULT_PRESET,
-                    "-crf",
-                    str(DEFAULT_CRF),
-                    "-c:a",
-                    "aac",
-                    "-b:a",
-                    DEFAULT_AUDIO_BITRATE,
-                    *_movflags_args(output),
-                    output,
-                ]
+                    output_path=output,
+                    extra=[
+                        "-filter_complex",
+                        f"[0:v]{video_filter}[v];[0:a]{audio_filter}[a]",
+                        "-map",
+                        "[v]",
+                        "-map",
+                        "[a]",
+                    ],
+                )
             )
         else:
             _run_ffmpeg(
-                [
-                    "-i",
+                _build_ffmpeg_cmd(
                     input_path,
-                    "-vf",
-                    video_filter,
-                    "-an",
-                    "-c:v",
-                    "libx264",
-                    "-preset",
-                    DEFAULT_PRESET,
-                    "-crf",
-                    str(DEFAULT_CRF),
-                    *_movflags_args(output),
-                    output,
-                ]
+                    output_path=output,
+                    video_filter=video_filter,
+                    audio_codec=None,
+                    extra=["-an"],
+                )
             )
 
     return _build_edit_result(

--- a/mcp_video/engine_split_screen.py
+++ b/mcp_video/engine_split_screen.py
@@ -2,18 +2,16 @@
 
 from __future__ import annotations
 
-from .defaults import DEFAULT_AUDIO_BITRATE
 from .engine_probe import probe
 from .engine_runtime_utils import (
     _build_edit_result,
-    _movflags_args,
-    _quality_args,
     _timed_operation,
 )
 from .paths import (
     _auto_output,
 )
 from .ffmpeg_helpers import (
+    _build_ffmpeg_cmd,
     _run_ffmpeg,
     _sanitize_ffmpeg_number,
 )
@@ -46,27 +44,19 @@ def split_screen(
 
     with _timed_operation() as timing:
         _run_ffmpeg(
-            [
-                "-i",
+            _build_ffmpeg_cmd(
                 left_path,
-                "-i",
                 right_path,
-                "-filter_complex",
-                filter_complex,
-                "-map",
-                "[v]",
-                "-map",
-                "0:a?",
-                "-c:v",
-                "libx264",
-                *_quality_args(),
-                "-c:a",
-                "aac",
-                "-b:a",
-                DEFAULT_AUDIO_BITRATE,
-                *_movflags_args(output),
-                output,
-            ]
+                output_path=output,
+                extra=[
+                    "-filter_complex",
+                    filter_complex,
+                    "-map",
+                    "[v]",
+                    "-map",
+                    "0:a?",
+                ],
+            )
         )
 
     return _build_edit_result(

--- a/mcp_video/engine_stabilize.py
+++ b/mcp_video/engine_stabilize.py
@@ -7,12 +7,9 @@ import shutil
 import subprocess
 import tempfile
 
-from .defaults import DEFAULT_AUDIO_BITRATE
 from .engine_runtime_utils import (
     _build_edit_result,
     _ffmpeg,
-    _movflags_args,
-    _quality_args,
     _require_filter,
     _timed_operation,
 )
@@ -20,6 +17,7 @@ from .paths import (
     _auto_output,
 )
 from .ffmpeg_helpers import (
+    _build_ffmpeg_cmd,
     _run_ffmpeg,
     _sanitize_ffmpeg_number,
 )
@@ -59,21 +57,11 @@ def stabilize(
 
             safe_vectors_file = _escape_ffmpeg_filter_value(vectors_file)
             _run_ffmpeg(
-                [
-                    "-i",
+                _build_ffmpeg_cmd(
                     input_path,
-                    "-vf",
-                    f"vidstabtransform=input={safe_vectors_file}:smoothing={safe_smoothing}:zoom={safe_zooming}:crop=black",
-                    "-c:v",
-                    "libx264",
-                    *_quality_args(),
-                    "-c:a",
-                    "aac",
-                    "-b:a",
-                    DEFAULT_AUDIO_BITRATE,
-                    *_movflags_args(output),
-                    output,
-                ]
+                    output_path=output,
+                    video_filter=f"vidstabtransform=input={safe_vectors_file}:smoothing={safe_smoothing}:zoom={safe_zooming}:crop=black",
+                )
             )
         finally:
             shutil.rmtree(tmpdir, ignore_errors=True)

--- a/mcp_video/engine_subtitle_generate.py
+++ b/mcp_video/engine_subtitle_generate.py
@@ -13,6 +13,7 @@ from .paths import (
     _auto_output_dir,
 )
 from .ffmpeg_helpers import (
+    _build_ffmpeg_cmd,
     _run_ffmpeg,
 )
 from .errors import MCPVideoError
@@ -44,19 +45,12 @@ def generate_subtitles(
         _validate_output_path(video_out)
         escaped_srt = _escape_ffmpeg_filter_value(srt_file)
         _run_ffmpeg(
-            [
-                "-i",
+            _build_ffmpeg_cmd(
                 input_path,
-                "-vf",
-                f"subtitles={escaped_srt}",
-                "-c:v",
-                "libx264",
-                *_quality_args(),
-                "-c:a",
-                "copy",
-                *_movflags_args(video_out),
-                video_out,
-            ]
+                output_path=video_out,
+                video_filter=f"subtitles={escaped_srt}",
+                audio_codec="copy",
+            )
         )
         return SubtitleResult(
             srt_path=srt_file,

--- a/mcp_video/engine_subtitles.py
+++ b/mcp_video/engine_subtitles.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from .engine_runtime_utils import (
     _build_edit_result,
-    _movflags_args,
     _require_filter,
     _timed_operation,
 )
@@ -12,9 +11,9 @@ from .paths import (
     _auto_output,
 )
 from .ffmpeg_helpers import (
+    _build_ffmpeg_cmd,
     _run_ffmpeg,
 )
-from .defaults import DEFAULT_CRF, DEFAULT_PRESET
 from .ffmpeg_helpers import _validate_input_path, _validate_output_path, _escape_ffmpeg_filter_value
 from .models import EditResult
 
@@ -38,22 +37,12 @@ def subtitles(
 
     with _timed_operation() as timing:
         _run_ffmpeg(
-            [
-                "-i",
+            _build_ffmpeg_cmd(
                 input_path,
-                "-vf",
-                f"subtitles={escaped_sub_path}:force_style={escaped_style}",
-                "-c:v",
-                "libx264",
-                "-preset",
-                DEFAULT_PRESET,
-                "-crf",
-                str(DEFAULT_CRF),
-                "-c:a",
-                "copy",
-                *_movflags_args(output),
-                output,
-            ]
+                output_path=output,
+                video_filter=f"subtitles={escaped_sub_path}:force_style={escaped_style}",
+                audio_codec="copy",
+            )
         )
 
     return _build_edit_result(

--- a/mcp_video/engine_text.py
+++ b/mcp_video/engine_text.py
@@ -19,6 +19,7 @@ from .models import (
     _position_coords,
 )
 from .ffmpeg_helpers import (
+    _build_ffmpeg_cmd,
     _run_ffmpeg,
     _sanitize_ffmpeg_number,
 )
@@ -96,19 +97,14 @@ def add_text(
 
     with _timed_operation() as timing:
         _run_ffmpeg(
-            [
-                "-i",
+            _build_ffmpeg_cmd(
                 input_path,
-                "-vf",
-                vf,
-                "-c:v",
-                "libx264",
-                *_quality_args(crf=crf, preset=preset),
-                "-c:a",
-                "copy",
-                *_movflags_args(output),
-                output,
-            ]
+                output_path=output,
+                video_filter=vf,
+                audio_codec="copy",
+                crf=crf,
+                preset=preset,
+            )
         )
 
     info = probe(output)

--- a/mcp_video/engine_timeline.py
+++ b/mcp_video/engine_timeline.py
@@ -24,6 +24,7 @@ from .models import (
     _position_coords,
 )
 from .ffmpeg_helpers import (
+    _build_ffmpeg_cmd,
     _run_ffmpeg,
     _sanitize_ffmpeg_number,
 )
@@ -256,11 +257,7 @@ def _run_overlay_command(
                 *inputs,
                 "-filter_complex",
                 ";".join(filter_parts),
-                "-map",
-                f"[{last_label}]",
-                "-map",
-                "0:a?",
-                *_encode_args(output_path),
+                *_encode_args(output_path, extra=["-map", f"[{last_label}]", "-map", "0:a?"]),
             ]
         )
     elif image_overlays:
@@ -269,16 +266,17 @@ def _run_overlay_command(
                 *inputs,
                 "-filter_complex",
                 ";".join(filter_parts),
-                "-map",
-                f"[{prev_label}]",
-                "-map",
-                "0:a?",
-                *_encode_args(output_path),
+                *_encode_args(output_path, extra=["-map", f"[{prev_label}]", "-map", "0:a?"]),
             ]
         )
     elif vf_parts:
         _run_ffmpeg([*inputs, "-vf", ",".join(vf_parts), *_encode_args(output_path)])
 
 
-def _encode_args(output_path: str) -> list[str]:
-    return ["-c:v", "libx264", *_quality_args(), "-c:a", "copy", *_movflags_args(output_path), output_path]
+def _encode_args(output_path: str, extra: list[str] | None = None) -> list[str]:
+    return _build_ffmpeg_cmd(
+        output_path=output_path,
+        video_codec="libx264",
+        audio_codec="copy",
+        extra=extra,
+    )

--- a/mcp_video/engine_transcode.py
+++ b/mcp_video/engine_transcode.py
@@ -2,9 +2,8 @@
 
 from __future__ import annotations
 
-from .defaults import DEFAULT_AUDIO_BITRATE, DEFAULT_CRF, DEFAULT_PRESET
+from .ffmpeg_helpers import _build_ffmpeg_cmd
 from .ffmpeg_helpers import _validate_input_path, _validate_output_path
-from .engine_runtime_utils import _movflags_args
 from .paths import _auto_output
 from .ffmpeg_helpers import _run_ffmpeg
 
@@ -18,22 +17,5 @@ def normalize(input_path: str, output_path: str | None = None) -> str:
     input_path = _validate_input_path(input_path)
     output = output_path or _auto_output(input_path, "normalized")
     _validate_output_path(output)
-    _run_ffmpeg(
-        [
-            "-i",
-            input_path,
-            "-c:v",
-            "libx264",
-            "-preset",
-            DEFAULT_PRESET,
-            "-crf",
-            str(DEFAULT_CRF),
-            "-c:a",
-            "aac",
-            "-b:a",
-            DEFAULT_AUDIO_BITRATE,
-            *_movflags_args(output),
-            output,
-        ]
-    )
+    _run_ffmpeg(_build_ffmpeg_cmd(input_path, output_path=output))
     return output

--- a/mcp_video/engine_watermark.py
+++ b/mcp_video/engine_watermark.py
@@ -15,6 +15,7 @@ from .models import (
     _resolve_position,
 )
 from .ffmpeg_helpers import (
+    _build_ffmpeg_cmd,
     _run_ffmpeg,
 )
 from .ffmpeg_helpers import _validate_input_path, _validate_output_path
@@ -56,21 +57,18 @@ def watermark(
 
     with _timed_operation() as timing:
         _run_ffmpeg(
-            [
-                "-i",
+            _build_ffmpeg_cmd(
                 input_path,
-                "-i",
                 image_path,
-                "-filter_complex",
-                f"[1:v]format=rgba,colorchannelmixer=aa={opacity_fmt}[wm];[0:v][wm]overlay={overlay_pos}",
-                "-c:v",
-                "libx264",
-                *_quality_args(crf=crf, preset=preset),
-                "-c:a",
-                "copy",
-                *_movflags_args(output),
-                output,
-            ]
+                output_path=output,
+                audio_codec="copy",
+                crf=crf,
+                preset=preset,
+                extra=[
+                    "-filter_complex",
+                    f"[1:v]format=rgba,colorchannelmixer=aa={opacity_fmt}[wm];[0:v][wm]overlay={overlay_pos}",
+                ],
+            )
         )
 
     return _build_edit_result(

--- a/mcp_video/ffmpeg_helpers.py
+++ b/mcp_video/ffmpeg_helpers.py
@@ -200,6 +200,77 @@ def _run_ffmpeg_with_progress(
     )
 
 
+def _build_ffmpeg_cmd(
+    *inputs: str,
+    output_path: str,
+    video_codec: str = "libx264",
+    video_filter: str | None = None,
+    audio_codec: str | None = "aac",
+    audio_filter: str | None = None,
+    audio_bitrate: str | None = None,
+    crf: int | None = None,
+    preset: str | None = None,
+    extra: list[str] | None = None,
+    movflags: bool = True,
+) -> list[str]:
+    """Build a standard FFmpeg argument list for video encoding.
+
+    Eliminates the repeated construction of::
+
+        ["-i", input, "-c:v", "libx264", *_quality_args(),
+         "-c:a", "aac", "-b:a", DEFAULT_AUDIO_BITRATE,
+         *_movflags_args(output), output]
+
+    found across 15+ engine functions.
+
+    Args:
+        *inputs: Input file paths. Each becomes a separate ``-i`` argument.
+        output_path: Output file path.
+        video_codec: Video codec (e.g. ``libx264``, ``copy``, ``prores_ks``).
+                     Use ``None`` to omit ``-c:v`` entirely.
+        video_filter: Video filter string. Adds ``-vf`` flag.
+        audio_codec: Audio codec (e.g. ``aac``, ``copy``, ``pcm_s16le``).
+                     Use ``None`` to omit ``-c:a`` entirely.
+        audio_filter: Audio filter string. Adds ``-af`` flag.
+        audio_bitrate: Audio bitrate (e.g. ``128k``). Defaults to
+                       ``DEFAULT_AUDIO_BITRATE`` when ``audio_codec == "aac"``.
+        crf: Constant Rate Factor. Passed to ``_quality_args()``.
+        preset: Encoding preset. Passed to ``_quality_args()``.
+        extra: Extra arguments inserted before movflags/output.
+        movflags: Whether to append ``-movflags +faststart`` for mp4/mov.
+    """
+    from .defaults import DEFAULT_AUDIO_BITRATE
+    from .engine_runtime_utils import _movflags_args, _quality_args
+
+    cmd: list[str] = []
+    for inp in inputs:
+        cmd.extend(["-i", inp])
+
+    if video_filter is not None:
+        cmd.extend(["-vf", video_filter])
+    if audio_filter is not None:
+        cmd.extend(["-af", audio_filter])
+
+    if video_codec is not None:
+        cmd.extend(["-c:v", video_codec])
+        if video_codec != "copy":
+            cmd.extend(_quality_args(crf=crf, preset=preset))
+
+    if audio_codec is not None:
+        cmd.extend(["-c:a", audio_codec])
+        if audio_codec == "aac":
+            cmd.extend(["-b:a", audio_bitrate or DEFAULT_AUDIO_BITRATE])
+
+    if extra:
+        cmd.extend(extra)
+
+    if movflags:
+        cmd.extend(_movflags_args(output_path))
+
+    cmd.append(output_path)
+    return cmd
+
+
 def _sanitize_ffmpeg_number(value: Any, name: str) -> float:
     """Ensure a value is numeric and finite before FFmpeg interpolation. Returns float(value)."""
     try:

--- a/mcp_video/hyperframes_engine.py
+++ b/mcp_video/hyperframes_engine.py
@@ -15,7 +15,8 @@ import shutil
 import subprocess
 import time
 from pathlib import Path
-from typing import Any, Callable
+from collections.abc import Callable
+from typing import Any
 
 from .errors import (
     HyperframesNotFoundError,
@@ -265,7 +266,7 @@ def render(
         output_path = os.path.join("out", f"{Path(project_path).name}.mp4")
 
     start_time = time.time()
-    result, _project = _hyperframes_op(
+    _result, _project = _hyperframes_op(
         "render",
         project_path=project_path,
         output_path=output_path,


### PR DESCRIPTION
Fixes UP035 and RUF059 lint errors in the Candidate J refactor.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/mcp-video/pr/183"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->