### PR TITLE
Fix stale MCP registry launch metadata

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Create venv
         run: python -m venv .venv
       - name: Install build dependencies
-        run: .venv/bin/pip install build twine
+        run: .venv/bin/pip install build jsonschema twine
       - name: Verify release version is publishable
         env:
           RELEASE_TAG: ${{ github.event.release.tag_name }}
@@ -81,6 +81,26 @@ jobs:
               raise SystemExit(1)
           print(f"Release {tag} is aligned and PyPI version {version} is available.")
           PY
+      - name: Validate MCP registry metadata
+        run: |
+          .venv/bin/python - <<'PY'
+          import json
+          import urllib.request
+          from pathlib import Path
+
+          from jsonschema import Draft7Validator
+
+          server = json.loads(Path("server.json").read_text())
+          with urllib.request.urlopen(server["$schema"], timeout=20) as response:
+              schema = json.load(response)
+          errors = sorted(Draft7Validator(schema).iter_errors(server), key=lambda error: list(error.path))
+          if errors:
+              for error in errors:
+                  path = "/".join(str(part) for part in error.path) or "<root>"
+                  print(f"{path}: {error.message}")
+              raise SystemExit(1)
+          print(f"MCP registry metadata is valid for {server['name']} {server['version']}.")
+          PY
       - name: Build package
         run: .venv/bin/python -m build
       - name: Check built artifact contents
@@ -109,3 +129,21 @@ jobs:
           path: dist/
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+
+  publish-mcp-registry:
+    name: Publish to MCP Registry
+    needs: publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install mcp-publisher
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+          ./mcp-publisher --help
+      - name: Authenticate to MCP Registry
+        run: ./mcp-publisher login github-oidc
+      - name: Publish server metadata
+        run: ./mcp-publisher publish

--- a/docs/AI_AGENT_DISCOVERY.md
+++ b/docs/AI_AGENT_DISCOVERY.md
@@ -84,9 +84,9 @@ Cursor:
 
 High-leverage listing targets:
 
-- Official MCP Registry — metadata in `server.json` at the repo root, ready for submission via `npx @anthropic-ai/mcp-registry publish`. Identifier: `io.github.KyaniteLabs/mcp-video`.
+- Official MCP Registry — metadata in `server.json` at the repo root, published from the release workflow via `mcp-publisher` after PyPI publication. Identifier: `io.github.KyaniteLabs/mcp-video`.
 - [Glama MCP Registry](https://glama.ai/mcp/servers) — Submit via GitHub repo URL.
-- [Smithery](https://smithery.ai) — `npx @anthropic-ai/mcp-registry publish`.
+- [Smithery](https://smithery.ai) — Submit via GitHub repo URL once the official registry and Glama listings are fresh.
 - [MCP.so](https://mcp.so) — Submit via GitHub repo URL.
 - [Awesome MCP Servers](https://github.com/punkpeye/awesome-mcp-servers) — Submit via PR.
 - GitHub topics for `mcp`, `mcp-server`, `ffmpeg`, `video-editing`, `ai-agents`.

--- a/index.html
+++ b/index.html
@@ -8,21 +8,21 @@
     <meta name="author" content="Simon Gonzalez De Cruz">
     <meta name="robots" content="index, follow, max-image-preview:large">
     <meta name="keywords" content="MCP server, video editing, FFmpeg, Hyperframes, AI agents, Claude Code, Cursor, Python video editing, open source">
-    <link rel="canonical" href="https://pastorsimon1798.github.io/mcp-video/">
-    <link rel="sitemap" type="application/xml" href="https://pastorsimon1798.github.io/mcp-video/sitemap.xml">
+    <link rel="canonical" href="https://kyanitelabs.github.io/mcp-video/">
+    <link rel="sitemap" type="application/xml" href="https://kyanitelabs.github.io/mcp-video/sitemap.xml">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://pastorsimon1798.github.io/mcp-video/">
+    <meta property="og:url" content="https://kyanitelabs.github.io/mcp-video/">
     <meta property="og:title" content="mcp-video — 87 Video Editing Tools for AI Agents">
     <meta property="og:description" content="Open-source MCP server that gives AI agents 87 video editing tools via FFmpeg and Hyperframes. Local, fast, free.">
     <meta property="og:site_name" content="mcp-video">
-    <meta property="og:image" content="https://pastorsimon1798.github.io/mcp-video/og-social-preview.png">
+    <meta property="og:image" content="https://kyanitelabs.github.io/mcp-video/og-social-preview.png">
     <meta property="og:image:width" content="1920">
     <meta property="og:image:height" content="1080">
     <meta property="og:image:alt" content="mcp-video — 87 video editing tools for AI agents">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="mcp-video — 87 Video Editing Tools for AI Agents">
     <meta name="twitter:description" content="Open-source MCP server with FFmpeg + Hyperframes. Works with Claude Code, Cursor, and any MCP client.">
-    <meta name="twitter:image" content="https://pastorsimon1798.github.io/mcp-video/og-social-preview.png">
+    <meta name="twitter:image" content="https://kyanitelabs.github.io/mcp-video/og-social-preview.png">
 
     <!-- Fonts with proper preconnect -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -39,14 +39,14 @@
       "@type": ["SoftwareSourceCode", "SoftwareApplication"],
       "name": "mcp-video",
       "description": "Open source MCP server, Python client, and CLI for AI-agent video editing with FFmpeg and Hyperframes. 87 tools across 10 categories.",
-      "url": "https://pastorsimon1798.github.io/mcp-video/",
-      "codeRepository": "https://github.com/Pastorsimon1798/mcp-video",
+      "url": "https://kyanitelabs.github.io/mcp-video/",
+      "codeRepository": "https://github.com/KyaniteLabs/mcp-video",
       "author": {
         "@type": "Person",
         "name": "Simon Gonzalez De Cruz",
-        "url": "https://github.com/Pastorsimon1798"
+        "url": "https://github.com/KyaniteLabs"
       },
-      "version": "1.3.0",
+      "version": "1.3.5",
       "datePublished": "2025-06-01",
       "programmingLanguage": ["Python", "TypeScript"],
       "runtimePlatform": ["Python 3.11+", "FFmpeg", "Model Context Protocol", "Hyperframes"],
@@ -54,7 +54,7 @@
       "operatingSystem": "macOS, Linux, Windows",
       "license": "https://www.apache.org/licenses/LICENSE-2.0",
       "downloadUrl": "https://pypi.org/project/mcp-video/#files",
-      "installUrl": "https://github.com/Pastorsimon1798/mcp-video#install",
+      "installUrl": "https://github.com/KyaniteLabs/mcp-video#install",
       "offers": {
         "@type": "Offer",
         "price": "0",
@@ -67,7 +67,7 @@
       },
       "sameAs": [
         "https://pypi.org/project/mcp-video/",
-        "https://github.com/Pastorsimon1798/mcp-video"
+        "https://github.com/KyaniteLabs/mcp-video"
       ]
     }
     </script>
@@ -76,11 +76,11 @@
       "@context": "https://schema.org",
       "@type": "Organization",
       "name": "mcp-video",
-      "url": "https://pastorsimon1798.github.io/mcp-video/",
-      "logo": "https://pastorsimon1798.github.io/mcp-video/logo.png",
+      "url": "https://kyanitelabs.github.io/mcp-video/",
+      "logo": "https://kyanitelabs.github.io/mcp-video/logo.png",
       "description": "Open-source MCP server for AI-powered video editing",
       "sameAs": [
-        "https://github.com/Pastorsimon1798/mcp-video",
+        "https://github.com/KyaniteLabs/mcp-video",
         "https://pypi.org/project/mcp-video/"
       ]
     }
@@ -837,7 +837,7 @@
         <a href="#interfaces" aria-current="false">Interfaces</a>
         <a href="#install" aria-current="false">Install</a>
         <a href="llms.txt" aria-current="false">llms.txt</a>
-        <a href="https://github.com/pastorsimon1798/mcp-video" class="nav-cta">GitHub</a>
+        <a href="https://github.com/KyaniteLabs/mcp-video" class="nav-cta">GitHub</a>
     </div>
     <button class="mobile-menu-btn" aria-label="Toggle navigation menu" aria-expanded="false" onclick="document.querySelector('.links').classList.toggle('mobile-open'); this.setAttribute('aria-expanded', this.getAttribute('aria-expanded') === 'false' ? 'true' : 'false');">☰</button>
 </nav>
@@ -849,7 +849,7 @@
 <div class="hero">
     <div class="hero-badge animate-in">
         <div class="pulse"></div>
-        v1.3.0 — 87 tools tested & working
+        v1.3.5 — 87 tools tested & working
     </div>
     <h1 class="animate-in delay-1">
         87 Video Tools.<br>
@@ -866,7 +866,7 @@
             <div class="label">Tools</div>
         </div>
         <div class="hero-stat">
-            <div class="num">858</div>
+            <div class="num">1058</div>
             <div class="label">Tests</div>
         </div>
         <div class="hero-stat">
@@ -879,7 +879,7 @@
         </div>
     </div>
     <div class="cta-row animate-in delay-4">
-        <a class="btn btn-primary" href="https://github.com/pastorsimon1798/mcp-video">View on GitHub</a>
+        <a class="btn btn-primary" href="https://github.com/KyaniteLabs/mcp-video">View on GitHub</a>
         <a class="btn btn-secondary" href="#install">pip install mcp-video</a>
     </div>
 </div>
@@ -1227,7 +1227,7 @@ mcp-video doctor  <span class="c"># Check FFmpeg and optional deps</span></pre>
 
     <div class="stats-bar">
         <div class="stat">
-            <div class="num">858</div>
+            <div class="num">1058</div>
             <div class="label">Tests Collected</div>
         </div>
         <div class="stat">
@@ -1270,7 +1270,7 @@ mcp-video doctor  <span class="c"># Check FFmpeg and optional deps</span></pre>
 <footer>
     <div>© 2025 Simon Gonzalez De Cruz. Apache-2.0 License.</div>
     <div class="footer-links">
-        <a href="https://github.com/pastorsimon1798/mcp-video">GitHub</a>
+        <a href="https://github.com/KyaniteLabs/mcp-video">GitHub</a>
         <a href="https://pypi.org/project/mcp-video/">PyPI</a>
         <a href="llms.txt">llms.txt</a>
     </div>

--- a/mcp_video/__init__.py
+++ b/mcp_video/__init__.py
@@ -1,6 +1,6 @@
 """mcp-video — Video editing MCP server for AI agents."""
 
-__version__ = "1.3.4"
+__version__ = "1.3.5"
 
 from .client import Client
 from .ai_engine import (

--- a/mcp_video/ai_engine/download.py
+++ b/mcp_video/ai_engine/download.py
@@ -173,7 +173,7 @@ def _download_direct_url(url: str, dest_dir: str) -> str:
     filename = re.sub(r"[^\w.\-]", "_", filename)
     dest = str(Path(dest_dir) / filename)
 
-    headers = {"User-Agent": "mcp-video/1.3 (+https://github.com/KyaniteLabs/mcp-video)"}
+    headers = {"User-Agent": "mcp-video/1.3.5 (+https://github.com/KyaniteLabs/mcp-video)"}
     req = urllib.request.Request(url, headers=headers)
     max_download_bytes = 2 * (1 << 30)  # 2 GiB limit
     opener = urllib.request.build_opener(urllib.request.ProxyHandler({}))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-video"
-version = "1.3.4"
+version = "1.3.5"
 description = "Video editing MCP server for AI agents. 87 tools, 3 interfaces, rich CLI. Local, fast, free."
 readme = "README.md"
 license = "Apache-2.0"

--- a/robots.txt
+++ b/robots.txt
@@ -19,5 +19,5 @@ Allow: /
 User-agent: Claude-User
 Allow: /
 
-Sitemap: https://pastorsimon1798.github.io/mcp-video/sitemap.xml
+Sitemap: https://kyanitelabs.github.io/mcp-video/sitemap.xml
 

--- a/scripts/github-pr-monitor.py
+++ b/scripts/github-pr-monitor.py
@@ -2,8 +2,8 @@
 """Monitor GitHub CI status + PR review activity (comments/reviews).
 
 Usage examples:
-  ./scripts/github-pr-monitor.py --owner Pastorsimon1798 --repo mcp-video
-  ./scripts/github-pr-monitor.py --owner Pastorsimon1798 --repo mcp-video --pr 17
+  ./scripts/github-pr-monitor.py --owner KyaniteLabs --repo mcp-video
+  ./scripts/github-pr-monitor.py --owner KyaniteLabs --repo mcp-video --pr 17
 
 Auth (optional):
   export GITHUB_TOKEN=ghp_xxx
@@ -158,7 +158,7 @@ def print_pr_summary(owner: str, repo: str, prs: list[dict[str, Any]], explicit_
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Monitor CI + review comments for a GitHub repo/PR.")
-    parser.add_argument("--owner", required=True, help="GitHub owner/org, e.g. Pastorsimon1798")
+    parser.add_argument("--owner", required=True, help="GitHub owner/org, e.g. KyaniteLabs")
     parser.add_argument("--repo", required=True, help="GitHub repository name, e.g. mcp-video")
     parser.add_argument("--pr", type=int, help="Specific PR number to inspect (default: first open PR)")
     parser.add_argument("--run-limit", type=int, default=5, help="How many recent workflow runs to show")

--- a/server.json
+++ b/server.json
@@ -3,7 +3,8 @@
   "name": "io.github.KyaniteLabs/mcp-video",
   "title": "mcp-video",
   "description": "Video editing MCP server for AI agents using FFmpeg and Hyperframes structured tools.",
-  "version": "1.3.4",
+  "version": "1.3.5",
+  "websiteUrl": "https://kyanitelabs.github.io/mcp-video/",
   "repository": {
     "url": "https://github.com/KyaniteLabs/mcp-video",
     "source": "github"
@@ -12,7 +13,8 @@
     {
       "registryType": "pypi",
       "identifier": "mcp-video",
-      "version": "1.3.4",
+      "version": "1.3.5",
+      "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"
       }

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,43 +1,43 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://pastorsimon1798.github.io/mcp-video/</loc>
+    <loc>https://kyanitelabs.github.io/mcp-video/</loc>
     <lastmod>2026-04-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
-    <loc>https://pastorsimon1798.github.io/mcp-video/llms.txt</loc>
+    <loc>https://kyanitelabs.github.io/mcp-video/llms.txt</loc>
     <lastmod>2026-04-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://pastorsimon1798.github.io/mcp-video/README.md</loc>
+    <loc>https://kyanitelabs.github.io/mcp-video/README.md</loc>
     <lastmod>2026-04-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://pastorsimon1798.github.io/mcp-video/docs/AI_AGENT_DISCOVERY.md</loc>
+    <loc>https://kyanitelabs.github.io/mcp-video/docs/AI_AGENT_DISCOVERY.md</loc>
     <lastmod>2026-04-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://pastorsimon1798.github.io/mcp-video/CONTRIBUTING.md</loc>
+    <loc>https://kyanitelabs.github.io/mcp-video/CONTRIBUTING.md</loc>
     <lastmod>2026-04-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://pastorsimon1798.github.io/mcp-video/SECURITY.md</loc>
+    <loc>https://kyanitelabs.github.io/mcp-video/SECURITY.md</loc>
     <lastmod>2026-04-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.4</priority>
   </url>
   <url>
-    <loc>https://pastorsimon1798.github.io/mcp-video/docs/faq.md</loc>
+    <loc>https://kyanitelabs.github.io/mcp-video/docs/faq.md</loc>
     <lastmod>2026-04-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>

--- a/tests/test_public_surface.py
+++ b/tests/test_public_surface.py
@@ -4,6 +4,14 @@ import re
 import subprocess
 import sys
 import asyncio
+import json
+from pathlib import Path
+
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+
+ROOT = Path(__file__).resolve().parents[1]
 
 
 EXPECTED_CLI_COMMANDS = {
@@ -220,6 +228,66 @@ def test_server_tool_registry_keeps_public_tool_names():
 
     assert tool_names >= EXPECTED_SERVER_TOOLS
     assert len(tool_names) == 87
+
+
+def test_stdio_server_launches_and_lists_tools_like_registry_clients():
+    """Exercise the package the way registries launch it: stdio subprocess + MCP handshake."""
+
+    async def check_server() -> None:
+        params = StdioServerParameters(command=sys.executable, args=["-m", "mcp_video"])
+        async with stdio_client(params) as (read, write), ClientSession(read, write) as session:
+            init_result = await session.initialize()
+            tools_result = await session.list_tools()
+
+        tool_names = {tool.name for tool in tools_result.tools}
+        assert init_result.serverInfo.name == "mcp-video"
+        assert tool_names >= EXPECTED_SERVER_TOOLS
+        assert len(tool_names) == 87
+
+    asyncio.run(check_server())
+
+
+def test_public_discovery_files_do_not_point_at_old_personal_namespace():
+    checked_paths = [
+        ROOT / "README.md",
+        ROOT / "server.json",
+        ROOT / "pyproject.toml",
+        ROOT / "index.html",
+        ROOT / "robots.txt",
+        ROOT / "sitemap.xml",
+        ROOT / "docs" / "AI_AGENT_DISCOVERY.md",
+        ROOT / "scripts" / "github-pr-monitor.py",
+        ROOT / "mcp_video" / "ai_engine" / "download.py",
+        ROOT / "mcp_video" / "errors.py",
+    ]
+    stale_fragments = [
+        "pastorsimon1798.github.io/mcp-video",
+        "github.com/pastorsimon1798/mcp-video",
+        "github.com/Pastorsimon1798/mcp-video",
+        "io.github.pastorsimon1798/mcp-video",
+    ]
+
+    offenders = {
+        str(path.relative_to(ROOT)): fragment
+        for path in checked_paths
+        for fragment in stale_fragments
+        if fragment in path.read_text(encoding="utf-8")
+    }
+
+    assert offenders == {}
+
+
+def test_server_json_and_readme_match_registry_identity():
+    server = json.loads((ROOT / "server.json").read_text(encoding="utf-8"))
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+
+    assert server["name"] == "io.github.KyaniteLabs/mcp-video"
+    assert server["websiteUrl"] == "https://kyanitelabs.github.io/mcp-video/"
+    assert server["repository"]["url"] == "https://github.com/KyaniteLabs/mcp-video"
+    assert server["packages"][0]["identifier"] == "mcp-video"
+    assert server["packages"][0]["runtimeHint"] == "uvx"
+    assert server["packages"][0]["transport"]["type"] == "stdio"
+    assert f"mcp-name: {server['name']}" in readme
 
 
 def test_module_reexports():


### PR DESCRIPTION
## Summary
- Bump release metadata to 1.3.5 for a registry/discovery launch fix.
- Add `websiteUrl` and `runtimeHint: uvx` to `server.json` while preserving PyPI stdio transport.
- Add an MCP stdio subprocess handshake regression that initializes the server and verifies all 87 tools are visible, matching registry/client launch behavior.
- Clean stale personal namespace URLs from public discovery surfaces: static site metadata, sitemap, robots, helper script examples, and user-agent.
- Add release-workflow validation of `server.json` against the official MCP schema.
- Add a release-workflow job that publishes metadata to the official MCP Registry with `mcp-publisher` after PyPI publish succeeds.

## Verification
- `python3 -m pytest tests/test_public_surface.py tests/test_launch_remediation.py -q --tb=short` -> 16 passed
- `python3 -m ruff check tests/test_public_surface.py mcp_video/ai_engine/download.py` -> clean
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/publish.yml")'` -> workflow YAML parsed
- `mcp-publisher validate` -> server.json is valid
- JSON Schema validation against `https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json` -> 0 errors
- `python3 -m build` -> built 1.3.5 wheel + sdist
- `python3 .github/scripts/check-built-artifacts.py dist` -> clean
- `twine check dist/*` -> PASSED
- `python3 -m ruff check .` -> clean
- `python3 -m pytest -q` -> 1061 passed, 8 skipped
- PyPI 1.3.5 availability check -> 404 before release

## Notes
The current published 1.3.4 package can launch and list 87 tools via a clean MCP stdio handshake, but the public discovery/registry surfaces were stale and the official registry publish step was missing from the release pipeline.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/mcp-video/pr/246"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->