### PR TITLE
Run workflows on Blacksmith

### DIFF
--- a/.github/workflows/integration-smoke.yml
+++ b/.github/workflows/integration-smoke.yml
@@ -25,6 +25,9 @@ jobs:
     runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v6
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
       - name: Create venv
         run: python3.13 -m venv .venv
       - name: Install base package
@@ -59,12 +62,16 @@ jobs:
     runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v6
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
       - name: Create venv
         run: python3.13 -m venv .venv
       - name: Ensure FFmpeg
         run: |
           if ! command -v ffmpeg &>/dev/null; then
-            brew install ffmpeg
+            sudo apt-get update
+            sudo apt-get install -y ffmpeg
           fi
           command -v ffmpeg >/dev/null
           command -v ffprobe >/dev/null
@@ -84,6 +91,9 @@ jobs:
     runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v6
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
       - name: Create venv
         run: python3.13 -m venv .venv
       - name: Install image extra
@@ -110,6 +120,9 @@ jobs:
     runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v6
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
       - name: Create venv
         run: python3.13 -m venv .venv
       - name: Install base package

--- a/.github/workflows/integration-smoke.yml
+++ b/.github/workflows/integration-smoke.yml
@@ -22,7 +22,7 @@ on:
 jobs:
   base-cli-and-doctor:
     name: Base CLI and doctor
-    runs-on: [self-hosted, macOS, ARM64]
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v6
       - name: Create venv
@@ -56,7 +56,7 @@ jobs:
 
   ffmpeg-smoke:
     name: FFmpeg operation smoke
-    runs-on: [self-hosted, macOS, ARM64]
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v6
       - name: Create venv
@@ -81,7 +81,7 @@ jobs:
 
   image-extra-smoke:
     name: Image extra smoke
-    runs-on: [self-hosted, macOS, ARM64]
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v6
       - name: Create venv
@@ -107,7 +107,7 @@ jobs:
 
   ai-module-smoke:
     name: AI module metadata smoke
-    runs-on: [self-hosted, macOS, ARM64]
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v6
       - name: Create venv

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -17,7 +17,7 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: [self-hosted, macOS, ARM64]
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v6
       - name: Check forbidden tracked artifacts

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   surface-audit:
     name: Check tracked release surface
-    runs-on: [self-hosted, macOS, ARM64]
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v6
       - name: Check forbidden tracked artifacts
@@ -20,7 +20,7 @@ jobs:
   build:
     name: Build package
     needs: surface-audit
-    runs-on: [self-hosted, macOS, ARM64]
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v6
         with:
@@ -44,7 +44,7 @@ jobs:
   publish:
     name: Publish to PyPI
     needs: build
-    runs-on: [self-hosted, macOS, ARM64]
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     environment: pypi
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- move repo-local workflow jobs off mixed self-hosted/GitHub-hosted runners
- use `blacksmith-2vcpu-ubuntu-2404` for the changed workflow jobs
- keep workflow and job names intact so required check contexts remain stable

## Changed workflows
- `.github/workflows/publish.yml`
- `.github/workflows/pages.yml`
- `.github/workflows/integration-smoke.yml`

## Verification
- parsed changed workflow YAML locally

## Context
This repo was in a mixed Kyanite state: Blacksmith was present, but some repo-local workflows still targeted non-Blacksmith runners and could queue/block PRs.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/mcp-video/pr/194"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->