### PR TITLE
Add CLAUDE.md and IDE instruction files

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -1,0 +1,45 @@
+# KyaniteLabs — AI Agent Instructions
+
+## Organization
+- Org: KyaniteLabs, owner: Pastorsimon1798
+- All repos use issue-driven development — contributions enter as GitHub issues, not direct PRs
+- Pipeline runs every 30 min: triage → fix → review → merge
+- All main/master branches are protected (no direct push, CI required)
+
+## Code Quality
+- Formatter: ruff (Python), prettier (JS/TS)
+- Linter: ruff (Python), eslint (JS/TS)
+- Config: pyproject.toml (Python), pnpm (Node)
+- Pin exact dependency versions
+- No orphaned code — every function called, every file imported
+- No commented-out code blocks
+
+## Security
+- No `shell=True` with user input
+- No hardcoded secrets/tokens/API keys
+- Validate file paths (no path traversal)
+- Use HTTPS for external calls
+- Parameterized queries for databases
+
+## Testing
+- Test behavior, not implementation
+- Test the unhappy path (API down, file missing, bad input)
+- Integration tests over mocks for external systems
+- One assertion per concept
+
+## Git
+- Commits tell why, not what
+- PRs under 400 lines
+- Rebase, don't merge on feature branches
+- Never skip CI
+
+## Local LLM
+- Use local inference at 100.66.225.85:1234 before cloud APIs
+- Check loaded models first, don't touch models you didn't load
+- Unload when done
+- CPU thread pool: 10, flash attention: on, KV cache: Q8
+
+## Agent Coordination
+- Check open PRs before editing files
+- Leave context in issues, not in code
+- Run CI checks locally before pushing

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,45 @@
+# KyaniteLabs — AI Agent Instructions
+
+## Organization
+- Org: KyaniteLabs, owner: Pastorsimon1798
+- All repos use issue-driven development — contributions enter as GitHub issues, not direct PRs
+- Pipeline runs every 30 min: triage → fix → review → merge
+- All main/master branches are protected (no direct push, CI required)
+
+## Code Quality
+- Formatter: ruff (Python), prettier (JS/TS)
+- Linter: ruff (Python), eslint (JS/TS)
+- Config: pyproject.toml (Python), pnpm (Node)
+- Pin exact dependency versions
+- No orphaned code — every function called, every file imported
+- No commented-out code blocks
+
+## Security
+- No `shell=True` with user input
+- No hardcoded secrets/tokens/API keys
+- Validate file paths (no path traversal)
+- Use HTTPS for external calls
+- Parameterized queries for databases
+
+## Testing
+- Test behavior, not implementation
+- Test the unhappy path (API down, file missing, bad input)
+- Integration tests over mocks for external systems
+- One assertion per concept
+
+## Git
+- Commits tell why, not what
+- PRs under 400 lines
+- Rebase, don't merge on feature branches
+- Never skip CI
+
+## Local LLM
+- Use local inference at 100.66.225.85:1234 before cloud APIs
+- Check loaded models first, don't touch models you didn't load
+- Unload when done
+- CPU thread pool: 10, flash attention: on, KV cache: Q8
+
+## Agent Coordination
+- Check open PRs before editing files
+- Leave context in issues, not in code
+- Run CI checks locally before pushing

--- a/.windsurfrules
+++ b/.windsurfrules
@@ -1,0 +1,45 @@
+# KyaniteLabs — AI Agent Instructions
+
+## Organization
+- Org: KyaniteLabs, owner: Pastorsimon1798
+- All repos use issue-driven development — contributions enter as GitHub issues, not direct PRs
+- Pipeline runs every 30 min: triage → fix → review → merge
+- All main/master branches are protected (no direct push, CI required)
+
+## Code Quality
+- Formatter: ruff (Python), prettier (JS/TS)
+- Linter: ruff (Python), eslint (JS/TS)
+- Config: pyproject.toml (Python), pnpm (Node)
+- Pin exact dependency versions
+- No orphaned code — every function called, every file imported
+- No commented-out code blocks
+
+## Security
+- No `shell=True` with user input
+- No hardcoded secrets/tokens/API keys
+- Validate file paths (no path traversal)
+- Use HTTPS for external calls
+- Parameterized queries for databases
+
+## Testing
+- Test behavior, not implementation
+- Test the unhappy path (API down, file missing, bad input)
+- Integration tests over mocks for external systems
+- One assertion per concept
+
+## Git
+- Commits tell why, not what
+- PRs under 400 lines
+- Rebase, don't merge on feature branches
+- Never skip CI
+
+## Local LLM
+- Use local inference at 100.66.225.85:1234 before cloud APIs
+- Check loaded models first, don't touch models you didn't load
+- Unload when done
+- CPU thread pool: 10, flash attention: on, KV cache: Q8
+
+## Agent Coordination
+- Check open PRs before editing files
+- Leave context in issues, not in code
+- Run CI checks locally before pushing


### PR DESCRIPTION
This PR adds CLAUDE.md and missing IDE instruction files to the repository.

## Changes

- **CLAUDE.md**: Instructions for Claude Code (loaded automatically when working in this repo)
- **.cursorrules**: Rules for Cursor IDE
- **.windsurfrules**: Rules for Windsurf IDE
- **.github/copilot-instructions.md**: Rules for GitHub Copilot

Note: AGENTS.md already exists in this repository and was not modified.

These files ensure consistent AI assistant behavior across all KyaniteLabs repositories.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/mcp-video/pr/200"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->