### PR TITLE
Keep PUSHING CREATION docs aligned

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-mcp-video currently collects **1054 tests** covering public MCP tools, Python client, CLI, FFmpeg operations, AI features, Hyperframes integration, security hardening, and engine internals. Some tests are environment-sensitive and may skip when optional dependencies or system capabilities are unavailable.
+mcp-video currently collects **1074 tests** covering public MCP tools, Python client, CLI, FFmpeg operations, AI features, cinematic creation helpers, Hyperframes integration, security hardening, and engine internals. Some tests are environment-sensitive and may skip when optional dependencies or system capabilities are unavailable.
 
 ## Test Suite: `tests/test_real_all_features.py`
 
@@ -131,7 +131,7 @@ pip install demucs torch torchaudio openai-whisper realesrgan basicsr imagehash 
 | test_44_ai_upscale | ~30s | FSRCNN model (fast CPU inference) |
 | test_43_ai_stem_separation | ~30s | Downloads model on first run |
 | Full suite | ~5min | All 70 real-media tests |
-| Full project suite | Environment-dependent | 1054 tests collected |
+| Full project suite | Environment-dependent | 1074 tests collected |
 
 ## Recent Fixes
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -2,7 +2,7 @@
 
 ## What is mcp-video?
 
-mcp-video is an open-source MCP server, Python library, and CLI that wraps FFmpeg and Hyperframes to give AI agents 87 video editing tools. It runs locally, requires no cloud services, and is free under the Apache-2.0 license.
+mcp-video is an open-source MCP server, Python library, and CLI that wraps FFmpeg, cinematic planning helpers, and Hyperframes to give AI agents 91 video editing and creation tools. It runs locally, requires no cloud services, and is free under the Apache-2.0 license.
 
 ## What is MCP?
 
@@ -46,7 +46,11 @@ mcp-video includes 7 AI features: silence removal, Whisper transcription, scene 
 
 ## How many tools does it have?
 
-87 MCP tools across 10 categories: Meta / Discovery, Core Editing, AI-Powered, Hyperframes, Audio Synthesis, Visual Effects, Transitions, Layout & Motion Graphics, Analysis, and Image Analysis. The count includes the `search_tools` meta-tool for fast discovery.
+91 MCP tools across 11 categories: Meta / Discovery, Cinematic Creation, Core Editing, AI-Powered, Hyperframes, Audio Synthesis, Visual Effects, Transitions, Layout & Motion Graphics, Analysis, and Image Analysis. The count includes the `search_tools` meta-tool for fast discovery.
+
+## What are the cinematic creation tools?
+
+The cinematic creation tools add a PUSHING CREATION-compatible pre-production workflow: `video_project_create` scaffolds a project with `style.md`, `storyboard.md`, and `refs/`; `style_pack_read` parses STYLE_ and NEG_ blocks; `storyboard_read` parses shot rows; and `shot_prompt_render` expands a storyboard shot into generation-ready positive and negative prompts.
 
 ## Is it free?
 
@@ -58,7 +62,7 @@ Very fast. Since it wraps FFmpeg directly, operations like trimming, merging, an
 
 ## Can I use it in production?
 
-Yes. mcp-video currently collects 1054 tests and has comprehensive error handling with structured error types, input validation, and FFmpeg timeout protection. It's used in CI/CD pipelines for automated video quality checks.
+Yes. mcp-video currently collects 1074 tests and has comprehensive error handling with structured error types, input validation, and FFmpeg timeout protection. It's used in CI/CD pipelines for automated video quality checks.
 
 ## How do I contribute?
 

--- a/docs/launch-checklist.md
+++ b/docs/launch-checklist.md
@@ -7,7 +7,7 @@
 **Do say:** "I audited every video editing MCP server (there are 20+). Here's what they all get wrong, and how I fixed it."
 
 **Key differentiators:**
-1. 1054 tests collected (almost all competitors have 0)
+1. 1074 tests collected (almost all competitors have 0)
 2. Progress callbacks (nobody does this — the #1 requested feature)
 3. Auto-fix error handling (parses FFmpeg errors into actionable fixes)
 4. Visual verification (returns thumbnail after every operation)
@@ -29,7 +29,7 @@ Most have 0 tests. None have progress reporting. All dump raw FFmpeg stderr when
 
 So I built mcp-video — the one that actually works.
 
-1054 tests collected. Progress callbacks. Auto-fix errors. Visual verification.
+1074 tests collected. Progress callbacks. Auto-fix errors. Visual verification.
 
 Here's what it does:
 
@@ -52,13 +52,13 @@ What makes mcp-video different from the 20+ other video MCP servers:
 Progress callbacks — FFmpeg stderr parsed into real-time percentage
 Auto-fix errors — "Codec error: vp9" → "Auto-convert from vp9 to H.264/AAC"
 Visual verification — thumbnail returned after every operation
-1054 tests collected — the next closest competitor has 0
+1074 tests collected — the next closest competitor has 0
 
 ---
 
 **Tweet 4 (tools):**
 
-87 MCP tools, including:
+91 MCP tools, including:
 
 video_info | video_trim | video_merge | video_add_text
 video_add_audio | video_resize | video_convert | video_speed
@@ -66,6 +66,7 @@ video_thumbnail | video_preview | video_storyboard | video_subtitles
 video_watermark | video_crop | video_rotate | video_fade
 video_export | video_edit | video_extract_audio
 hyperframes_init | hyperframes_render | search_tools
+video_project_create | style_pack_read | storyboard_read | shot_prompt_render
 
 Plus 5 platform templates: TikTok, YouTube Shorts, Reels, YouTube, Instagram Post.
 
@@ -99,7 +100,7 @@ If you build with MCP, I'd love to hear what tools you need.
 
 ## Hacker News Show HN Post
 
-**Title:** Show HN: mcp-video - The video editing MCP server that actually works (1054 tests)
+**Title:** Show HN: mcp-video - The video editing MCP server that actually works (1074 tests)
 
 **Body:**
 
@@ -110,13 +111,14 @@ I audited 20+ video editing MCP servers before building mcp-video. Here's what I
 - All dump raw FFmpeg stderr when things fail
 - None have visual verification
 
-mcp-video fixes all of these. It's an open-source MCP server that wraps FFmpeg and Hyperframes into 87 structured tools with:
+mcp-video fixes all of these. It's an open-source MCP server that wraps FFmpeg, cinematic planning helpers, and Hyperframes into 91 structured tools with:
 
-- **1054 tests collected** across the full testing pyramid (unit -> integration -> e2e)
+- **1074 tests collected** across the full testing pyramid (unit -> integration -> e2e)
 - **Progress callbacks** — parses FFmpeg stderr in real-time, returns percentage (0-100) to the agent
 - **Auto-fix error handling** — parses FFmpeg errors into structured responses with actionable suggestions ("Codec error: vp9" → "Auto-convert from vp9 to H.264/AAC")
 - **Visual verification** — returns a base64 thumbnail of the first frame after every operation, so agents can confirm results
 - **Timeline DSL** — declarative multi-track edits (video + audio + text + transitions) in a single JSON object
+- **Cinematic pre-production** — PUSHING CREATION-compatible style packs, storyboards, and shot-prompt expansion
 - **5 platform templates** — TikTok, YouTube Shorts, Instagram Reel, YouTube, Instagram Post
 - **3 interfaces** — MCP server, Python client, CLI
 
@@ -137,7 +139,7 @@ Quick setup:
 }
 ```
 
-1054 tests collected. Pure Python. Core install only depends on mcp + pydantic + FFmpeg.
+1074 tests collected. Pure Python. Core install only depends on mcp + pydantic + FFmpeg.
 
 pip install mcp-video
 
@@ -158,12 +160,13 @@ Hey everyone. I audited every video editing MCP server I could find before build
 The state of the field: most have 0 tests, none report progress, all dump raw FFmpeg stderr, and none let agents verify results visually.
 
 mcp-video fixes all of that:
-- 1054 tests collected (unit, integration, e2e)
+- 1074 tests collected (unit, integration, e2e)
 - Real-time progress callbacks (parses FFmpeg stderr)
 - Auto-fix error handling (structured errors with suggested actions)
 - Visual verification (thumbnail returned after every operation)
 - Timeline DSL for complex multi-track edits
 - 5 platform templates (TikTok, YouTube Shorts, etc.)
+- Cinematic pre-production tools for style packs, storyboards, and shot prompts
 - 3 interfaces: MCP server, Python client, CLI
 
 Quick setup:
@@ -180,7 +183,7 @@ Quick setup:
 
 Then: "Hey Claude, trim this video from 0:30 to 1:00 and add a title card."
 
-87 tools. Apache 2.0.
+91 tools. Apache 2.0.
 
 What tools would you want to see in a video editing MCP server?
 
@@ -190,19 +193,19 @@ GitHub: https://github.com/KyaniteLabs/mcp-video
 
 ### r/ClaudeAI
 
-**Title:** mcp-video — progress callbacks, visual verification, and 1054 tests for video editing in Claude Code
+**Title:** mcp-video — progress callbacks, visual verification, and 1074 tests for video editing in Claude Code
 
 **Body:**
 
 If you've ever wanted Claude to edit video for you, this is how.
 
-mcp-video is an MCP server with 87 video editing and creation tools. What makes it different from the 20+ other video MCP servers:
+mcp-video is an MCP server with 91 video editing and creation tools. What makes it different from the 20+ other video MCP servers:
 
 1. **Progress callbacks** — Long operations (convert, merge, export) now report real-time progress. Your agent can tell you "50% done..." instead of going silent.
 
 2. **Visual verification** — After every operation, mcp-video returns a thumbnail of the first frame. You can confirm the result looks right without opening the file.
 
-3. **1054 tests collected** — The next closest competitor has 0.
+3. **1074 tests collected** — The next closest competitor has 0.
 
 4. **Auto-fix errors** — When FFmpeg fails, mcp-video parses the error and suggests a fix. "Codec error: vp9" → "Auto-convert from vp9 to H.264/AAC".
 
@@ -227,23 +230,24 @@ https://github.com/KyaniteLabs/mcp-video
 
 ### r/LocalLLaMA
 
-**Title:** mcp-video — open source video editing MCP server (1054 tests, progress callbacks, works with Claude/Cursor)
+**Title:** mcp-video — open source video editing MCP server (1074 tests, progress callbacks, works with Claude/Cursor)
 
 **Body:**
 
 Built an MCP server for video editing. After auditing 20+ competitors, I focused on what they all get wrong: tests, error handling, and progress reporting.
 
-87 tools that wrap FFmpeg and Hyperframes into a clean API for AI agents. Works with Claude Code, Cursor, and any MCP-compatible client.
+91 tools that wrap FFmpeg, cinematic planning helpers, and Hyperframes into a clean API for AI agents. Works with Claude Code, Cursor, and any MCP-compatible client.
 
 What's different:
-- 1054 tests collected (next closest competitor: 0)
+- 1074 tests collected (next closest competitor: 0)
 - Progress callbacks (real-time FFmpeg stderr parsing)
 - Auto-fix error handling (structured errors with suggested actions)
 - Visual verification (thumbnail returned after operations)
 - Timeline DSL for complex multi-track edits
+- Cinematic pre-production tools for style packs, storyboards, and shot prompts
 - Python client and CLI
 
-1054 tests collected. Apache 2.0. pip install mcp-video.
+1074 tests collected. Apache 2.0. pip install mcp-video.
 
 https://github.com/KyaniteLabs/mcp-video
 
@@ -255,7 +259,7 @@ https://github.com/KyaniteLabs/mcp-video
 
 Hey [Name], I saw you've been building with MCP and thought you might be interested — I just shipped mcp-video, an open-source video editing MCP server.
 
-87 tools (trim, merge, text, audio, resize, crop, rotate, fade, convert, Hyperframes render, and more) that work with Claude Code, Cursor, etc. It's the most tested video MCP server I'm aware of — 1054 tests collected, progress callbacks, auto-fix error handling.
+91 tools (trim, merge, text, audio, resize, crop, rotate, fade, convert, cinematic style packs/storyboards, Hyperframes render, and more) that work with Claude Code, Cursor, etc. It's the most tested video MCP server I'm aware of — 1074 tests collected, progress callbacks, auto-fix error handling.
 
 Would love your feedback if you get a chance to try it. What video editing capabilities would be most useful in your workflows?
 
@@ -273,7 +277,7 @@ Would you be interested in beta testing? Looking for people who edit video regul
 
 Hey [Name], been following your work on [their project]. I just built mcp-video — an MCP server for video editing.
 
-The architecture is: MCP server wrapping FFmpeg and Hyperframes, with a Python client and CLI. 87 tools, 1054 tests collected, progress callbacks, auto-fix errors, Apache 2.0.
+The architecture is: MCP server wrapping FFmpeg, cinematic planning helpers, and Hyperframes, with a Python client and CLI. 91 tools, 1074 tests collected, progress callbacks, auto-fix errors, Apache 2.0.
 
 Curious if you've thought about adding video capabilities to [their project]? Would be happy to collaborate or share what I've learned about the MCP tool-building patterns.
 


### PR DESCRIPTION
## Summary
- refresh FAQ, launch copy, and testing docs for the 91-tool PUSHING CREATION surface
- add FAQ coverage for the cinematic creation tools
- update collected test count to 1074 based on pytest collection

## Verification
- python3 -m pytest --collect-only -q tests | tail -1
- python3 ./scripts/repo-readiness-audit.py
- git diff --check
- rg stale public doc counts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/mcp-video/pr/252"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->