### PR TITLE
fix(ci): use setup-python in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,8 +14,11 @@ jobs:
     runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
       - name: Check forbidden tracked artifacts
-        run: python3.13 .github/scripts/check-forbidden-artifacts.py
+        run: python .github/scripts/check-forbidden-artifacts.py
 
   build:
     name: Build package
@@ -25,8 +28,11 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0  # Needed for hatch-vcs if ever adopted
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
       - name: Create venv
-        run: python3.13 -m venv .venv
+        run: python -m venv .venv
       - name: Install build dependencies
         run: .venv/bin/pip install build twine
       - name: Build package


### PR DESCRIPTION
## Summary
The publish workflow hardcodes `python3.13` which doesn't exist on Blacksmith runners. Uses `actions/setup-python@v6` instead, matching the pattern in `ci.yml`.

## Why
v1.3.1 publish failed because `python3.13` wasn't found on PATH. All other workflows use `setup-python` to install it properly.

## Test plan
- [x] Pattern matches ci.yml (which works)
- [ ] Merge then re-trigger publish for v1.3.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/mcp-video/pr/197"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->