### PR TITLE
[codex] Add cinematic pre-production tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@
 
 <p align="center">
   <strong>Video editing MCP server for AI agents.</strong><br>
-  87 structured tools for FFmpeg video editing, media analysis, subtitles, audio, effects, and Hyperframes video creation.
+  91 structured tools for FFmpeg video editing, cinematic prompt planning, media analysis, subtitles, audio, effects, and Hyperframes video creation.
 </p>
 
 <p align="center">
   <a href="https://pypi.org/project/mcp-video/"><img src="https://img.shields.io/pypi/v/mcp-video.svg" alt="PyPI"></a>
   <a href="https://github.com/KyaniteLabs/mcp-video/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/KyaniteLabs/mcp-video/.github/workflows/ci.yml?branch=master&label=CI" alt="CI"></a>
-  <img src="https://img.shields.io/badge/MCP-87%20tools-orange.svg" alt="87 MCP tools">
+  <img src="https://img.shields.io/badge/MCP-91%20tools-orange.svg" alt="91 MCP tools">
   <img src="https://img.shields.io/badge/python-3.11%2B-blue.svg" alt="Python 3.11+">
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue.svg" alt="Apache 2.0">
 </p>
@@ -35,7 +35,7 @@
 
 ## Public Discovery
 
-**mcp-video** is a free, open-source **Model Context Protocol (MCP) server**, Python library, and CLI that gives AI agents a real video-editing surface. It wraps FFmpeg, media analysis, quality checks, subtitles, audio generation, effects, and code-driven Hyperframes rendering behind structured tool schemas.
+**mcp-video** is a free, open-source **Model Context Protocol (MCP) server**, Python library, and CLI that gives AI agents a real video-editing surface. It wraps FFmpeg, cinematic style-pack/storyboard planning, media analysis, quality checks, subtitles, audio generation, effects, and code-driven Hyperframes rendering behind structured tool schemas.
 
 Best-fit searches:
 
@@ -60,6 +60,7 @@ Use it when you want an AI assistant to:
 - add text, subtitles, watermarks, overlays, filters, fades, effects, and transitions;
 - extract audio, normalize audio, synthesize audio, add generated audio, or create waveforms;
 - detect scenes, make thumbnails, generate storyboards, compare quality, and create release checkpoints;
+- scaffold cinematic projects, read STYLE_/NEG_ blocks, parse storyboard tables, and expand shot prompts;
 - create new video projects with Hyperframes and post-process the result with FFmpeg tools;
 - drive repeatable media workflows from Claude Code, Cursor, Codex-style clients, scripts, or CI.
 
@@ -164,17 +165,19 @@ mcp-video video-quality-check clip.mp4
 | Social clips | "Turn this landscape recording into a captioned TikTok and YouTube Short." |
 | Podcast production | "Find the strongest segment, trim it, normalize audio, add chapters, and export." |
 | Product demos | "Create a short launch video from screenshots, title cards, and voiceover." |
+| Cinematic planning | "Create a style pack and storyboard, then render shot prompts for generation." |
 | Quality review | "Compare these two exports, make thumbnails, and flag visual or audio problems." |
 | Batch automation | "Convert this folder of clips to web-ready MP4 with consistent loudness." |
 | Code-created video | "Scaffold a Hyperframes composition, render it, then add subtitles and a watermark." |
 
 ## Tool Surface
 
-mcp-video registers **87 MCP tools** across 10 categories, including a `search_tools` discovery tool so agents can find the right operation without loading every tool description into context.
+mcp-video registers **91 MCP tools** across 11 categories, including a `search_tools` discovery tool so agents can find the right operation without loading every tool description into context.
 
 | Category | Count | Highlights |
 | --- | ---: | --- |
 | Core video editing | 32 | trim, merge, resize, crop, rotate, convert, overlays, subtitles, export, cleanup, templates |
+| Cinematic creation | 4 | project scaffold, style-pack parsing, storyboard parsing, shot prompt expansion |
 | AI-assisted media | 11 | transcription, scene detection, upscaling, stem separation, silence removal, color grading |
 | Hyperframes | 8 | init, preview, render, still, validate, compositions, add block, post-process |
 | Procedural audio | 7 | synthesize, compose, presets, effects, sequences, generated audio, spatial audio |

--- a/docs/AI_AGENT_DISCOVERY.md
+++ b/docs/AI_AGENT_DISCOVERY.md
@@ -4,7 +4,7 @@ This document is the short, explicit discovery map for agents, answer engines, a
 
 ## Canonical Positioning
 
-`mcp-video` is an open source MCP server, Python library, and CLI for video editing and video creation workflows. It wraps FFmpeg and Hyperframes with structured tool calls so agents can edit video without inventing brittle shell commands.
+`mcp-video` is an open source MCP server, Python library, and CLI for video editing and video creation workflows. It wraps FFmpeg, cinematic style-pack/storyboard planning, and Hyperframes with structured tool calls so agents can edit and plan video without inventing brittle shell commands.
 
 ## Best Queries To Match
 
@@ -14,6 +14,8 @@ This document is the short, explicit discovery map for agents, answer engines, a
 - Claude Code video editing MCP
 - Cursor MCP video editing
 - programmatic video editing Python
+- cinematic video prompt storyboard MCP
+- AI video style pack workflow
 - Hyperframes MCP integration
 - FFmpeg tools for AI agents
 
@@ -22,8 +24,9 @@ This document is the short, explicit discovery map for agents, answer engines, a
 - `README.md` - install, quick start, tools, CLI, Python client, workflows.
 - `CLAUDE.md` - Layer 0 identity: what this project is, where to find staged pipelines.
 - `llms.txt` - compact machine-readable project map.
-- `mcp_video/server.py` - MCP tool registration layer (87 tools total, including `search_tools`).
+- `mcp_video/server.py` - MCP tool registration layer (91 tools total, including `search_tools`).
 - `mcp_video/engine.py` - core FFmpeg operations.
+- `mcp_video/creation_engine.py` - PUSHING CREATION-style project, style-pack, storyboard, and shot-prompt helpers.
 - `mcp_video/client/` - Python client mixins. Use `Client.inspect()`, `Client.pipeline()`, and `Client.release_checkpoint()` for guarded agent workflows.
 - `mcp_video/client/meta.py` - Client-side tool discovery (`search_tools`).
 - `mcp_video/client/hyperframes.py` - Hyperframes client mixin.

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -1,6 +1,6 @@
 # MCP Tools Reference
 
-87 MCP tools across 10 categories, including the `search_tools` meta-tool. All return structured JSON with `success`, `output_path`, and operation metadata. On failure, they return `{"success": false, "error": {...}}` with auto-fix suggestions.
+91 MCP tools across 11 categories, including the `search_tools` meta-tool. All return structured JSON with `success`, `output_path`, and operation metadata. On failure, they return `{"success": false, "error": {...}}` with auto-fix suggestions.
 
 ---
 
@@ -8,7 +8,7 @@
 
 | Tool | Description |
 |------|-------------|
-| `search_tools` | Search all registered MCP tools by keyword. Returns matching tool names, descriptions, and required parameters. Use this when you need to find the right tool without loading all 87 descriptions into context. |
+| `search_tools` | Search all registered MCP tools by keyword. Returns matching tool names, descriptions, and required parameters. Use this when you need to find the right tool without loading all 91 descriptions into context. |
 
 **Python Client:**
 ```python
@@ -17,6 +17,19 @@ editor = Client()
 results = editor.search_tools("subtitle")
 # Returns: {"success": True, "count": 3, "tools": [...]}
 ```
+
+---
+
+## Cinematic Creation (4 tools)
+
+Plan video generation like a director of photography before rendering. These tools implement a PUSHING CREATION-compatible pre-production workflow: project scaffold, STYLE_/NEG_ blocks, storyboard tables, and prompt expansion.
+
+| Tool | Description |
+|------|-------------|
+| `video_project_create` | Scaffold `projects/<slug>/style.md`, `storyboard.md`, and `refs/` using cinematic starter templates |
+| `style_pack_read` | Parse STYLE_ and NEG_ blocks from `style.md` or a project directory |
+| `storyboard_read` | Parse storyboard rows from `storyboard.md` or a project directory |
+| `shot_prompt_render` | Expand one storyboard shot into `prompt` and `negative_prompt` strings for a generation provider |
 
 ---
 

--- a/llms.txt
+++ b/llms.txt
@@ -2,12 +2,13 @@
 
 > Video editing MCP server, Python library, and CLI for AI agents.
 
-mcp-video gives AI agents 87 structured tools for FFmpeg-based video editing, video analysis, subtitles, resizing, transcoding, audio workflows, effects, quality checkpoints, and Hyperframes code-driven video creation.
+mcp-video gives AI agents 91 structured tools for FFmpeg-based video editing, cinematic style-pack and storyboard planning, video analysis, subtitles, resizing, transcoding, audio workflows, effects, quality checkpoints, and Hyperframes code-driven video creation.
 
 ## Use cases
 - Claude Code / Cursor video editing tools
 - FFmpeg automation through MCP
 - Agentic media pipelines
+- Cinematic video prompt planning with STYLE_/NEG_ blocks and storyboard tables
 - Python video editing scripts
 - CLI video operations
 - Video QA checkpoints for generated media
@@ -17,6 +18,7 @@ mcp-video gives AI agents 87 structured tools for FFmpeg-based video editing, vi
 - `README.md`: public overview and install guide
 - `docs/TOOLS.md`: MCP tool reference
 - `docs/AI_AGENT_DISCOVERY.md`: agent discovery guidance
+- `mcp_video/creation_engine.py`: cinematic project, style-pack, storyboard, and shot-prompt helpers
 - `examples/`: usage examples
 
 ## Safety Rules For Agents
@@ -27,4 +29,4 @@ mcp-video gives AI agents 87 structured tools for FFmpeg-based video editing, vi
 - Use timeouts on all subprocess calls
 
 ## Keywords
-video editing MCP server, AI agent video editing, FFmpeg automation, Claude Code video tools, Cursor MCP video tools, Codex video automation, Python video library, video automation CLI, Model Context Protocol, Hyperframes, subtitles, reels automation, shorts automation.
+video editing MCP server, AI agent video editing, cinematic video storyboard MCP, AI video style pack, FFmpeg automation, Claude Code video tools, Cursor MCP video tools, Codex video automation, Python video library, video automation CLI, Model Context Protocol, Hyperframes, subtitles, reels automation, shorts automation.

--- a/mcp_video/creation_engine.py
+++ b/mcp_video/creation_engine.py
@@ -1,0 +1,208 @@
+"""PUSHING CREATION-style project, style-pack, and storyboard helpers."""
+
+from __future__ import annotations
+
+from importlib import resources
+from pathlib import Path
+import re
+import shutil
+from typing import Any
+
+from .errors import MCPVideoError
+
+_SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,79}$")
+_BLOCK_RE = re.compile(r"^##\s+((?:STYLE|NEG)_[A-Z0-9_]+)\s*$")
+_STORYBOARD_COLUMNS = (
+    "shot",
+    "provider",
+    "model",
+    "camera",
+    "lens",
+    "aspect",
+    "action",
+    "refs",
+    "style",
+    "neg",
+    "mode",
+    "duration",
+)
+
+
+def _creation_error(message: str, code: str = "invalid_parameter") -> MCPVideoError:
+    return MCPVideoError(message, error_type="validation_error", code=code)
+
+
+def _validate_slug(slug: str) -> str:
+    if not _SLUG_RE.match(slug):
+        raise _creation_error("Invalid slug: use lowercase letters, numbers, hyphens, or underscores")
+    return slug
+
+
+def _resolve_dir(path: str | None) -> Path:
+    base = Path(path or ".").expanduser().resolve()
+    if base.exists() and not base.is_dir():
+        raise _creation_error(f"Output directory is not a directory: {base}")
+    return base
+
+
+def _template_path(name: str) -> Path:
+    return Path(str(resources.files("mcp_video.creation_templates").joinpath(name)))
+
+
+def _copy_template(name: str, destination: Path) -> None:
+    shutil.copyfile(_template_path(name), destination)
+
+
+def create_video_project(slug: str, output_dir: str | None = None) -> dict[str, Any]:
+    """Scaffold a PUSHING CREATION-compatible video project."""
+    slug = _validate_slug(slug)
+    project = _resolve_dir(output_dir) / "projects" / slug
+    if project.exists():
+        raise _creation_error(f"Project already exists: {project}", code="project_exists")
+
+    refs = project / "refs"
+    refs.mkdir(parents=True)
+    _copy_template("style.md", project / "style.md")
+    _copy_template("storyboard.md", project / "storyboard.md")
+    (refs / ".gitkeep").write_text("")
+
+    return {
+        "project_path": str(project),
+        "files": [str(project / "style.md"), str(project / "storyboard.md"), str(refs)],
+        "next_steps": [
+            "Drop reference stills, plates, or mood frames into refs/.",
+            "Customize style.md STYLE_ and NEG_ blocks for the project's visual voice.",
+            "Replace the storyboard example rows with the project's own shot list.",
+        ],
+    }
+
+
+def _read_text_file(path: str, filename: str | None = None) -> tuple[Path, str]:
+    candidate = Path(path).expanduser()
+    if candidate.is_dir() and filename:
+        candidate = candidate / filename
+    resolved = candidate.resolve()
+    if not resolved.is_file():
+        raise _creation_error(f"File not found: {resolved}", code="not_found")
+    return resolved, resolved.read_text()
+
+
+def read_style_pack(path: str) -> dict[str, Any]:
+    """Parse STYLE_ and NEG_ blocks from a style.md file or project directory."""
+    resolved, text = _read_text_file(path, "style.md")
+    blocks: list[dict[str, str]] = []
+    current_name: str | None = None
+    current_lines: list[str] = []
+
+    def flush() -> None:
+        if current_name is None:
+            return
+        body = " ".join(line.strip() for line in current_lines if line.strip())
+        blocks.append({"name": current_name, "type": current_name.split("_", 1)[0], "body": body})
+
+    for line in text.splitlines():
+        match = _BLOCK_RE.match(line.strip())
+        if match:
+            flush()
+            current_name = match.group(1)
+            current_lines = []
+            continue
+        if current_name is not None and not line.lstrip().startswith("<!--"):
+            current_lines.append(line)
+    flush()
+
+    style_blocks = [block for block in blocks if block["type"] == "STYLE"]
+    negative_blocks = [block for block in blocks if block["type"] == "NEG"]
+    return {
+        "style_path": str(resolved),
+        "block_count": len(blocks),
+        "blocks": blocks,
+        "style_blocks": style_blocks,
+        "negative_blocks": negative_blocks,
+    }
+
+
+def _split_table_row(line: str) -> list[str]:
+    return [cell.strip() for cell in line.strip().strip("|").split("|")]
+
+
+def _is_separator_row(cells: list[str]) -> bool:
+    return bool(cells) and all(set(cell.replace(":", "").strip()) <= {"-"} for cell in cells)
+
+
+def _split_refs(value: str) -> list[str]:
+    return [part.strip() for part in re.split(r"[,;]", value) if part.strip()]
+
+
+def _split_blocks(value: str) -> list[str]:
+    return [part.strip() for part in re.split(r"[,;+]", value) if part.strip()]
+
+
+def read_storyboard(path: str) -> dict[str, Any]:
+    """Parse a PUSHING CREATION storyboard markdown table."""
+    resolved, text = _read_text_file(path, "storyboard.md")
+    rows: list[dict[str, Any]] = []
+    header_seen = False
+
+    for line in text.splitlines():
+        if not line.strip().startswith("|"):
+            continue
+        cells = _split_table_row(line)
+        lower_cells = [cell.lower() for cell in cells]
+        if lower_cells == list(_STORYBOARD_COLUMNS):
+            header_seen = True
+            continue
+        if not header_seen or _is_separator_row(cells):
+            continue
+        if len(cells) != len(_STORYBOARD_COLUMNS):
+            continue
+        row = dict(zip(_STORYBOARD_COLUMNS, cells, strict=True))
+        row["refs"] = _split_refs(row["refs"])
+        row["style"] = _split_blocks(row["style"])
+        row["neg"] = _split_blocks(row["neg"])
+        rows.append(row)
+
+    return {"storyboard_path": str(resolved), "shot_count": len(rows), "shots": rows}
+
+
+def _find_shot(storyboard: dict[str, Any], shot: str | int) -> dict[str, Any]:
+    shots = storyboard["shots"]
+    if isinstance(shot, int) or str(shot).isdigit():
+        index = int(shot) - 1
+        if 0 <= index < len(shots):
+            return shots[index]
+    for row in shots:
+        if row["shot"] == str(shot):
+            return row
+    raise _creation_error(f"Shot not found: {shot}", code="not_found")
+
+
+def render_shot_prompt(project_path: str, shot: str | int) -> dict[str, Any]:
+    """Expand storyboard style references into a provider-ready shot prompt."""
+    project = Path(project_path).expanduser().resolve()
+    style_pack = read_style_pack(str(project))
+    storyboard = read_storyboard(str(project))
+    row = _find_shot(storyboard, shot)
+    block_map = {block["name"]: block["body"] for block in style_pack["blocks"]}
+
+    missing = [name for name in [*row["style"], *row["neg"]] if name and name not in block_map]
+    if missing:
+        raise _creation_error(f"Referenced style blocks not found: {', '.join(missing)}", code="missing_style_block")
+
+    style_parts = [block_map[name] for name in row["style"] if name]
+    negative_parts = [block_map[name] for name in row["neg"] if name]
+    prompt_parts = [row["action"], *style_parts]
+
+    return {
+        "shot": row["shot"],
+        "provider": row["provider"],
+        "model": row["model"],
+        "mode": row["mode"],
+        "duration": row["duration"],
+        "aspect": row["aspect"],
+        "refs": row["refs"],
+        "style_blocks": row["style"],
+        "negative_blocks": row["neg"],
+        "prompt": "\n\n".join(part for part in prompt_parts if part),
+        "negative_prompt": ", ".join(part for part in negative_parts if part),
+    }

--- a/mcp_video/creation_templates/__init__.py
+++ b/mcp_video/creation_templates/__init__.py
@@ -1,0 +1,1 @@
+"""Bundled PUSHING CREATION-compatible markdown templates."""

--- a/mcp_video/creation_templates/storyboard.md
+++ b/mcp_video/creation_templates/storyboard.md
@@ -1,0 +1,23 @@
+<!--
+PUSHING CREATION-compatible storyboard starter.
+Replace the example shots with your project-specific shot list.
+-->
+---
+title: BMW M-Series Track Day - Worked Example
+slug: bmw-track-day
+active_provider: seedream
+active_model: Seedream 5
+pack_version: '0.1'
+---
+
+# Shots
+
+| Shot | Provider | Model | Camera | Lens | Aspect | Action | Refs | Style | Neg | Mode | Duration |
+|------|----------|-------|--------|------|--------|--------|------|-------|-----|------|----------|
+| paddock_awakening |  |  | ARRI Alexa Mini LF on Steadicam | 24mm Prime T1.5 | 21:9 | Shot on ARRI Alexa Mini LF on Steadicam, slow smooth push-in. Lens 24mm prime T1.5, settings f/2.8, 1/48 at 24fps, ISO 160. Wide establishing shot, early morning golden hour light hitting a pit lane. A sleek Isle of Man Green BMW M3 and a Sao Paulo Yellow BMW M4 parked together. Protagonist in casual high-end streetwear carrying a racing helmet walks toward the cars. |  | STYLE_PHOTOREAL_BASE, STYLE_GOLDEN_HOUR, STYLE_COMPOSITION_OFFCENTRE | NEG_AI_COMPOSITION, NEG_AI_LIGHTING, NEG_OBJECT_GEOMETRY |  |  |
+| tactile_prep |  |  | RED Komodo 6K handheld | 50mm Macro T1.4 | 16:9 | Shot on RED Komodo 6K handheld, subtle organic camera breathing and a slow rack focus. Lens 50mm macro T1.4, settings f/1.4, 1/96 at 48fps slightly slowed, ISO 400. Extreme close-up inside the cabin, hands in driving gloves firmly gripping an Alcantara steering wheel. Morning sun flares warmly through the windshield. | hands_on_wheel.jpg | STYLE_PHOTOREAL_BASE, STYLE_MACRO_TACTILE, STYLE_GRAIN_HALATION | NEG_HUMAN_ANATOMY, NEG_AI_PLASTIC_SKIN |  |  |
+| epic_track_wide |  |  | ARRI Alexa 65 helicopter gimbal | 14mm Prime T2.8 | 21:9 | Shot on ARRI Alexa 65 mounted on a helicopter gimbal, slow sweeping aerial tracking shot. Lens 14mm ultra-wide prime T2.8, settings f/8.0, 1/100 at 24fps, ISO 200. Big epic wide establishing shot of a sweeping race track corner surrounded by vast dramatic landscapes. A lone green performance car carves the apex, small but powerful against the massive scale of the circuit. |  | STYLE_PHOTOREAL_BASE, STYLE_GOLDEN_HOUR, STYLE_ANAMORPHIC | NEG_OBJECT_GEOMETRY, NEG_AI_LIGHTING |  |  |
+
+# Shot Notes
+
+Each row should be a self-contained brief. Camera and rig establish spatial language, lens and T-stop establish depth of field, action describes what happens, Style and Neg reference blocks from style.md.

--- a/mcp_video/creation_templates/style.md
+++ b/mcp_video/creation_templates/style.md
@@ -1,0 +1,69 @@
+<!--
+PUSHING CREATION-compatible starter style pack.
+Inspired by github.com/PUSHINGSQUARES/pushing-creation and kept compatible
+with the STYLE_/NEG_ block convention used by PUSHING FRAMES.
+-->
+---
+title: Cinematography Rules - Starter Library
+author: mcp-video
+pack_version: '0.1'
+template_id: cinematography
+---
+
+## STYLE_PHOTOREAL_BASE
+photorealistic textures, real-world physics, natural skin pores, fabric weave visible, micro-imperfections, scratches, dust, fingerprints, shot on professional cinema equipment by a working DP, high dynamic range, natural depth of field falloff, no AI-clean.
+
+## STYLE_KODAK_VISION
+kodak vision3 50d daylight stock with kodak 2383 print emulation, gentle highlight rolloff, subtle shadow crush, warm neutral midtones, organic colour science, finished print look.
+
+## STYLE_ANAMORPHIC
+anamorphic 2x squeeze, horizontal blue streak lens flares, elliptical bokeh, edge breathing toward frame corners, complex chromatic aberration in highlights and dust motes, subtle barrel breathing on focus pulls.
+
+## STYLE_GOLDEN_HOUR
+late afternoon golden hour, low angled key from frame right casting long shadows, warm rim along subject edge, cooler fill from open sky, no overhead noon sun, directional and falling off.
+
+## STYLE_OVERCAST_DIFFUSED
+overcast sky, soft directional light from above-left, low contrast but still shaped, wet pavement holding reflections, no hard shadows, no studio softbox uniformity.
+
+## STYLE_LOW_LIGHT_PRACTICALS
+night-time, motivated by named practical sources, neon signage, tungsten window spill, sodium streetlamp, heavy halation around bright bulbs, deep shadows held with detail not crushed, no flat dim ambient.
+
+## STYLE_SHALLOW_DOF
+extremely shallow depth of field at T1.5-T2.0 on cine prime, focus locked tight on subject's eyes or hands, foreground and background falling off into creamy out-of-focus, organic falloff not gaussian blur.
+
+## STYLE_MACRO_TACTILE
+extreme macro close-up, dust motes catching directional light, fingerprint smears on glass, fabric weave at thread level, micro chromatic aberration on metal edges, breath fog on cold surfaces.
+
+## STYLE_GRAIN_HALATION
+subtle 35mm film grain visible in shadows and skin midtones, halation bleeding around clipped highlights, micro chromatic aberration on hard edges, soft bloom on bright sources, analogue interference not noise.
+
+## STYLE_HANDHELD_OPERATOR
+handheld with experienced operator, organic micro-breathing, subtle weight shifts on each step, slight rack focus between subjects, parallax that feels human, not gimbal-smooth, not shaky-cam.
+
+## STYLE_COMPOSITION_OFFCENTRE
+subject placed on rule-of-thirds intersection or in negative-space asymmetry, leading lines drawing eye through frame, shoulders or foreground elements breaking the edge, never centred-front-on hero portrait.
+
+## STYLE_REAL_SKIN
+visible skin pores, individual hair strands at hairline, slight facial asymmetry, subtle ruddiness in cheeks and ears, fine lines around eyes if appropriate to age, micro-imperfections, nobody is airbrushed.
+
+## NEG_AI_PLASTIC_SKIN
+plastic skin, smooth airbrushed skin, doll-like, mannequin, waxy, porcelain, instagram filter, beauty filter, smoothed pores, symmetrical face, perfect teeth, perfect makeup, photoshop liquify, plumped lips, identical eyes.
+
+## NEG_AI_COMPOSITION
+centred front-lit hero shot, symmetrical lighting, balanced studio softbox setup, corporate headshot framing, dead-centre subject, magazine-cover staging, every-feature-evenly-lit, no shadow side, generic stock photo.
+
+## NEG_AI_LIGHTING
+flat noon lighting, evenly-lit ambient, glow without source direction, fake lens flare overlay, every-light-balanced, studio softbox uniformity, ringlight beauty look, ambient-occlusion-fake, golden filter applied evenly.
+
+## NEG_HUMAN_ANATOMY
+deformed hands, extra fingers, missing fingers, fused fingers, distorted fingers, bad anatomy, bad proportions, extra limbs, missing limbs, floating limbs, disconnected limbs, mutated faces, mutation, disfigured, bad eyes, crossed eyes, bad teeth, clothing glitches, impossible pose.
+
+## NEG_OBJECT_GEOMETRY
+deformed geometry, distorted proportions, extra parts, missing parts, bad perspective, melted edges, ugly, blurry, low quality, watermark, text, writing, signature, logo glitches, broken physics, impossible reflection.
+
+## NEG_INFLUENCER_AESTHETIC
+travel-influencer aesthetic, everything-dreamy, all-golden-filter, soft-glowy-everywhere, main character framing, instagram preset look, lifestyle stock photo, polished commercial sheen.
+
+# Notes
+
+Treat the model like a director of photography. Lead shot prompts with "Shot on [camera]" or "Shot on [camera] mounted on [rig]". State T-stop, shutter speed, fps, lighting state, and direction. Use only the STYLE_ and NEG_ blocks a shot actually needs.

--- a/mcp_video/server.py
+++ b/mcp_video/server.py
@@ -65,6 +65,12 @@ from .server_tools_image import (
     image_extract_colors as image_extract_colors,
     image_generate_palette as image_generate_palette,
 )
+from .server_tools_creation import (
+    shot_prompt_render as shot_prompt_render,
+    storyboard_read as storyboard_read,
+    style_pack_read as style_pack_read,
+    video_project_create as video_project_create,
+)
 from .server_tools_hyperframes import (
     hyperframes_add_block as hyperframes_add_block,
     hyperframes_compositions as hyperframes_compositions,

--- a/mcp_video/server_tools_creation.py
+++ b/mcp_video/server_tools_creation.py
@@ -1,0 +1,61 @@
+"""PUSHING CREATION-compatible MCP tool registrations."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .server_app import _result, _safe_tool, mcp
+
+
+@mcp.tool()
+@_safe_tool
+def video_project_create(slug: str, output_dir: str | None = None) -> dict[str, Any]:
+    """Scaffold a cinematic video project with style, storyboard, and refs folders.
+
+    Args:
+        slug: Project slug using lowercase letters, numbers, hyphens, or underscores.
+        output_dir: Base directory for the projects/ folder. Defaults to the current working directory.
+    """
+    from .creation_engine import create_video_project
+
+    return _result(create_video_project(slug, output_dir=output_dir))
+
+
+@mcp.tool()
+@_safe_tool
+def style_pack_read(path: str) -> dict[str, Any]:
+    """Read STYLE_ and NEG_ blocks from a style.md file or project directory.
+
+    Args:
+        path: Absolute path to style.md or to a project directory containing style.md.
+    """
+    from .creation_engine import read_style_pack
+
+    return _result(read_style_pack(path))
+
+
+@mcp.tool()
+@_safe_tool
+def storyboard_read(path: str) -> dict[str, Any]:
+    """Read a PUSHING CREATION storyboard table from storyboard.md or a project directory.
+
+    Args:
+        path: Absolute path to storyboard.md or to a project directory containing storyboard.md.
+    """
+    from .creation_engine import read_storyboard
+
+    return _result(read_storyboard(path))
+
+
+@mcp.tool()
+@_safe_tool
+def shot_prompt_render(project_path: str, shot: str) -> dict[str, Any]:
+    """Expand one storyboard shot into prompt and negative_prompt strings.
+
+    Args:
+        project_path: Absolute path to a project directory containing style.md and storyboard.md.
+        shot: Shot id or 1-based row number from storyboard.md.
+    """
+    from .creation_engine import render_shot_prompt
+
+    return _result(render_shot_prompt(project_path, shot))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "mcp-video"
 version = "1.3.5"
-description = "Video editing MCP server for AI agents. 87 FFmpeg and Hyperframes tools, Python client, and CLI. Local, fast, free."
+description = "Video editing MCP server for AI agents. 91 FFmpeg, creation, and Hyperframes tools, Python client, and CLI. Local, fast, free."
 readme = "README.md"
 license = "Apache-2.0"
 requires-python = ">=3.11"

--- a/tests/test_creation_engine.py
+++ b/tests/test_creation_engine.py
@@ -1,0 +1,98 @@
+"""Tests for PUSHING CREATION style-pack and storyboard helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from mcp_video.creation_engine import (
+    create_video_project,
+    read_storyboard,
+    read_style_pack,
+    render_shot_prompt,
+)
+from mcp_video.errors import MCPVideoError
+
+
+def test_create_video_project_scaffolds_pushing_creation_layout(tmp_path: Path):
+    result = create_video_project("editorial-portrait", output_dir=str(tmp_path))
+
+    project = tmp_path / "projects" / "editorial-portrait"
+    assert result["project_path"] == str(project)
+    assert (project / "style.md").is_file()
+    assert (project / "storyboard.md").is_file()
+    assert (project / "refs" / ".gitkeep").is_file()
+    assert result["next_steps"][0].startswith("Drop reference stills")
+
+
+def test_create_video_project_rejects_unsafe_slug(tmp_path: Path):
+    with pytest.raises(MCPVideoError) as exc_info:
+        create_video_project("../nope", output_dir=str(tmp_path))
+
+    assert exc_info.value.code == "invalid_parameter"
+
+
+def test_read_style_pack_parses_style_and_negative_blocks(tmp_path: Path):
+    style_path = tmp_path / "style.md"
+    style_path.write_text(
+        """
+## STYLE_GOLDEN_HOUR
+late afternoon rim light, warm key
+
+## NEG_AI_LIGHTING
+flat noon, fake lens flare
+""".strip()
+    )
+
+    result = read_style_pack(str(style_path))
+
+    assert result["block_count"] == 2
+    assert result["style_blocks"][0]["name"] == "STYLE_GOLDEN_HOUR"
+    assert result["negative_blocks"][0]["body"] == "flat noon, fake lens flare"
+
+
+def test_read_storyboard_parses_markdown_table(tmp_path: Path):
+    storyboard_path = tmp_path / "storyboard.md"
+    storyboard_path.write_text(
+        """
+| Shot | Provider | Model | Camera | Lens | Aspect | Action | Refs | Style | Neg | Mode | Duration |
+|------|----------|-------|--------|------|--------|--------|------|-------|-----|------|----------|
+| opener | runway | gen3 | ARRI Alexa 35 | 50mm T1.5 | 16:9 | Shot on ARRI, slow push. | hero.jpg | STYLE_GOLDEN_HOUR | NEG_AI_LIGHTING | video | 5s |
+""".strip()
+    )
+
+    result = read_storyboard(str(storyboard_path))
+
+    assert result["shot_count"] == 1
+    assert result["shots"][0]["shot"] == "opener"
+    assert result["shots"][0]["style"] == ["STYLE_GOLDEN_HOUR"]
+
+
+def test_render_shot_prompt_expands_referenced_blocks(tmp_path: Path):
+    project = tmp_path / "projects" / "launch"
+    project.mkdir(parents=True)
+    (project / "style.md").write_text(
+        """
+## STYLE_GOLDEN_HOUR
+late afternoon rim light, warm key
+
+## NEG_AI_LIGHTING
+flat noon, fake lens flare
+""".strip()
+    )
+    (project / "storyboard.md").write_text(
+        """
+| Shot | Provider | Model | Camera | Lens | Aspect | Action | Refs | Style | Neg | Mode | Duration |
+|------|----------|-------|--------|------|--------|--------|------|-------|-----|------|----------|
+| opener | runway | gen3 | ARRI Alexa 35 | 50mm T1.5 | 16:9 | Shot on ARRI Alexa 35, slow push. | hero.jpg | STYLE_GOLDEN_HOUR | NEG_AI_LIGHTING | video | 5s |
+""".strip()
+    )
+
+    result = render_shot_prompt(str(project), shot="opener")
+
+    assert result["shot"] == "opener"
+    assert result["provider"] == "runway"
+    assert "Shot on ARRI Alexa 35" in result["prompt"]
+    assert "late afternoon rim light" in result["prompt"]
+    assert result["negative_prompt"] == "flat noon, fake lens flare"

--- a/tests/test_public_surface.py
+++ b/tests/test_public_surface.py
@@ -188,6 +188,10 @@ EXPECTED_SERVER_TOOLS = {
     "image_extract_colors",
     "image_generate_palette",
     "image_analyze_product",
+    "video_project_create",
+    "style_pack_read",
+    "storyboard_read",
+    "shot_prompt_render",
 }
 
 
@@ -227,7 +231,7 @@ def test_server_tool_registry_keeps_public_tool_names():
     tool_names = {tool.name for tool in asyncio.run(mcp.list_tools())}
 
     assert tool_names >= EXPECTED_SERVER_TOOLS
-    assert len(tool_names) == 87
+    assert len(tool_names) == 91
 
 
 def test_stdio_server_launches_and_lists_tools_like_registry_clients():
@@ -242,7 +246,7 @@ def test_stdio_server_launches_and_lists_tools_like_registry_clients():
         tool_names = {tool.name for tool in tools_result.tools}
         assert init_result.serverInfo.name == "mcp-video"
         assert tool_names >= EXPECTED_SERVER_TOOLS
-        assert len(tool_names) == 87
+        assert len(tool_names) == 91
 
     asyncio.run(check_server())
 
@@ -306,6 +310,8 @@ def test_module_reexports():
         "video_analyze",
         "hyperframes_render",
         "image_analyze_product",
+        "video_project_create",
+        "shot_prompt_render",
     ]:
         assert hasattr(server, name), f"server missing {name}"
 


### PR DESCRIPTION
## Summary

Adds a PUSHING CREATION-style pre-production layer to mcp-video as typed MCP tools instead of vendoring Claude slash commands. The new workflow lets agents scaffold cinematic projects, parse STYLE_/NEG_ style packs, parse markdown storyboards, and expand a shot into provider-ready prompt and negative_prompt strings.

## Changes

- Add `mcp_video.creation_engine` for project scaffold, style-pack parsing, storyboard parsing, and shot prompt rendering.
- Add `mcp_video.server_tools_creation` and register `video_project_create`, `style_pack_read`, `storyboard_read`, and `shot_prompt_render`.
- Bundle PUSHING CREATION-compatible starter templates under `mcp_video/creation_templates/`.
- Update public docs, discovery text, and tool count from 87/90-era references to 91 tools.
- Add focused tests for the creation engine and public MCP registry surface.

## Validation

- `python3 -m pytest tests/test_creation_engine.py tests/test_public_surface.py -q --tb=short` -> 9 passed
- `python3 -c "import mcp_video; import mcp_video.server; print('imports ok')"` -> imports ok
- `python3 -m ruff check mcp_video/creation_engine.py mcp_video/server_tools_creation.py tests/test_creation_engine.py tests/test_public_surface.py` -> passed
- `python3 -m pytest tests/ -x -q --tb=short` -> 1039 passed, 9 skipped
- MCP registry sanity check -> 91 tools, all four creation tools present

## Notes

Not tested: live MCP client handshake after packaging/publish.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/mcp-video/pr/250"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->