### PR TITLE
Make dogfood video QA tell the truth

### DIFF
--- a/mcp_video/effects_engine/text.py
+++ b/mcp_video/effects_engine/text.py
@@ -9,8 +9,8 @@ import logging
 import os
 import tempfile
 import textwrap
-from pathlib import Path
 from collections.abc import Callable
+from pathlib import Path
 from typing import Any
 
 from ..defaults import DEFAULT_SAFE_SUBTITLE_FONT_SIZE, DEFAULT_SUBTITLE_MAX_CHARS_PER_LINE, DEFAULT_SUBTITLE_MAX_LINES
@@ -216,6 +216,14 @@ def _escape_sendcmd_value(value: str) -> str:
     return _escape_ffmpeg_filter_value(value)
 
 
+def _drawtext_font_option(font: str | None) -> str:
+    """Return a drawtext font option that works for both font names and paths."""
+    if font and os.path.exists(font):
+        return f"fontfile={_escape_ffmpeg_filter_value(font)}"
+    safe_font = _escape_ffmpeg_filter_value(font or "Arial")
+    return f"font={safe_font}"
+
+
 def _build_typewriter_filter(
     text: str,
     font: str,
@@ -225,14 +233,14 @@ def _build_typewriter_filter(
     start: float,
     duration: float,
     typewriter_speed: float,
-    video_path: str,
+    video: str,
 ) -> tuple[str, str]:
     """Build a filter chain and sendcmd file for character-by-character reveal.
 
     Returns:
         (filter_complex, cmd_file_path)
     """
-    video_w, video_h = _get_video_dimensions(video_path)
+    video_w, video_h = _get_video_dimensions(video)
     text_w, text_h = _measure_text(text, font, size)
     text_x, text_y = _text_position_xy(position, video_w, video_h, text_w, text_h)
 
@@ -246,7 +254,7 @@ def _build_typewriter_filter(
     char_duration = max(0.01, safe_speed)
     end_time = safe_start + safe_duration
 
-    safe_font = _escape_ffmpeg_filter_value(font) if font is not None else font
+    font_option = _drawtext_font_option(font)
     safe_color = _escape_ffmpeg_filter_value(color) if color is not None else color
     safe_size = int(_sanitize_ffmpeg_number(size, "size"))
     safe_text_x = int(_sanitize_ffmpeg_number(text_x, "text_x"))
@@ -275,7 +283,7 @@ def _build_typewriter_filter(
     safe_cmd_path = _escape_ffmpeg_filter_value(cmd_path)
     filter_complex = (
         f"sendcmd=f={safe_cmd_path},"
-        f"drawtext@1=text='':font={safe_font}:fontsize={safe_size}:fontcolor={safe_color}:"
+        f"drawtext@1=text='':{font_option}:fontsize={safe_size}:fontcolor={safe_color}:"
         f"x={safe_text_x}:y={safe_text_y}:enable='between(t\\,{safe_start}\\,{end_time})'"
     )
     return filter_complex, cmd_path
@@ -294,7 +302,7 @@ def _build_fade_filter(
 ) -> tuple[str, str]:
     """Build fade-in / fade-out drawtext filter."""
     safe_text = _escape_ffmpeg_filter_value(text)
-    safe_font = _escape_ffmpeg_filter_value(font) if font is not None else font
+    font_option = _drawtext_font_option(font)
     safe_color = _escape_ffmpeg_filter_value(color) if color is not None else color
     pos_map = {
         "center": "(w-text_w)/2:(h-text_h)/2",
@@ -317,7 +325,7 @@ def _build_fade_filter(
         f"if(lt(t,{fade_out_end}),({fade_out_end}-t)/0.5,0))))"
     )
     filter_complex = (
-        f"drawtext=text='{safe_text}':font={safe_font}:fontsize={size}:fontcolor={safe_color}:"
+        f"drawtext=text='{safe_text}':{font_option}:fontsize={size}:fontcolor={safe_color}:"
         f"x={pos.split(':')[0]}:y={pos.split(':')[1]}:"
         f"enable='between(t\\,{start}\\,{start + duration})':"
         f"alpha='{alpha_expr}'"
@@ -338,7 +346,7 @@ def _build_slide_up_filter(
 ) -> tuple[str, str]:
     """Build slide-up drawtext filter."""
     safe_text = _escape_ffmpeg_filter_value(text)
-    safe_font = _escape_ffmpeg_filter_value(font) if font is not None else font
+    font_option = _drawtext_font_option(font)
     safe_color = _escape_ffmpeg_filter_value(color) if color is not None else color
     pos_map = {
         "center": "(w-text_w)/2:(h-text_h)/2",
@@ -350,10 +358,10 @@ def _build_slide_up_filter(
         "bottom-right": "w-text_w-20:h-text_h-20",
     }
     pos = pos_map.get(position, pos_map["center"])
-    y_offset = f"+50*(1-min(1,(t-{start})/0.3))"
+    y_offset = f"+50*(1-min(1\\,(t-{start})/0.3))"
     pos = pos.replace("(h-text_h)/2", f"(h-text_h)/2{y_offset}")
     filter_complex = (
-        f"drawtext=text='{safe_text}':font={safe_font}:fontsize={size}:fontcolor={safe_color}:"
+        f"drawtext=text='{safe_text}':{font_option}:fontsize={size}:fontcolor={safe_color}:"
         f"x={pos.split(':')[0]}:y={pos.split(':')[1]}:"
         f"enable='between(t\\,{start}\\,{start + duration})':"
         f"alpha='1'"
@@ -374,7 +382,7 @@ def _build_glitch_filter(
 ) -> tuple[str, str]:
     """Build glitch-style drawtext filter."""
     safe_text = _escape_ffmpeg_filter_value(text)
-    safe_font = _escape_ffmpeg_filter_value(font) if font is not None else font
+    font_option = _drawtext_font_option(font)
     safe_color = _escape_ffmpeg_filter_value(color) if color is not None else color
     pos_map = {
         "center": "(w-text_w)/2:(h-text_h)/2",
@@ -388,7 +396,7 @@ def _build_glitch_filter(
     pos = pos_map.get(position, pos_map["center"])
     alpha_expr = "if(random(0)*lt(mod(t,0.2),0.1),0.8,1)"
     filter_complex = (
-        f"drawtext=text='{safe_text}':font={safe_font}:fontsize={size}:fontcolor={safe_color}:"
+        f"drawtext=text='{safe_text}':{font_option}:fontsize={size}:fontcolor={safe_color}:"
         f"x={pos.split(':')[0]}:y={pos.split(':')[1]}:"
         f"enable='between(t\\,{start}\\,{start + duration})':"
         f"alpha='{alpha_expr}'"

--- a/mcp_video/quality_guardrails.py
+++ b/mcp_video/quality_guardrails.py
@@ -197,6 +197,13 @@ class VisualQualityGuardrails:
             logger.warning("ffmpeg signalstats failed for %s: %s: %s", video, type(exc).__name__, exc)
             return {}
 
+    def _mean_signalstat(self, video: str, tag: str) -> float | None:
+        """Return the mean for a signalstats frame tag, if available."""
+        stats = self._run_ffprobe(video, f"lavfi.signalstats.{tag}")
+        if not stats or "mean" not in stats:
+            return None
+        return float(stats["mean"])
+
     def _analyze_loudnorm(self, video: str) -> dict[str, Any]:
         """Analyze audio loudness using loudnorm filter."""
         cmd = [
@@ -242,7 +249,12 @@ class VisualQualityGuardrails:
             return {"_error": diagnostic}
 
     def _get_rgb_means(self, video: str) -> dict[str, Any] | None:
-        """Get mean RGB values for color balance analysis."""
+        """Get approximate mean RGB values for color balance analysis.
+
+        FFmpeg's signalstats filter exposes YUV means, not RGB means. Convert
+        those means into RGB-ish values so the color balance check uses fields
+        that are actually emitted by signalstats.
+        """
         cmd = [
             "ffprobe",
             "-v",
@@ -252,7 +264,7 @@ class VisualQualityGuardrails:
             "-i",
             f"movie={_escape_lavfi_path(video)},signalstats",
             "-show_entries",
-            "frame_tags=lavfi.signalstats.RAVG,lavfi.signalstats.GAVG,lavfi.signalstats.BAVG",
+            "frame_tags=lavfi.signalstats.YAVG,lavfi.signalstats.UAVG,lavfi.signalstats.VAVG",
             "-of",
             "json",
         ]
@@ -274,29 +286,34 @@ class VisualQualityGuardrails:
                 logger.warning("ffprobe RGB means returned no frames for %s", video)
                 return {"_error": diagnostic}
 
-            # Average RGB across frames
-            r_vals, g_vals, b_vals = [], [], []
+            y_vals, u_vals, v_vals = [], [], []
             for frame in frames:
                 tags = frame.get("tags", {})
-                if "lavfi.signalstats.RAVG" in tags:
+                if "lavfi.signalstats.YAVG" in tags:
                     with contextlib.suppress(ValueError, TypeError):
-                        r_vals.append(float(tags["lavfi.signalstats.RAVG"]))
-                if "lavfi.signalstats.GAVG" in tags:
+                        y_vals.append(float(tags["lavfi.signalstats.YAVG"]))
+                if "lavfi.signalstats.UAVG" in tags:
                     with contextlib.suppress(ValueError, TypeError):
-                        g_vals.append(float(tags["lavfi.signalstats.GAVG"]))
-                if "lavfi.signalstats.BAVG" in tags:
+                        u_vals.append(float(tags["lavfi.signalstats.UAVG"]))
+                if "lavfi.signalstats.VAVG" in tags:
                     with contextlib.suppress(ValueError, TypeError):
-                        b_vals.append(float(tags["lavfi.signalstats.BAVG"]))
+                        v_vals.append(float(tags["lavfi.signalstats.VAVG"]))
 
-            if not (r_vals and g_vals and b_vals):
-                diagnostic = _diagnostic("ffprobe_rgb_means", "ffprobe returned incomplete RGB values")
-                logger.warning("ffprobe RGB means returned incomplete RGB values for %s", video)
+            if not (y_vals and u_vals and v_vals):
+                diagnostic = _diagnostic("ffprobe_rgb_means", "ffprobe returned incomplete YUV values")
+                logger.warning("ffprobe RGB means returned incomplete YUV values for %s", video)
                 return {"_error": diagnostic}
 
+            y = sum(y_vals) / len(y_vals)
+            u = sum(u_vals) / len(u_vals) - 128
+            v = sum(v_vals) / len(v_vals) - 128
+            r = max(0.0, min(255.0, y + 1.402 * v))
+            g = max(0.0, min(255.0, y - 0.344136 * u - 0.714136 * v))
+            b = max(0.0, min(255.0, y + 1.772 * u))
             return {
-                "r": sum(r_vals) / len(r_vals),
-                "g": sum(g_vals) / len(g_vals),
-                "b": sum(b_vals) / len(b_vals),
+                "r": r,
+                "g": g,
+                "b": b,
             }
         except subprocess.TimeoutExpired:
             diagnostic = _diagnostic("ffprobe_rgb_means", "ffprobe timed out")
@@ -359,18 +376,21 @@ class VisualQualityGuardrails:
 
     def check_contrast(self, video: str) -> QualityReport:
         """Check video has adequate contrast."""
-        stats = self._run_ffprobe(video, "lavfi.signalstats.YSTDV")
-
-        if not stats or "mean" not in stats:
+        y_high = self._mean_signalstat(video, "YHIGH")
+        y_low = self._mean_signalstat(video, "YLOW")
+        if y_high is None or y_low is None:
+            y_high = self._mean_signalstat(video, "YMAX")
+            y_low = self._mean_signalstat(video, "YMIN")
+        if y_high is None or y_low is None:
             return QualityReport(
                 check_name="contrast",
                 passed=False,
                 score=0.0,
                 message="Could not analyze contrast (analysis failed)",
-                details={"diagnostic": stats.get("_error")} if stats else {},
+                details={"diagnostic": _diagnostic("ffprobe_signalstats", "missing luminance range values")},
             )
 
-        y_std = stats["mean"]  # Standard deviation of luminance
+        y_std = max(0.0, (y_high - y_low) / 2.56)  # Approximate contrast on a 0-100 scale.
 
         # Standard deviation indicates contrast (higher = more contrast)
         passed = self.CONTRAST_MIN <= y_std <= self.CONTRAST_MAX
@@ -394,36 +414,29 @@ class VisualQualityGuardrails:
             passed=passed,
             score=score,
             message=message,
-            details={"y_std": y_std, "target_range": [self.CONTRAST_MIN, self.CONTRAST_MAX]},
+            details={
+                "y_std": y_std,
+                "y_low": y_low,
+                "y_high": y_high,
+                "target_range": [self.CONTRAST_MIN, self.CONTRAST_MAX],
+            },
         )
 
     def check_saturation(self, video: str) -> QualityReport:
         """Check saturation levels."""
-        # Analyze chroma channels (U and V in YUV)
-        u_stats = self._run_ffprobe(video, "lavfi.signalstats.UAVG")
-        v_stats = self._run_ffprobe(video, "lavfi.signalstats.VAVG")
-
-        if not u_stats or not v_stats:
-            diagnostics = [
-                stats.get("_error") for stats in (u_stats, v_stats) if isinstance(stats, dict) and stats.get("_error")
-            ]
+        sat_avg = self._mean_signalstat(video, "SATAVG")
+        if sat_avg is None:
             return QualityReport(
                 check_name="saturation",
                 passed=False,
                 score=0.0,
                 message="Could not analyze saturation (analysis failed)",
-                details={"diagnostics": diagnostics} if diagnostics else {},
+                details={"diagnostic": _diagnostic("ffprobe_signalstats", "missing SATAVG values")},
             )
 
-        u_mean = u_stats.get("mean", 128)
-        v_mean = v_stats.get("mean", 128)
-
-        # Chroma deviation from neutral gray (128) indicates saturation
-        # Calculate distance from neutral in UV plane
-        saturation = ((u_mean - 128) ** 2 + (v_mean - 128) ** 2) ** 0.5
-
-        # Scale to approximate percentage (typical max ~60)
-        saturation_pct = (saturation / 60) * 100
+        # signalstats SATAVG is a per-pixel saturation average. 181 is a
+        # practical full-saturation ceiling for 8-bit YUV in FFmpeg output.
+        saturation_pct = (sat_avg / 181) * 100
 
         passed = self.SATURATION_MIN <= saturation_pct <= self.SATURATION_MAX
 
@@ -444,7 +457,7 @@ class VisualQualityGuardrails:
             passed=passed,
             score=score,
             message=message,
-            details={"saturation_pct": saturation_pct, "u_mean": u_mean, "v_mean": v_mean},
+            details={"saturation_pct": saturation_pct, "sat_avg": sat_avg},
         )
 
     def check_audio_levels(self, video: str) -> QualityReport:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,7 @@
 """Tests for CLI commands via subprocess — needs FFmpeg."""
 
 import json
+import os
 import subprocess
 import sys
 from types import SimpleNamespace
@@ -653,6 +654,30 @@ class TestCLICompositionHandlers:
         assert handled is True
         assert "Progress bar" in stdout
         assert output.name in stdout
+
+    @pytest.mark.parametrize("animation", ["typewriter", "slide-up"])
+    def test_video_text_animated_handles_font_paths_with_spaces(self, animation, sample_video, tmp_path):
+        font = "/System/Library/Fonts/Supplemental/Arial Black.ttf"
+        if not os.path.exists(font):
+            pytest.skip("macOS Arial Black fixture font not available")
+
+        output = tmp_path / f"{animation}.mp4"
+        result = run_cli(
+            "video-text-animated",
+            sample_video,
+            "Dogfood text",
+            "-a",
+            animation,
+            "--font",
+            font,
+            "--duration",
+            "1.0",
+            "-o",
+            str(output),
+        )
+
+        assert "Animated text" in result.stdout
+        assert output.exists()
 
     def test_transition_morph_outputs_text(self, sample_video, tmp_path):
         output = tmp_path / "morph.mp4"

--- a/tests/test_quality_guardrails.py
+++ b/tests/test_quality_guardrails.py
@@ -54,7 +54,7 @@ def create_test_video(output_path: str, color: str = "gray", duration: float = 2
         "-shortest",
         output_path,
     ]
-    result = subprocess.run(cmd, capture_output=True, text=True)
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
     if result.returncode != 0:
         raise RuntimeError(f"Failed to create test video: {result.stderr}")
     return output_path

--- a/tests/test_quality_guardrails.py
+++ b/tests/test_quality_guardrails.py
@@ -81,6 +81,32 @@ def create_video_no_audio(output_path: str, color: str = "gray", duration: float
     return output_path
 
 
+def create_colorful_test_video(output_path: str, duration: float = 2.0) -> str:
+    """Create a colorful moving fixture with enough chroma/contrast for guardrails."""
+    cmd = [
+        "ffmpeg",
+        "-y",
+        "-f",
+        "lavfi",
+        "-i",
+        f"testsrc2=size=320x240:rate=24:duration={duration}",
+        "-f",
+        "lavfi",
+        "-i",
+        f"sine=frequency=1000:duration={duration}",
+        "-vf",
+        "hue=s=1.4,eq=brightness=0.03:contrast=1.1",
+        "-pix_fmt",
+        "yuv420p",
+        "-shortest",
+        output_path,
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        raise RuntimeError(f"Failed to create colorful test video: {result.stderr}")
+    return output_path
+
+
 class TestQualityReport:
     """Tests for QualityReport dataclass."""
 
@@ -196,6 +222,21 @@ class TestVisualQualityGuardrails:
             details = report.details
             if details.get("color_cast"):
                 assert "red" in details["color_cast"] or report.score < 70
+
+    def test_colorful_fixture_has_usable_contrast_and_saturation(self, guardrails, tmp_path):
+        """Dogfood-style colorful video should not fail due missing signalstats fields."""
+        video_path = str(tmp_path / "colorful.mp4")
+        create_colorful_test_video(video_path)
+
+        contrast = guardrails.check_contrast(video_path)
+        saturation = guardrails.check_saturation(video_path)
+        color_balance = guardrails.check_color_balance(video_path)
+
+        assert contrast.passed is True
+        assert contrast.details["y_high"] > contrast.details["y_low"]
+        assert saturation.passed is True
+        assert saturation.details["sat_avg"] > 0
+        assert color_balance.score > 0
 
     def test_bad_color_cast_fixture_fails_quality_gate(self, tmp_path):
         from mcp_video.quality_guardrails import assert_quality


### PR DESCRIPTION
Repair failures surfaced by the v1.3.2 dogfood render: animated text now handles real font-file paths and typewriter routing, and visual quality analysis uses FFmpeg signalstats fields that exist for contrast, saturation, and color balance.

Constraint: Dogfood against the published package exposed valid MP4s failing quality analysis and animated text commands failing on macOS font paths.

Rejected: Treat the quality warnings as cosmetic | they hid broken analyzer assumptions and made the release artifact look worse than it was.

Confidence: high

Scope-risk: moderate

Directive: Keep dogfood-generated media in ignored artifacts; keep regression tests on real FFmpeg fixtures for user-visible CLI paths.

Tested: python3 -m pytest tests/test_quality_guardrails.py tests/test_cli.py::TestCLICompositionHandlers -q --tb=short; python3 -m ruff check mcp_video/effects_engine/text.py mcp_video/quality_guardrails.py tests/test_cli.py tests/test_quality_guardrails.py; python3 -m ruff format --check mcp_video/effects_engine/text.py mcp_video/quality_guardrails.py tests/test_cli.py tests/test_quality_guardrails.py; python3 -m mcp_video --format json video-quality-check dogfood_artifacts/mcp_video_132_dogfood_showcase.mp4; python3 -m mcp_video video-text-animated dogfood_artifacts/bg_04.mp4 'post-switch slide-up' -a slide-up --font '/System/Library/Fonts/Supplemental/Arial Black.ttf' --duration 1.5 -o dogfood_artifacts/post_switch_slideup.mp4; python3 -m mcp_video video-text-animated dogfood_artifacts/bg_04.mp4 'post-switch typewriter' -a typewriter --font '/System/Library/Fonts/Supplemental/Arial Black.ttf' --duration 1.5 --typewriter-speed 0.04 -o dogfood_artifacts/post_switch_typewriter.mp4

Not-tested: Full repository test suite after this narrow dogfood repair.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/mcp-video/pr/243"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->