### PR TITLE
Release 1.3.3 dogfood QA patch

### DIFF
--- a/.github/scripts/check-built-artifacts.py
+++ b/.github/scripts/check-built-artifacts.py
@@ -52,12 +52,14 @@ def find_offenders(artifact: Path) -> list[str]:
     else:
         raise ValueError(f"Unsupported artifact type: {artifact}")
 
-    return [
-        name
-        for name in names
-        if any(fragment in name for fragment in FORBIDDEN_SUBSTRINGS)
-        or any(name.endswith(suffix) for suffix in FORBIDDEN_SUFFIXES)
-    ]
+    offenders = []
+    for name in names:
+        normalized = f"/{name.lstrip('/')}"
+        if any(fragment in normalized for fragment in FORBIDDEN_SUBSTRINGS) or any(
+            normalized.endswith(suffix) for suffix in FORBIDDEN_SUFFIXES
+        ):
+            offenders.append(name)
+    return offenders
 
 
 def main() -> int:

--- a/.github/scripts/check-built-artifacts.py
+++ b/.github/scripts/check-built-artifacts.py
@@ -9,14 +9,33 @@ import zipfile
 from pathlib import Path
 
 FORBIDDEN_SUBSTRINGS = (
+    "/.github/",
+    "/.git/",
     "/.playwright-mcp/",
+    "/.pytest_cache/",
+    "/.ruff_cache/",
     "/.stitch/",
-    "/out/",
-    "/manual/",
+    "/__pycache__/",
+    "/demo/",
+    "/docs/",
+    "/dogfood_artifacts/",
     "/explainer-video/",
+    "/examples/",
+    "/manual/",
+    "/out/",
 )
 
 FORBIDDEN_SUFFIXES = (
+    "/.coverage",
+    "/.git",
+    "/index.html",
+    "/og-social-preview.png",
+    "/uv.lock",
+    ".mp3",
+    ".mp4",
+    ".mov",
+    ".wav",
+    ".webm",
     "/test_comprehensive.py",
     "/test_real_video.py",
 )

--- a/mcp_video/__init__.py
+++ b/mcp_video/__init__.py
@@ -1,6 +1,6 @@
 """mcp-video — Video editing MCP server for AI agents."""
 
-__version__ = "1.3.2"
+__version__ = "1.3.3"
 
 from .client import Client
 from .ai_engine import (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-video"
-version = "1.3.2"
+version = "1.3.3"
 description = "Video editing MCP server for AI agents. 87 tools, 3 interfaces, rich CLI. Local, fast, free."
 readme = "README.md"
 license = "Apache-2.0"
@@ -111,6 +111,11 @@ Discussions = "https://github.com/KyaniteLabs/mcp-video/discussions"
 
 [tool.hatch.build]
 exclude = [
+    ".git/",
+    ".gitignore",
+    ".coverage",
+    ".pytest_cache/",
+    ".ruff_cache/",
     ".venv/",
     ".venv-build/",
     ".playwright-mcp/",
@@ -119,15 +124,31 @@ exclude = [
     "manual/",
     "out/",
     "explainer-video/",
+    "dogfood_artifacts/",
     "dist/",
     "build/",
     "test_comprehensive.py",
     "test_real_video.py",
+    "*.mp3",
+    "*.mp4",
+    "*.mov",
+    "*.wav",
+    "*.webm",
     "*.egg-info/",
 ]
 
 [tool.hatch.build.targets.wheel]
 packages = ["mcp_video"]
+
+[tool.hatch.build.targets.sdist]
+only-include = [
+    "/mcp_video",
+    "/CHANGELOG.md",
+    "/LICENSE",
+    "/README.md",
+    "/pyproject.toml",
+    "/server.json",
+]
 
 [tool.pytest.ini_options]
 markers = [

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.KyaniteLabs/mcp-video",
   "title": "mcp-video",
   "description": "Video editing MCP server for AI agents using FFmpeg and Hyperframes structured tools.",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "repository": {
     "url": "https://github.com/KyaniteLabs/mcp-video",
     "source": "github"
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "mcp-video",
-      "version": "1.3.2",
+      "version": "1.3.3",
       "transport": {
         "type": "stdio"
       }

--- a/tests/test_launch_remediation.py
+++ b/tests/test_launch_remediation.py
@@ -150,3 +150,18 @@ def test_built_artifact_checker_accepts_package_only_wheel(tmp_path):
         zf.writestr("mcp_video-9.9.9.dist-info/METADATA", "Name: mcp-video\n")
 
     assert checker["find_offenders"](wheel) == []
+
+
+def test_built_artifact_checker_normalizes_wheel_root_paths(tmp_path):
+    checker = runpy.run_path(".github/scripts/check-built-artifacts.py")
+    wheel = tmp_path / "mcp_video-9.9.9-py3-none-any.whl"
+
+    with zipfile.ZipFile(wheel, "w") as zf:
+        zf.writestr("mcp_video/__init__.py", "")
+        zf.writestr(".github/workflows/publish.yml", "")
+        zf.writestr("dogfood_artifacts/showcase.mp4", "")
+
+    offenders = checker["find_offenders"](wheel)
+
+    assert ".github/workflows/publish.yml" in offenders
+    assert "dogfood_artifacts/showcase.mp4" in offenders

--- a/tests/test_launch_remediation.py
+++ b/tests/test_launch_remediation.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import runpy
+import tarfile
+import zipfile
 from pathlib import Path
 
 import pytest
@@ -107,3 +110,43 @@ def test_ytdlp_rejects_resolved_private_media_url(monkeypatch, tmp_path):
         _download_with_ytdlp("https://youtube.com/watch?v=unsafe", str(tmp_path))
 
     assert exc_info.value.code == "ssrf_blocked"
+
+
+def test_built_artifact_checker_rejects_dogfood_media_and_repo_metadata(tmp_path):
+    checker = runpy.run_path(".github/scripts/check-built-artifacts.py")
+    archive = tmp_path / "mcp_video-9.9.9.tar.gz"
+
+    with tarfile.open(archive, "w:gz") as tf:
+        for name, body in {
+            "mcp_video-9.9.9/mcp_video/__init__.py": b"",
+            "mcp_video-9.9.9/dogfood_artifacts/showcase.mp4": b"media",
+            "mcp_video-9.9.9/.git/config": b"repo",
+            "mcp_video-9.9.9/.github/workflows/publish.yml": b"ci",
+            "mcp_video-9.9.9/uv.lock": b"lock",
+            "mcp_video-9.9.9/og-social-preview.png": b"image",
+            "mcp_video-9.9.9/.coverage": b"coverage",
+        }.items():
+            path = tmp_path / name
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_bytes(body)
+            tf.add(path, arcname=name)
+
+    offenders = checker["find_offenders"](archive)
+
+    assert "mcp_video-9.9.9/dogfood_artifacts/showcase.mp4" in offenders
+    assert "mcp_video-9.9.9/.git/config" in offenders
+    assert "mcp_video-9.9.9/.github/workflows/publish.yml" in offenders
+    assert "mcp_video-9.9.9/uv.lock" in offenders
+    assert "mcp_video-9.9.9/og-social-preview.png" in offenders
+    assert "mcp_video-9.9.9/.coverage" in offenders
+
+
+def test_built_artifact_checker_accepts_package_only_wheel(tmp_path):
+    checker = runpy.run_path(".github/scripts/check-built-artifacts.py")
+    wheel = tmp_path / "mcp_video-9.9.9-py3-none-any.whl"
+
+    with zipfile.ZipFile(wheel, "w") as zf:
+        zf.writestr("mcp_video/__init__.py", "")
+        zf.writestr("mcp_video-9.9.9.dist-info/METADATA", "Name: mcp-video\n")
+
+    assert checker["find_offenders"](wheel) == []


### PR DESCRIPTION
## Summary
- Bump mcp-video package/server metadata to 1.3.3 for the dogfood QA patch release.
- Narrow the Hatch sdist to runtime source and essential release metadata.
- Harden built-artifact checks so PyPI builds fail if dogfood media, repo internals, caches, generated media, docs/examples/demo, or CI/website surfaces leak into artifacts.
- Add regression tests for the release artifact checker.

## Verification
- `python3 -m pytest tests/test_launch_remediation.py -q --tb=short` -> 7 passed
- `python3 -m ruff check .github/scripts/check-built-artifacts.py tests/test_launch_remediation.py` -> clean
- `git diff --check` -> clean
- `python3 -m build` -> built wheel + sdist
- `python3 .github/scripts/check-built-artifacts.py dist` -> wheel clean, sdist clean
- `twine check dist/*` -> PASSED
- `python3 -m ruff check .` -> clean
- `python3 -m pytest -q` -> 1056 passed, 8 skipped
- Built sdist is 188 KB and archive inspection found 0 forbidden entries

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/mcp-video/pr/244"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->