### PR TITLE
Refresh mcp-video registry metadata after username rename

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -1,7 +1,7 @@
 # KyaniteLabs — AI Agent Instructions
 
 ## Organization
-- Org: KyaniteLabs, owner: Pastorsimon1798
+- Org: KyaniteLabs, owner: simongonzalezdc
 - All repos use issue-driven development — contributions enter as GitHub issues, not direct PRs
 - Pipeline runs every 30 min: triage → fix → review → merge
 - All main/master branches are protected (no direct push, CI required)

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # Default ownership for repository changes.
-* @Pastorsimon1798
+* @simongonzalezdc
 

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,2 @@
-github: [Pastorsimon1798]
+github: [simongonzalezdc]
 ko_fi: kyanitelabs

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,7 +1,7 @@
 # KyaniteLabs — AI Agent Instructions
 
 ## Organization
-- Org: KyaniteLabs, owner: Pastorsimon1798
+- Org: KyaniteLabs, owner: simongonzalezdc
 - All repos use issue-driven development — contributions enter as GitHub issues, not direct PRs
 - Pipeline runs every 30 min: triage → fix → review → merge
 - All main/master branches are protected (no direct push, CI required)

--- a/.windsurfrules
+++ b/.windsurfrules
@@ -1,7 +1,7 @@
 # KyaniteLabs — AI Agent Instructions
 
 ## Organization
-- Org: KyaniteLabs, owner: Pastorsimon1798
+- Org: KyaniteLabs, owner: simongonzalezdc
 - All repos use issue-driven development — contributions enter as GitHub issues, not direct PRs
 - Pipeline runs every 30 min: triage → fix → review → merge
 - All main/master branches are protected (no direct push, CI required)

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -2,7 +2,7 @@
 
 ## Active Maintainer
 
-- Simon Gonzalez De Cruz (GitHub: `@Pastorsimon1798`)
+- Simon Gonzalez De Cruz (GitHub: `@simongonzalezdc`)
 
 ## Maintainer Checklist
 

--- a/glama.json
+++ b/glama.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://glama.ai/mcp/schemas/server.json",
-  "maintainers": ["Pastorsimon1798"]
+  "maintainers": ["simongonzalezdc"]
 }

--- a/tests/test_public_surface.py
+++ b/tests/test_public_surface.py
@@ -261,10 +261,10 @@ def test_public_discovery_files_do_not_point_at_old_personal_namespace():
         ROOT / "mcp_video" / "errors.py",
     ]
     stale_fragments = [
-        "pastorsimon1798.github.io/mcp-video",
-        "github.com/pastorsimon1798/mcp-video",
-        "github.com/Pastorsimon1798/mcp-video",
-        "io.github.pastorsimon1798/mcp-video",
+        "pastor" + "simon1798.github.io/mcp-video",
+        "github.com/" + "pastor" + "simon1798/mcp-video",
+        "github.com/" + "Pastor" + "simon1798/mcp-video",
+        "io.github." + "pastor" + "simon1798/mcp-video",
     ]
 
     offenders = {


### PR DESCRIPTION
## Summary\n- update Glama, CODEOWNERS, funding, and maintainer metadata from the retired handle to simongonzalezdc\n- keep stale-namespace public-surface tests while removing literal stale handles from repo scans\n\n## Verification\n- python3 -m pytest tests/test_public_surface.py\n- stale-handle rg scan returned no public metadata matches

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/mcp-video/pr/249"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->