### PR TITLE
Use Blacksmith Linux for CI and deterministic thumbnail bounds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   changes:
     name: Change detection
-    runs-on: [self-hosted, macOS, ARM64]
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     outputs:
       code: ${{ steps.classify.outputs.code }}
       docker: ${{ steps.classify.outputs.docker }}
@@ -47,21 +47,27 @@ jobs:
 
   repository-readiness:
     name: Repository readiness
-    runs-on: [self-hosted, macOS, ARM64]
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
       - name: Create venv
-        run: python3.13 -m venv .venv
+        run: python -m venv .venv
       - name: Run repository readiness audit
         run: .venv/bin/python ./scripts/repo-readiness-audit.py
 
   lint:
     name: Lint
-    runs-on: [self-hosted, macOS, ARM64]
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
       - name: Create venv
-        run: python3.13 -m venv .venv
+        run: python -m venv .venv
       - name: Install ruff
         run: .venv/bin/pip install ruff
       - name: Ruff check
@@ -71,11 +77,14 @@ jobs:
 
   package-surface:
     name: Package surface
-    runs-on: [self-hosted, macOS, ARM64]
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
       - name: Create venv
-        run: python3.13 -m venv .venv
+        run: python -m venv .venv
       - name: Install build tools
         run: .venv/bin/pip install build
       - name: Build release artifacts
@@ -86,21 +95,26 @@ jobs:
   test:
     name: Test (Python 3.13)
     needs: changes
-    runs-on: [self-hosted, macOS, ARM64]
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - name: Skip tests
         if: github.event_name == 'pull_request' && needs.changes.outputs.code != 'true'
         run: echo "Code inputs unchanged; marking Python 3.13 test check successful."
       - uses: actions/checkout@v6
         if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true'
+      - uses: actions/setup-python@v6
+        if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true'
+        with:
+          python-version: '3.13'
       - name: Create venv
         if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true'
-        run: python3.13 -m venv .venv
+        run: python -m venv .venv
       - name: Ensure FFmpeg
         if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true'
         run: |
           if ! command -v ffmpeg &>/dev/null; then
-            brew install ffmpeg || (echo "FFmpeg not available; skipping" && exit 0)
+            sudo apt-get update
+            sudo apt-get install -y ffmpeg
           fi
       - name: Install dependencies
         if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true'
@@ -112,7 +126,7 @@ jobs:
   compatibility:
     name: Compatibility (Python ${{ matrix.python-version }})
     needs: changes
-    runs-on: [self-hosted, macOS, ARM64]
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     strategy:
       fail-fast: false
       matrix:
@@ -123,14 +137,19 @@ jobs:
         run: echo "Code inputs unchanged; marking Python ${{ matrix.python-version }} compatibility check successful."
       - uses: actions/checkout@v6
         if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true'
+      - uses: actions/setup-python@v6
+        if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true'
+        with:
+          python-version: ${{ matrix.python-version }}
       - name: Create venv
         if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true'
-        run: python${{ matrix.python-version }} -m venv .venv
+        run: python -m venv .venv
       - name: Ensure FFmpeg
         if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true'
         run: |
           if ! command -v ffmpeg &>/dev/null; then
-            brew install ffmpeg || (echo "FFmpeg not available; skipping" && exit 0)
+            sudo apt-get update
+            sudo apt-get install -y ffmpeg
           fi
       - name: Install dependencies
         if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true'
@@ -142,7 +161,7 @@ jobs:
   docker:
     name: Docker build
     needs: changes
-    runs-on: [self-hosted, macOS, ARM64]
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v6
       - name: Skip Docker build

--- a/mcp_video/engine_thumbnail.py
+++ b/mcp_video/engine_thumbnail.py
@@ -27,13 +27,16 @@ def thumbnail(
         # Clamp to valid range
         dur = get_duration(input_path)
         try:
-            timestamp = min(_time_to_seconds(timestamp), dur * 0.99)
+            requested_timestamp = _time_to_seconds(timestamp)
         except ValueError as exc:
             raise MCPVideoError(
                 f"Invalid timestamp: '{timestamp}'. Expected seconds or HH:MM:SS format.",
                 error_type="validation_error",
                 code="invalid_parameter",
             ) from exc
+        if requested_timestamp > dur:
+            raise ValueError(f"Timestamp {requested_timestamp:.3f}s exceeds video duration {dur:.3f}s")
+        timestamp = requested_timestamp
 
     output = output_path or _auto_output(input_path, f"frame_{timestamp:.1f}s", ext=".jpg")
     _validate_output_path(output)

--- a/mcp_video/engine_thumbnail.py
+++ b/mcp_video/engine_thumbnail.py
@@ -34,7 +34,7 @@ def thumbnail(
                 error_type="validation_error",
                 code="invalid_parameter",
             ) from exc
-        if requested_timestamp > dur:
+        if requested_timestamp >= dur:
             raise InputFileError(
                 input_path,
                 f"Timestamp {requested_timestamp:.3f}s exceeds video duration {dur:.3f}s",

--- a/mcp_video/engine_thumbnail.py
+++ b/mcp_video/engine_thumbnail.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from .engine_edit import _time_to_seconds
-from .errors import MCPVideoError
+from .errors import InputFileError, MCPVideoError
 from .ffmpeg_helpers import _validate_input_path, _validate_output_path
 from .engine_probe import get_duration
 from .paths import _auto_output
@@ -35,7 +35,10 @@ def thumbnail(
                 code="invalid_parameter",
             ) from exc
         if requested_timestamp > dur:
-            raise ValueError(f"Timestamp {requested_timestamp:.3f}s exceeds video duration {dur:.3f}s")
+            raise InputFileError(
+                input_path,
+                f"Timestamp {requested_timestamp:.3f}s exceeds video duration {dur:.3f}s",
+            )
         timestamp = requested_timestamp
 
     output = output_path or _auto_output(input_path, f"frame_{timestamp:.1f}s", ext=".jpg")

--- a/tests/test_red_team.py
+++ b/tests/test_red_team.py
@@ -312,6 +312,13 @@ class TestBoundaryValues:
         with pytest.raises((InputFileError, ProcessingError, ValueError)):
             thumbnail(sample_video, timestamp=beyond_duration)
 
+    def test_thumbnail_at_exact_duration(self, sample_video):
+        """Thumbnail at EOF should be pre-validated before FFmpeg."""
+        info = probe(sample_video)
+
+        with pytest.raises((InputFileError, ProcessingError, ValueError)):
+            thumbnail(sample_video, timestamp=info.duration)
+
     def test_trim_zero_duration(self, sample_video):
         """Trimming with zero duration should raise an error or succeed with a tiny file."""
         try:


### PR DESCRIPTION
## Summary\n- route standard CI jobs to Blacksmith Linux\n- add setup-python where CI previously assumed local Python executables\n- switch Linux FFmpeg install path from Homebrew to apt\n- reject explicit thumbnail timestamps at or beyond video duration with typed InputFileError\n- add red-team coverage for EOF thumbnail timestamps\n\n## Verification\n- scripts/repo-readiness-audit.py\n- ruff check mcp_video/\n- ruff format --check mcp_video/\n- pytest tests/test_red_team.py::TestBoundaryValues::test_thumbnail_beyond_duration tests/test_red_team.py::TestBoundaryValues::test_thumbnail_at_exact_duration -q\n- full non-slow test suite passed locally before review follow-ups: 1014 passed, 10 skipped, 19 deselected\n\nSupersedes #186. Related to KyaniteLabs/mcp-video#179, KyaniteLabs/mcp-video#178, KyaniteLabs/mcp-video#181

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/mcp-video/pr/187"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->