### PR TITLE
Release 1.3.4 quiet animated text fallback

### DIFF
--- a/mcp_video/__init__.py
+++ b/mcp_video/__init__.py
@@ -1,6 +1,6 @@
 """mcp-video — Video editing MCP server for AI agents."""
 
-__version__ = "1.3.3"
+__version__ = "1.3.4"
 
 from .client import Client
 from .ai_engine import (

--- a/mcp_video/effects_engine/text.py
+++ b/mcp_video/effects_engine/text.py
@@ -131,6 +131,11 @@ def _get_video_dimensions(video_path: str) -> tuple[int, int]:
 
 def _load_pil_font(font_name: str, size: int):
     """Try to locate a TrueType font file for PIL."""
+    try:
+        from PIL import ImageFont
+    except ImportError:
+        return None
+
     import glob
     import platform
 
@@ -160,19 +165,13 @@ def _load_pil_font(font_name: str, size: int):
             base = os.path.splitext(os.path.basename(path))[0].replace(" ", "").replace("-", "").lower()
             if cleaned in base or base in cleaned:
                 try:
-                    from PIL import ImageFont
-
                     return ImageFont.truetype(path, size)
                 except OSError:
                     continue
     try:
-        from PIL import ImageFont
-
         return ImageFont.truetype(font_name, size)
     except OSError:
         try:
-            from PIL import ImageFont
-
             return ImageFont.truetype(f"{font_name}.ttf", size)
         except OSError:
             return None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-video"
-version = "1.3.3"
+version = "1.3.4"
 description = "Video editing MCP server for AI agents. 87 tools, 3 interfaces, rich CLI. Local, fast, free."
 readme = "README.md"
 license = "Apache-2.0"

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.KyaniteLabs/mcp-video",
   "title": "mcp-video",
   "description": "Video editing MCP server for AI agents using FFmpeg and Hyperframes structured tools.",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "repository": {
     "url": "https://github.com/KyaniteLabs/mcp-video",
     "source": "github"
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "mcp-video",
-      "version": "1.3.3",
+      "version": "1.3.4",
       "transport": {
         "type": "stdio"
       }

--- a/tests/test_launch_remediation.py
+++ b/tests/test_launch_remediation.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import builtins
+import logging
 import runpy
 import tarfile
 import zipfile
@@ -165,3 +167,23 @@ def test_built_artifact_checker_normalizes_wheel_root_paths(tmp_path):
 
     assert ".github/workflows/publish.yml" in offenders
     assert "dogfood_artifacts/showcase.mp4" in offenders
+
+
+def test_text_measurement_quietly_uses_fallback_without_pillow(monkeypatch, caplog):
+    from mcp_video.effects_engine import text as text_engine
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "PIL" or name.startswith("PIL."):
+            raise ImportError("No module named 'PIL'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    with caplog.at_level(logging.WARNING):
+        width, height = text_engine._measure_text("fallback", "Arial", 40)
+
+    assert width > 0
+    assert height > 0
+    assert "PIL text measurement failed" not in caplog.text


### PR DESCRIPTION
## Summary
- Bump mcp-video package/server metadata to 1.3.4.
- Make missing optional Pillow a quiet heuristic fallback for animated text measurement instead of a warning during normal base-package CLI use.
- Add regression coverage so the fallback stays warning-free.

## Verification
- `python3 -m pytest tests/test_launch_remediation.py -q --tb=short` -> 9 passed
- `python3 -m ruff check mcp_video/effects_engine/text.py tests/test_launch_remediation.py` -> clean
- `git diff --check` -> clean
- `python3 -m build` -> built wheel + sdist
- `python3 .github/scripts/check-built-artifacts.py dist` -> wheel clean, sdist clean
- release metadata/PyPI availability check -> 1.3.4 aligned and PyPI returned 404
- `python3 -m ruff check .` -> clean
- `python3 -m pytest -q` -> 1058 passed, 8 skipped

## Context
This is a tiny dogfood polish follow-up after 1.3.3: the published package worked, but the default install emitted a noisy Pillow fallback warning when rendering animated text. The fallback is intentional, so the warning should not be user-visible.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/mcp-video/pr/245"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->