### PR TITLE
Sharpen GitHub discovery and launch metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 <p align="center">
-  <img src="og-social-preview.png" alt="mcp-video" width="100%">
+  <a href="https://kyanitelabs.tech">
+    <img src="https://kyanitelabs.tech/static/brand/hero_crystal_workbench_1672x941.png" alt="Kyanite Labs AI tool workbench hero image" width="100%">
+  </a>
 </p>
 
 <!-- mcp-name: io.github.KyaniteLabs/mcp-video -->
@@ -7,58 +9,63 @@
 <h1 align="center">mcp-video</h1>
 
 <p align="center">
-  <strong>Video editing and creation for AI agents.</strong><br>
-  Edit existing video with FFmpeg. Create new video from code with Hyperframes.
+  <strong>Video editing MCP server for AI agents.</strong><br>
+  87 structured tools for FFmpeg video editing, media analysis, subtitles, audio, effects, and Hyperframes video creation.
 </p>
 
 <p align="center">
   <a href="https://pypi.org/project/mcp-video/"><img src="https://img.shields.io/pypi/v/mcp-video.svg" alt="PyPI"></a>
   <a href="https://github.com/KyaniteLabs/mcp-video/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/KyaniteLabs/mcp-video/.github/workflows/ci.yml?branch=master&label=CI" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tools-87%20MCP%20tools-orange.svg" alt="Tools">
-  <img src="https://img.shields.io/badge/license-Apache%202.0-blue.svg" alt="License">
-  <img src="https://img.shields.io/badge/python-3.11+-blue.svg" alt="Python">
+  <img src="https://img.shields.io/badge/MCP-87%20tools-orange.svg" alt="87 MCP tools">
+  <img src="https://img.shields.io/badge/python-3.11%2B-blue.svg" alt="Python 3.11+">
+  <img src="https://img.shields.io/badge/license-Apache%202.0-blue.svg" alt="Apache 2.0">
 </p>
 
 <p align="center">
-  <a href="#installation">Install</a> &bull;
+  <a href="#install">Install</a> &bull;
   <a href="#quick-start">Quick Start</a> &bull;
-  <a href="#tools-overview">Tools</a> &bull;
-  <a href="docs/TOOLS.md">Full Reference</a> &bull;
-  <a href="docs/AI_AGENT_DISCOVERY.md">Agent Discovery</a> &bull;
-  <a href="CONTRIBUTING.md">Contributing</a> &bull;
-  <a href="CHANGELOG.md">Changelog</a>
+  <a href="#what-agents-can-do">Agent Workflows</a> &bull;
+  <a href="#tool-surface">Tools</a> &bull;
+  <a href="docs/TOOLS.md">Tool Reference</a> &bull;
+  <a href="docs/AI_AGENT_DISCOVERY.md">AI Discovery</a> &bull;
+  <a href="llms.txt">llms.txt</a>
 </p>
 
 ---
 
-
 ## Public Discovery
 
-**mcp-video** is an MCP server, Python library, and CLI for agentic video editing. It helps AI agents and automation scripts inspect, trim, merge, subtitle, resize, transcode, analyze, and generate video with FFmpeg and code-driven creation workflows.
+**mcp-video** is a free, open-source **Model Context Protocol (MCP) server**, Python library, and CLI that gives AI agents a real video-editing surface. It wraps FFmpeg, media analysis, quality checks, subtitles, audio generation, effects, and code-driven Hyperframes rendering behind structured tool schemas.
 
-**Best-fit searches:** video editing MCP server, AI agent video editing, FFmpeg automation, Claude video tools, Cursor MCP video, Python video editing library, agentic media pipeline, video automation CLI.
+Best-fit searches:
 
-## What is mcp-video?
+- video editing MCP server
+- AI agent video editing
+- FFmpeg MCP tools
+- Claude Code video editing
+- Cursor MCP video tools
+- Python video editing library
+- subtitle automation
+- reels and shorts automation
+- agentic media pipeline
+- local AI video workflow
 
-An open-source video editing server built on the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/). It gives AI agents, developers, and video creators the ability to programmatically edit and create video files.
+## Why It Exists
 
-**Two modes:**
-1. **Edit existing video** with FFmpeg — trim, merge, overlay text, add audio, apply filters, stabilize, detect scenes, transcribe, and more.
-2. **Create new video from code** with [Hyperframes](https://hyperframes.io/) (HTML-native, Apache 2.0) — scaffold compositions, preview live, render to MP4, then post-process.
+AI agents can write FFmpeg commands, but they should not have to guess flags, parse brittle stderr, or silently publish broken media. mcp-video gives agents typed operations, inspectable tool metadata, structured results, and quality checkpoints so a video workflow can be automated and reviewed without turning into shell-command roulette.
 
-**Three interfaces:**
+Use it when you want an AI assistant to:
 
-| Interface | Best For | Example |
-|-----------|----------|---------|
-| **MCP Server** | AI agents (Claude Code, Cursor) | *"Trim this video and add a title"* |
-| **Python Client** | Scripts, automation, pipelines | `editor.trim("v.mp4", start="0:30", duration="15")` |
-| **CLI** | Shell scripts, quick ops, humans | `mcp-video trim video.mp4 -s 0:30 -d 15` |
+- trim, merge, resize, crop, rotate, transcode, or export video;
+- add text, subtitles, watermarks, overlays, filters, fades, effects, and transitions;
+- extract audio, normalize audio, synthesize audio, add generated audio, or create waveforms;
+- detect scenes, make thumbnails, generate storyboards, compare quality, and create release checkpoints;
+- create new video projects with Hyperframes and post-process the result with FFmpeg tools;
+- drive repeatable media workflows from Claude Code, Cursor, Codex-style clients, scripts, or CI.
 
----
+## Install
 
-## Installation
-
-**Prerequisites:** [FFmpeg](https://ffmpeg.org) must be installed. For Hyperframes features, you also need [Node.js](https://nodejs.org/) 22+.
+Prerequisite: [FFmpeg](https://ffmpeg.org/) must be installed and available on `PATH`.
 
 ```bash
 # macOS
@@ -68,348 +75,190 @@ brew install ffmpeg
 sudo apt install ffmpeg
 ```
 
-**Install:**
+Run without a global install:
+
+```bash
+uvx --from mcp-video mcp-video doctor
+```
+
+Or install with pip:
 
 ```bash
 pip install mcp-video
-# or run without installing:
-uvx mcp-video
-```
-
-Verify your setup:
-
-```bash
 mcp-video doctor
-mcp-video doctor --json
 ```
 
----
+Hyperframes tools additionally need Node.js 22+ because they call the Hyperframes CLI through `npx`.
 
 ## Quick Start
 
-### As an MCP Server (for AI agents)
+### Claude Code
 
-**Claude Code:**
 ```bash
-claude mcp add mcp-video -- uvx mcp-video
+claude mcp add mcp-video -- uvx --from mcp-video mcp-video
 ```
 
-**Claude Desktop:**
+### Claude Desktop
+
 ```json
 {
   "mcpServers": {
     "mcp-video": {
       "command": "uvx",
-      "args": ["mcp-video"]
+      "args": ["--from", "mcp-video", "mcp-video"]
     }
   }
 }
 ```
 
-**Cursor:**
+### Cursor
+
 ```json
 {
   "mcpServers": {
     "mcp-video": {
       "command": "uvx",
-      "args": ["mcp-video"]
+      "args": ["--from", "mcp-video", "mcp-video"]
     }
   }
 }
 ```
 
-Then just ask your agent: *"Trim this video from 0:30 to 1:00, add a title card, and resize for TikTok."*
+Then ask your agent:
 
-### As a Python Library
-
-```python
-from mcp_video import Client
-
-editor = Client()
-
-info = editor.info("interview.mp4")
-clip = editor.trim("interview.mp4", start="00:02:15", duration="00:00:30")
-video = editor.merge(clips=["intro.mp4", clip.output_path, "outro.mp4"])
-video = editor.add_text(video.output_path, text="EPISODE 42", position="top-center", size=48)
-result = editor.resize(video.output_path, aspect_ratio="9:16")
-```
-
-### Agent-safe Python workflow
-
-For autonomous agents, prefer inspection, pipeline chaining, and a release checkpoint:
-
-```python
-from mcp_video import Client
-
-client = Client()
-print(client.inspect("create_from_images"))  # Real params, aliases, return type
-
-result = client.pipeline(
-    [
-        {"op": "create_from_images", "images": frames, "fps": 30},
-        {"op": "effect_glow", "intensity": 0.2},  # safe capped default
-        {"op": "add_audio", "audio_path": "soundtrack.wav", "mix": True},
-        {"op": "export", "quality": "high"},
-    ],
-    output_path="final.mp4",
-)
-
-checkpoint = client.release_checkpoint(result.output_path)
-print(checkpoint["thumbnail"], checkpoint["storyboard"])
-```
-
-Agent contract:
-
-- Media-producing client calls return `EditResult` with `.output_path`.
-- Analysis/discovery calls return typed reports or dictionaries.
-- `Client.inspect(name)` exposes parameters, aliases, category, and return type.
-- Raw unexpected-keyword errors are converted into actionable `MCPVideoError` guidance.
-- Do not publish agent-generated video without `assert_quality()` or `release_checkpoint()` plus human visual/audio inspection.
-
-### As a CLI Tool
-
-```bash
-mcp-video info video.mp4
-mcp-video trim video.mp4 -s 00:02:15 -d 30
-mcp-video convert video.mp4 -f webm -q high
-mcp-video template tiktok video.mp4 --caption "Check this out!"
-```
-
----
-
-## MCP Tools
-
-87 MCP tools across 10 categories, including the `search_tools` meta-tool for fast discovery. All return structured JSON. See the [full tool reference](docs/TOOLS.md) for complete details.
-
-| Category | Count | Highlights |
-|----------|-------|------------|
-| **Core Video** | 32 | trim, merge, text, audio, resize, convert, filters, stabilize, chroma key, subtitles, watermark, batch, cleanup, template preview, export |
-| **AI-Powered** | 11 | transcribe (Whisper), scene detect, stem separation (Demucs), upscale, color grade |
-| **Hyperframes** | 8 | init, render, still, preview, compositions, validate, add block, pipeline |
-| **Audio Synthesis** | 7 | generate waveforms, presets, sequences, effects, spatial audio — pure NumPy |
-| **Visual Effects** | 8 | vignette, chromatic aberration, scanlines, noise, glow, luma key, mask, shape mask |
-| **Transitions** | 3 | glitch, pixelate, morph |
-| **Layout & Motion** | 6 | grid, pip, animated text, counters, progress bars, auto-chapters |
-| **Analysis** | 8 | scene detect, thumbnail, preview, storyboard, quality compare, metadata, waveform, release checkpoint |
-| **Image Analysis** | 3 | color extraction, palette generation, product analysis |
-| **Meta** | 1 | `search_tools` — keyword search across all tools |
-| **Resources** | 4 | prompts, workflows, templates, examples |
-
-**Tool discovery:**
-```python
-from mcp_video import Client
-editor = Client()
-results = editor.search_tools("subtitle")  # Find subtitle-related tools
-```
-
----
-
-## Hyperframes Integration
-
-Create videos programmatically with [Hyperframes](https://hyperframes.io/) — an HTML-native framework for video.
-
-```
-1. Init project       -> hyperframes_init
-2. Add blocks         -> hyperframes_add_block
-3. Preview live       -> hyperframes_preview
-4. Render             -> hyperframes_render
-5. Post-process       -> hyperframes_to_mcpvideo
-```
-
-See [Hyperframes docs](docs/TOOLS.md#hyperframes--html-native-video-8-tools) and the [Python client reference](docs/PYTHON_CLIENT.md).
-
----
+> Trim this interview into a 45-second vertical clip, add burned captions, normalize the audio, make a thumbnail, and create a release checkpoint before export.
 
 ## Python Client
 
 ```python
 from mcp_video import Client
+
 editor = Client()
+
+clip = editor.trim("interview.mp4", start="00:02:15", duration="00:00:45")
+caption_file = "captions.srt"
+editor.ai_transcribe(clip.output_path, output_srt=caption_file)
+captioned = editor.subtitles(clip.output_path, subtitle_file=caption_file)
+vertical = editor.resize(captioned.output_path, aspect_ratio="9:16")
+checkpoint = editor.release_checkpoint(vertical.output_path)
+
+print(checkpoint["thumbnail"])
+print(checkpoint["storyboard"])
 ```
 
-See the [full Python client reference](docs/PYTHON_CLIENT.md) for all methods and return types.
-
----
-
-## CLI Reference
-
-```
-mcp-video [command] [options]
-```
-
-See the [full CLI reference](docs/CLI_REFERENCE.md) for all commands and options.
-
----
-
-## Timeline DSL
-
-For complex multi-track edits, describe everything in a single JSON object:
-
-```python
-editor.edit({
-    "width": 1080,
-    "height": 1920,
-    "tracks": [
-        {
-            "type": "video",
-            "clips": [
-                {"source": "intro.mp4", "start": 0, "duration": 5},
-                {"source": "main.mp4", "start": 5, "trim_start": 10, "duration": 30},
-                {"source": "outro.mp4", "start": 35, "duration": 10},
-            ],
-            "transitions": [
-                {"after_clip": 0, "type": "fade", "duration": 1.0},
-            ],
-        },
-        {
-            "type": "audio",
-            "clips": [
-                {"source": "music.mp3", "start": 0, "volume": 0.7, "fade_in": 2},
-            ],
-        },
-    ],
-    "export": {"format": "mp4", "quality": "high"},
-})
-```
-
----
-
-## Templates
-
-Pre-built templates for common social media formats:
-
-```python
-from mcp_video.templates import tiktok_template, youtube_shorts_template
-
-timeline = tiktok_template(video_path="clip.mp4", caption="Check this out!", music_path="bgm.mp3")
-result = editor.edit(timeline)
-```
-
-Supports: TikTok, YouTube Shorts, Instagram Reels/Posts, YouTube Videos.
-
----
-
-## Error Handling
-
-Structured, actionable errors with auto-fix suggestions:
-
-```json
-{
-  "success": false,
-  "error": {
-    "type": "encoding_error",
-    "code": "unsupported_codec",
-    "message": "Codec error: vp9 — Auto-convert input from vp9 to H.264/AAC before editing",
-    "suggested_action": {
-      "auto_fix": true,
-      "description": "Auto-convert input from vp9 to H.264/AAC before editing"
-    }
-  }
-}
-```
-
----
-
-## Workflows
-
-ICM-style staged pipelines for common productions — with `CONTEXT.md` stage contracts, `references/` factory config, and runnable `workflow.py` scripts.
+## CLI
 
 ```bash
-cd workflows/01-social-media-clip
-python workflow.py /path/to/video.mp4
+mcp-video info interview.mp4
+mcp-video trim interview.mp4 -s 00:02:15 -d 45
+mcp-video video-ai-transcribe clip.mp4 --output captions.srt
+mcp-video subtitles clip.mp4 captions.srt
+mcp-video resize clip.mp4 --aspect-ratio 9:16
+mcp-video video-quality-check clip.mp4
 ```
 
-| Workflow | Stages | Description |
-|----------|--------|-------------|
-| `01-social-media-clip` | 5 | Landscape → TikTok / Short / Reel |
-| `02-podcast-clip` | 6 | Highlight with chapters + burned captions |
-| `03-explainer-video` | 7 | Branded explainer from scratch |
-| `04-hyperframes-video` | 5 | Create from scratch with Hyperframes, then post-process |
+## What Agents Can Do
 
-See [`workflows/CONTEXT.md`](workflows/CONTEXT.md) for the routing table.
+| Workflow | Example prompt |
+| --- | --- |
+| Social clips | "Turn this landscape recording into a captioned TikTok and YouTube Short." |
+| Podcast production | "Find the strongest segment, trim it, normalize audio, add chapters, and export." |
+| Product demos | "Create a short launch video from screenshots, title cards, and voiceover." |
+| Quality review | "Compare these two exports, make thumbnails, and flag visual or audio problems." |
+| Batch automation | "Convert this folder of clips to web-ready MP4 with consistent loudness." |
+| Code-created video | "Scaffold a Hyperframes composition, render it, then add subtitles and a watermark." |
 
-## Architecture
+## Tool Surface
 
+mcp-video registers **87 MCP tools** across 10 categories, including a `search_tools` discovery tool so agents can find the right operation without loading every tool description into context.
+
+| Category | Count | Highlights |
+| --- | ---: | --- |
+| Core video editing | 32 | trim, merge, resize, crop, rotate, convert, overlays, subtitles, export, cleanup, templates |
+| AI-assisted media | 11 | transcription, scene detection, upscaling, stem separation, silence removal, color grading |
+| Hyperframes | 8 | init, preview, render, still, validate, compositions, add block, post-process |
+| Procedural audio | 7 | synthesize, compose, presets, effects, sequences, generated audio, spatial audio |
+| Visual effects | 8 | vignette, glow, noise, scanlines, chromatic aberration, luma key, mask, shape mask |
+| Transitions | 3 | glitch, morph, pixelate |
+| Layout and motion | 6 | grid, picture-in-picture, animated text, counters, progress bars, auto-chapters |
+| Analysis | 8 | scene detection, thumbnail, preview, storyboard, quality compare, metadata, waveform, release checkpoint |
+| Image analysis | 3 | extract colors, generate palettes, analyze product images |
+| Discovery | 1 | `search_tools` |
+
+```python
+from mcp_video import Client
+
+editor = Client()
+matches = editor.search_tools("subtitle")
+print(matches["tools"])
 ```
-mcp_video/
-  client/                # Python Client API (mixins per domain)
-  client/meta.py         # Client discovery mixin (search_tools)
-  server.py              # MCP server (87 tools + 4 resources)
-  server_tools_*.py      # Tool registration by category
-  engine.py              # Core FFmpeg engine
-  engine_*.py            # Specialized engines (thumbnail, edit, probe, etc.)
-  models.py              # Pydantic models
-  errors.py              # Error hierarchy + FFmpeg stderr parser
-  ffmpeg_helpers.py      # Shared FFmpeg utilities
-  audio_engine.py        # Procedural audio synthesis
-  effects_engine.py      # Visual effects + motion graphics
-  transitions_engine.py  # Clip transitions
-  ai_engine.py           # AI features (Whisper, Demucs, Real-ESRGAN)
-  hyperframes_engine.py  # Hyperframes CLI wrapper
-  image_engine.py        # Image color analysis
-  quality_guardrails.py  # Automated quality checks
-workflows/               # ICM staged pipelines
-  CONTEXT.md             # Layer 1 routing table
-  01-social-media-clip/  # Stage contract + runnable script
-  02-podcast-clip/       # Stage contract + runnable script
-  03-explainer-video/    # Stage contract + runnable script
+
+Full reference: [docs/TOOLS.md](docs/TOOLS.md)
+
+## Agent-Safe Workflow
+
+For autonomous agents, the intended path is inspect, edit, verify, then ask a human to review release artifacts:
+
+```python
+from mcp_video import Client
+
+client = Client()
+
+print(client.inspect("trim"))
+
+result = client.pipeline(
+    [
+        {"op": "trim", "input": "source.mp4", "start": "00:01:00", "duration": "00:00:45"},
+        {"op": "add_text", "text": "Launch clip", "position": "top-center"},
+        {"op": "normalize_audio"},
+        {"op": "resize", "aspect_ratio": "9:16"},
+        {"op": "export", "quality": "high"},
+        {"op": "release_checkpoint"},
+    ],
+    output_path="final-short.mp4",
+)
 ```
 
----
+Safety contract:
 
-## Supported Formats
+- Media-producing calls return structured results with output paths.
+- Analysis and discovery calls return structured JSON reports.
+- Tool discovery is available through `search_tools()` and `Client.inspect()`.
+- Unexpected keyword errors are converted into actionable `MCPVideoError` guidance.
+- Do not publish agent-generated video without `video_quality_check`, `video_release_checkpoint`, and human visual/audio inspection.
 
-| Video | Audio (extraction) | Subtitles |
-|-------|-------------------|-----------|
-| MP4, WebM, MOV, GIF | MP3, AAC, WAV, OGG, FLAC | SRT, WebVTT |
+## Documentation
 
----
-
-## Agent Discovery
-
-- [`llms.txt`](llms.txt) — compact project map for agents
-- [`docs/AI_AGENT_DISCOVERY.md`](docs/AI_AGENT_DISCOVERY.md) — richer positioning and integration snippets
-
----
+- [Tool reference](docs/TOOLS.md)
+- [Python client reference](docs/PYTHON_CLIENT.md)
+- [CLI reference](docs/CLI_REFERENCE.md)
+- [AI agent discovery guide](docs/AI_AGENT_DISCOVERY.md)
+- [Testing guide](docs/TESTING.md)
+- [FAQ](docs/faq.md)
+- [llms.txt](llms.txt)
 
 ## Development
 
 ```bash
 git clone https://github.com/KyaniteLabs/mcp-video.git
 cd mcp-video
-python -m venv .venv
+python3 -m venv .venv
 source .venv/bin/activate
-pip install -e ".[dev]"
-```
-
----
-
-## Community & Support
-
-- **Contributing:** [CONTRIBUTING.md](CONTRIBUTING.md)
-- **Security:** [SECURITY.md](SECURITY.md) (private reporting path)
-- **Help:** [SUPPORT.md](SUPPORT.md) or [GitHub Discussions](https://github.com/KyaniteLabs/mcp-video/discussions)
-- **Code of Conduct:** [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)
-- **Changelog:** [CHANGELOG.md](CHANGELOG.md)
-- **Roadmap:** [ROADMAP.md](ROADMAP.md)
-- **Governance:** [GOVERNANCE.md](GOVERNANCE.md)
-- **Maintainers:** [MAINTAINERS.md](MAINTAINERS.md)
-
-## Testing
-
-Tests are excluded from the PyPI package. To run locally:
-
-```bash
 pip install -e ".[dev]"
 pytest tests/ -v -m "not slow and not hyperframes"
 ```
 
-See [docs/TESTING.md](docs/TESTING.md) for full test categories and CI details.
+## Community
+
+- [Contributing](CONTRIBUTING.md)
+- [Security](SECURITY.md)
+- [Support](SUPPORT.md)
+- [Roadmap](ROADMAP.md)
+- [Changelog](CHANGELOG.md)
+- [GitHub Discussions](https://github.com/KyaniteLabs/mcp-video/discussions)
 
 ## License
 
-Apache 2.0 — see [LICENSE](LICENSE).
+Apache 2.0. See [LICENSE](LICENSE).
 
-Built on [FFmpeg](https://ffmpeg.org/), [Hyperframes](https://hyperframes.io/), and the [Model Context Protocol](https://modelcontextprotocol.io/).
-
-See [docs/LEGAL_REVIEW.md](docs/LEGAL_REVIEW.md) for dependency licensing notes.
+Built with [FFmpeg](https://ffmpeg.org/), [Hyperframes](https://hyperframes.io/), and the [Model Context Protocol](https://modelcontextprotocol.io/).

--- a/docs/AI_AGENT_DISCOVERY.md
+++ b/docs/AI_AGENT_DISCOVERY.md
@@ -41,7 +41,7 @@ This document is the short, explicit discovery map for agents, answer engines, a
 Claude Code:
 
 ```bash
-claude mcp add mcp-video -- uvx mcp-video
+claude mcp add mcp-video -- uvx --from mcp-video mcp-video
 ```
 
 Claude Desktop:
@@ -51,7 +51,7 @@ Claude Desktop:
   "mcpServers": {
     "mcp-video": {
       "command": "uvx",
-      "args": ["mcp-video"]
+      "args": ["--from", "mcp-video", "mcp-video"]
     }
   }
 }
@@ -64,7 +64,7 @@ Cursor:
   "mcpServers": {
     "mcp-video": {
       "command": "uvx",
-      "args": ["mcp-video"]
+      "args": ["--from", "mcp-video", "mcp-video"]
     }
   }
 }

--- a/llms.txt
+++ b/llms.txt
@@ -2,7 +2,7 @@
 
 > Video editing MCP server, Python library, and CLI for AI agents.
 
-mcp-video gives AI agents structured tools for FFmpeg-based video editing, video analysis, subtitles, resizing, transcoding, and code-driven video creation workflows.
+mcp-video gives AI agents 87 structured tools for FFmpeg-based video editing, video analysis, subtitles, resizing, transcoding, audio workflows, effects, quality checkpoints, and Hyperframes code-driven video creation.
 
 ## Use cases
 - Claude Code / Cursor video editing tools
@@ -11,6 +11,7 @@ mcp-video gives AI agents structured tools for FFmpeg-based video editing, video
 - Python video editing scripts
 - CLI video operations
 - Video QA checkpoints for generated media
+- Local AI video workflows with human review before publication
 
 ## Key paths
 - `README.md`: public overview and install guide
@@ -26,4 +27,4 @@ mcp-video gives AI agents structured tools for FFmpeg-based video editing, video
 - Use timeouts on all subprocess calls
 
 ## Keywords
-video editing MCP server, AI agent video editing, FFmpeg automation, Claude video tools, Cursor MCP, Python video library, video automation CLI, Model Context Protocol.
+video editing MCP server, AI agent video editing, FFmpeg automation, Claude Code video tools, Cursor MCP video tools, Codex video automation, Python video library, video automation CLI, Model Context Protocol, Hyperframes, subtitles, reels automation, shorts automation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,15 +5,15 @@ build-backend = "hatchling.build"
 [project]
 name = "mcp-video"
 version = "1.3.5"
-description = "Video editing MCP server for AI agents. 87 tools, 3 interfaces, rich CLI. Local, fast, free."
+description = "Video editing MCP server for AI agents. 87 FFmpeg and Hyperframes tools, Python client, and CLI. Local, fast, free."
 readme = "README.md"
 license = "Apache-2.0"
 requires-python = ">=3.11"
 keywords = [
     "video", "editing", "mcp", "ffmpeg", "hyperframes", "ai", "agents",
-    "claude", "cursor", "subtitle", "whisper", "transcription",
+    "claude", "claude-code", "cursor", "codex", "subtitle", "subtitles", "whisper", "transcription",
     "video-processing", "chroma-key", "stabilization", "color-grading",
-    "model-context-protocol", "cli",
+    "model-context-protocol", "mcp-server", "ai-video", "video-automation", "cli",
 ]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
@@ -102,7 +102,7 @@ ignore = ["E501", "S603", "S607", "S311", "S310", "S112", "S110"]
 mcp-video = "mcp_video.__main__:main"
 
 [project.urls]
-Homepage = "https://github.com/KyaniteLabs/mcp-video"
+Homepage = "https://kyanitelabs.github.io/mcp-video/"
 Documentation = "https://github.com/KyaniteLabs/mcp-video#readme"
 Repository = "https://github.com/KyaniteLabs/mcp-video"
 "Bug Tracker" = "https://github.com/KyaniteLabs/mcp-video/issues"

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.KyaniteLabs/mcp-video",
   "title": "mcp-video",
-  "description": "Video editing MCP server for AI agents using FFmpeg and Hyperframes structured tools.",
+  "description": "Video editing MCP server for AI agents using 87 structured FFmpeg and Hyperframes tools.",
   "version": "1.3.5",
   "websiteUrl": "https://kyanitelabs.github.io/mcp-video/",
   "repository": {


### PR DESCRIPTION
## Summary
- replace the mcp-video README with a cleaner launch-ready discovery surface using the Kyanite Labs website hero image
- align PyPI metadata, MCP registry metadata, and llms.txt around the current KyaniteLabs owner and 87-tool surface
- refresh AI agent discovery install snippets to use the explicit uvx --from invocation

## Verification
- python3 import counted 87 registered MCP tools
- python3 -m build
- python3 -m twine check dist/*
- parsed pyproject.toml and server.json

## Notes
- Updated live repository description/homepage/topics separately with gh repo edit: removed stale Remotion topics, added hyperframes/subtitles/cli/media-automation.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/mcp-video/pr/247"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->