### PR TITLE
Use Blacksmith Linux for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   changes:
     name: Change detection
-    runs-on: [self-hosted, macOS, ARM64]
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     outputs:
       code: ${{ steps.classify.outputs.code }}
       docker: ${{ steps.classify.outputs.docker }}
@@ -47,21 +47,27 @@ jobs:
 
   repository-readiness:
     name: Repository readiness
-    runs-on: [self-hosted, macOS, ARM64]
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
       - name: Create venv
-        run: python3.13 -m venv .venv
+        run: python -m venv .venv
       - name: Run repository readiness audit
         run: .venv/bin/python ./scripts/repo-readiness-audit.py
 
   lint:
     name: Lint
-    runs-on: [self-hosted, macOS, ARM64]
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
       - name: Create venv
-        run: python3.13 -m venv .venv
+        run: python -m venv .venv
       - name: Install ruff
         run: .venv/bin/pip install ruff
       - name: Ruff check
@@ -71,11 +77,14 @@ jobs:
 
   package-surface:
     name: Package surface
-    runs-on: [self-hosted, macOS, ARM64]
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
       - name: Create venv
-        run: python3.13 -m venv .venv
+        run: python -m venv .venv
       - name: Install build tools
         run: .venv/bin/pip install build
       - name: Build release artifacts
@@ -86,21 +95,26 @@ jobs:
   test:
     name: Test (Python 3.13)
     needs: changes
-    runs-on: [self-hosted, macOS, ARM64]
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - name: Skip tests
         if: github.event_name == 'pull_request' && needs.changes.outputs.code != 'true'
         run: echo "Code inputs unchanged; marking Python 3.13 test check successful."
       - uses: actions/checkout@v6
         if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true'
+      - uses: actions/setup-python@v6
+        if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true'
+        with:
+          python-version: '3.13'
       - name: Create venv
         if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true'
-        run: python3.13 -m venv .venv
+        run: python -m venv .venv
       - name: Ensure FFmpeg
         if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true'
         run: |
           if ! command -v ffmpeg &>/dev/null; then
-            brew install ffmpeg || (echo "FFmpeg not available; skipping" && exit 0)
+            sudo apt-get update
+            sudo apt-get install -y ffmpeg
           fi
       - name: Install dependencies
         if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true'
@@ -112,7 +126,7 @@ jobs:
   compatibility:
     name: Compatibility (Python ${{ matrix.python-version }})
     needs: changes
-    runs-on: [self-hosted, macOS, ARM64]
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     strategy:
       fail-fast: false
       matrix:
@@ -123,14 +137,19 @@ jobs:
         run: echo "Code inputs unchanged; marking Python ${{ matrix.python-version }} compatibility check successful."
       - uses: actions/checkout@v6
         if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true'
+      - uses: actions/setup-python@v6
+        if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true'
+        with:
+          python-version: ${{ matrix.python-version }}
       - name: Create venv
         if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true'
-        run: python${{ matrix.python-version }} -m venv .venv
+        run: python -m venv .venv
       - name: Ensure FFmpeg
         if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true'
         run: |
           if ! command -v ffmpeg &>/dev/null; then
-            brew install ffmpeg || (echo "FFmpeg not available; skipping" && exit 0)
+            sudo apt-get update
+            sudo apt-get install -y ffmpeg
           fi
       - name: Install dependencies
         if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true'
@@ -142,7 +161,7 @@ jobs:
   docker:
     name: Docker build
     needs: changes
-    runs-on: [self-hosted, macOS, ARM64]
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v6
       - name: Skip Docker build


### PR DESCRIPTION
## Summary\n- route standard CI jobs to Blacksmith Linux\n- add setup-python where CI previously assumed local python executables\n- switch Linux FFmpeg install path from Homebrew to apt\n\n## Why\nOpen Kyanite PRs are blocked before project checks run because the self-hosted macOS runner cannot install Python into the actions toolcache: /Users/runner permission denied. These jobs are generic build/test/lint/package/docker checks and should run on Blacksmith for KyaniteLabs.\n\n## Verification\n- python3.13 venv\n- scripts/repo-readiness-audit.py\n- ruff check mcp_video/\n- ruff format --check mcp_video/\n- pytest tests/ -q -m 'not slow' --tb=short: 1014 passed, 10 skipped, 19 deselected\n\nRelated to KyaniteLabs/mcp-video#179\nRelated to KyaniteLabs/mcp-video#178\nRelated to KyaniteLabs/mcp-video#181

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/mcp-video/pr/184"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->