### PR TITLE
[codex] Restore README readiness anchors

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Use it when you want an AI assistant to:
 - create new video projects with Hyperframes and post-process the result with FFmpeg tools;
 - drive repeatable media workflows from Claude Code, Cursor, Codex-style clients, scripts, or CI.
 
-## Install
+## Installation
 
 Prerequisite: [FFmpeg](https://ffmpeg.org/) must be installed and available on `PATH`.
 
@@ -170,7 +170,7 @@ mcp-video video-quality-check clip.mp4
 | Batch automation | "Convert this folder of clips to web-ready MP4 with consistent loudness." |
 | Code-created video | "Scaffold a Hyperframes composition, render it, then add subtitles and a watermark." |
 
-## Tool Surface
+## MCP Tools
 
 mcp-video registers **91 MCP tools** across 11 categories, including a `search_tools` discovery tool so agents can find the right operation without loading every tool description into context.
 
@@ -240,6 +240,16 @@ Safety contract:
 - [FAQ](docs/faq.md)
 - [llms.txt](llms.txt)
 
+## Testing
+
+Run the standard development suite after installing dev dependencies:
+
+```bash
+pytest tests/ -v -m "not slow and not hyperframes"
+```
+
+See the [testing guide](docs/TESTING.md) for slower media and integration checks.
+
 ## Development
 
 ```bash
@@ -254,6 +264,9 @@ pytest tests/ -v -m "not slow and not hyperframes"
 ## Community
 
 - [Contributing](CONTRIBUTING.md)
+- [Code of Conduct](CODE_OF_CONDUCT.md)
+- [Governance](GOVERNANCE.md)
+- [Maintainers](MAINTAINERS.md)
 - [Security](SECURITY.md)
 - [Support](SUPPORT.md)
 - [Roadmap](ROADMAP.md)


### PR DESCRIPTION
## Summary

Fixes the post-merge `Repository readiness` failure on master by restoring the README section anchors and governance links expected by `scripts/repo-readiness-audit.py`.

## Changes

- Rename `## Install` to `## Installation`.
- Rename `## Tool Surface` to `## MCP Tools`.
- Add a concise `## Testing` section linking to the testing guide.
- Add Code of Conduct, Governance, and Maintainers links to Community.

## Validation

- `.venv/bin/python ./scripts/repo-readiness-audit.py` -> baseline passed; only pre-commit dirty-tree warning before commit
- `git diff --check` -> passed

## Notes

This is a README-only follow-up to unblock master CI after PR #250 merged.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/mcp-video/pr/251"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->