### PR TITLE
Prepare v1.3.6 cinematic creation release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,25 @@ This project follows a simple release-note style:
 
 ## Unreleased
 
+## 1.3.6 - 2026-05-06
+
+### Added
+
+- Added PUSHING CREATION-compatible cinematic pre-production tools:
+  - `video_project_create`
+  - `style_pack_read`
+  - `storyboard_read`
+  - `shot_prompt_render`
+
+### Changed
+
+- Updated package, MCP registry metadata, README, `llms.txt`, and tool docs for the 91-tool cinematic creation surface.
+- Toned down public launch copy so test coverage is supporting evidence rather than the main product message.
+
+### Fixed
+
+- Restored README readiness anchors required by the repository audit.
+
 ## 1.3.1 - 2026-05-03
 
 ### Security

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -62,7 +62,7 @@ Very fast. Since it wraps FFmpeg directly, operations like trimming, merging, an
 
 ## Can I use it in production?
 
-Yes. mcp-video currently collects 1074 tests and has comprehensive error handling with structured error types, input validation, and FFmpeg timeout protection. It's used in CI/CD pipelines for automated video quality checks.
+Yes. mcp-video has comprehensive error handling with structured error types, input validation, FFmpeg timeout protection, and CI coverage for package and repository readiness. It's used in CI/CD pipelines for automated video quality checks.
 
 ## How do I contribute?
 

--- a/docs/launch-checklist.md
+++ b/docs/launch-checklist.md
@@ -4,16 +4,16 @@
 
 **Don't say:** "I built a video editing MCP server" (there are 20+).
 
-**Do say:** "I audited every video editing MCP server (there are 20+). Here's what they all get wrong, and how I fixed it."
+**Do say:** "I built a local video-production surface for AI agents: editing, cinematic planning, rendering, and release checks without brittle FFmpeg prompting."
 
 **Key differentiators:**
-1. 1074 tests collected (almost all competitors have 0)
-2. Progress callbacks (nobody does this — the #1 requested feature)
-3. Auto-fix error handling (parses FFmpeg errors into actionable fixes)
-4. Visual verification (returns thumbnail after every operation)
-5. Timeline DSL (declarative multi-track edits in one JSON)
-6. Platform templates (TikTok/YouTube/Instagram presets)
-7. 3 interfaces (MCP + Python client + CLI)
+1. 91 structured tools across editing, planning, analysis, audio, effects, and Hyperframes rendering
+2. Cinematic pre-production with style packs, storyboards, and shot-prompt expansion
+3. Progress callbacks for long FFmpeg operations
+4. Auto-fix error handling that turns FFmpeg failures into actionable fixes
+5. Visual verification with thumbnails, storyboards, and release checkpoints
+6. Timeline DSL and platform templates for repeatable social/video workflows
+7. 3 interfaces: MCP server, Python client, and CLI
 
 ---
 
@@ -23,13 +23,11 @@
 
 **Tweet 1 (hook — competitive angle):**
 
-I audited every video editing MCP server (there are 20+).
+AI agents can edit video, but raw FFmpeg prompting gets brittle fast.
 
-Most have 0 tests. None have progress reporting. All dump raw FFmpeg stderr when things fail.
+So I built mcp-video: a local MCP server with structured video tools for editing, planning, rendering, and release checks.
 
-So I built mcp-video — the one that actually works.
-
-1074 tests collected. Progress callbacks. Auto-fix errors. Visual verification.
+91 tools. No cloud. No guessed FFmpeg flags.
 
 Here's what it does:
 
@@ -49,10 +47,11 @@ No FFmpeg flags to memorize. No cloud API to pay for. Your video never leaves yo
 
 What makes mcp-video different from the 20+ other video MCP servers:
 
+91 structured tools — editing, analysis, audio, effects, cinematic planning, Hyperframes rendering
 Progress callbacks — FFmpeg stderr parsed into real-time percentage
 Auto-fix errors — "Codec error: vp9" → "Auto-convert from vp9 to H.264/AAC"
-Visual verification — thumbnail returned after every operation
-1074 tests collected — the next closest competitor has 0
+Visual verification — thumbnails, storyboards, and release checkpoints
+Cinematic planning — style packs, storyboard tables, and shot prompts before generation
 
 ---
 
@@ -100,20 +99,12 @@ If you build with MCP, I'd love to hear what tools you need.
 
 ## Hacker News Show HN Post
 
-**Title:** Show HN: mcp-video - The video editing MCP server that actually works (1074 tests)
+**Title:** Show HN: mcp-video - Local video editing and planning tools for AI agents
 
 **Body:**
 
-I audited 20+ video editing MCP servers before building mcp-video. Here's what I found:
+mcp-video is an open-source MCP server that wraps FFmpeg, cinematic planning helpers, and Hyperframes into 91 structured tools for agents:
 
-- Most have 0 tests
-- None report progress on long operations
-- All dump raw FFmpeg stderr when things fail
-- None have visual verification
-
-mcp-video fixes all of these. It's an open-source MCP server that wraps FFmpeg, cinematic planning helpers, and Hyperframes into 91 structured tools with:
-
-- **1074 tests collected** across the full testing pyramid (unit -> integration -> e2e)
 - **Progress callbacks** — parses FFmpeg stderr in real-time, returns percentage (0-100) to the agent
 - **Auto-fix error handling** — parses FFmpeg errors into structured responses with actionable suggestions ("Codec error: vp9" → "Auto-convert from vp9 to H.264/AAC")
 - **Visual verification** — returns a base64 thumbnail of the first frame after every operation, so agents can confirm results
@@ -126,6 +117,7 @@ Three interfaces:
 - MCP Server: Add to your config, then just tell your agent what to edit
 - Python Client: Clean API for automation (`editor.trim("v.mp4", start="0:30", duration="15")`)
 - CLI: `mcp-video trim video.mp4 -s 0:30 -d 15`
+- CI-backed release process for package, registry, and repository readiness
 
 Quick setup:
 ```json
@@ -139,8 +131,6 @@ Quick setup:
 }
 ```
 
-1074 tests collected. Pure Python. Core install only depends on mcp + pydantic + FFmpeg.
-
 pip install mcp-video
 
 GitHub: https://github.com/KyaniteLabs/mcp-video
@@ -151,16 +141,14 @@ GitHub: https://github.com/KyaniteLabs/mcp-video
 
 ### r/MCP (Model Context Protocol)
 
-**Title:** After trying 20+ video MCP servers, I built one that actually has tests
+**Title:** mcp-video: local video editing, storyboards, and release checks for AI agents
 
 **Body:**
 
-Hey everyone. I audited every video editing MCP server I could find before building mcp-video.
+Hey everyone. I built mcp-video because I wanted agents to edit video through structured operations instead of fragile one-off FFmpeg commands.
 
-The state of the field: most have 0 tests, none report progress, all dump raw FFmpeg stderr, and none let agents verify results visually.
-
-mcp-video fixes all of that:
-- 1074 tests collected (unit, integration, e2e)
+mcp-video gives agents:
+- 91 structured tools for editing, analysis, effects, audio, cinematic planning, and Hyperframes rendering
 - Real-time progress callbacks (parses FFmpeg stderr)
 - Auto-fix error handling (structured errors with suggested actions)
 - Visual verification (thumbnail returned after every operation)
@@ -193,19 +181,19 @@ GitHub: https://github.com/KyaniteLabs/mcp-video
 
 ### r/ClaudeAI
 
-**Title:** mcp-video — progress callbacks, visual verification, and 1074 tests for video editing in Claude Code
+**Title:** mcp-video — local video editing, planning, and release checks in Claude Code
 
 **Body:**
 
 If you've ever wanted Claude to edit video for you, this is how.
 
-mcp-video is an MCP server with 91 video editing and creation tools. What makes it different from the 20+ other video MCP servers:
+mcp-video is an MCP server with 91 video editing and creation tools:
 
 1. **Progress callbacks** — Long operations (convert, merge, export) now report real-time progress. Your agent can tell you "50% done..." instead of going silent.
 
 2. **Visual verification** — After every operation, mcp-video returns a thumbnail of the first frame. You can confirm the result looks right without opening the file.
 
-3. **1074 tests collected** — The next closest competitor has 0.
+3. **Cinematic planning** — Style packs, storyboard tables, and shot prompts help plan generated video before rendering.
 
 4. **Auto-fix errors** — When FFmpeg fails, mcp-video parses the error and suggests a fix. "Codec error: vp9" → "Auto-convert from vp9 to H.264/AAC".
 
@@ -230,16 +218,15 @@ https://github.com/KyaniteLabs/mcp-video
 
 ### r/LocalLLaMA
 
-**Title:** mcp-video — open source video editing MCP server (1074 tests, progress callbacks, works with Claude/Cursor)
+**Title:** mcp-video — open source video editing MCP server with planning and release checks
 
 **Body:**
 
-Built an MCP server for video editing. After auditing 20+ competitors, I focused on what they all get wrong: tests, error handling, and progress reporting.
+Built an MCP server for local video editing and planning. The goal is to give agents structured media operations instead of raw shell-command improvisation.
 
 91 tools that wrap FFmpeg, cinematic planning helpers, and Hyperframes into a clean API for AI agents. Works with Claude Code, Cursor, and any MCP-compatible client.
 
 What's different:
-- 1074 tests collected (next closest competitor: 0)
 - Progress callbacks (real-time FFmpeg stderr parsing)
 - Auto-fix error handling (structured errors with suggested actions)
 - Visual verification (thumbnail returned after operations)
@@ -247,7 +234,7 @@ What's different:
 - Cinematic pre-production tools for style packs, storyboards, and shot prompts
 - Python client and CLI
 
-1074 tests collected. Apache 2.0. pip install mcp-video.
+Apache 2.0. pip install mcp-video.
 
 https://github.com/KyaniteLabs/mcp-video
 
@@ -259,7 +246,7 @@ https://github.com/KyaniteLabs/mcp-video
 
 Hey [Name], I saw you've been building with MCP and thought you might be interested — I just shipped mcp-video, an open-source video editing MCP server.
 
-91 tools (trim, merge, text, audio, resize, crop, rotate, fade, convert, cinematic style packs/storyboards, Hyperframes render, and more) that work with Claude Code, Cursor, etc. It's the most tested video MCP server I'm aware of — 1074 tests collected, progress callbacks, auto-fix error handling.
+91 tools (trim, merge, text, audio, resize, crop, rotate, fade, convert, cinematic style packs/storyboards, Hyperframes render, and more) that work with Claude Code, Cursor, etc. The useful part is that agents get structured operations, progress callbacks, visual review artifacts, and actionable FFmpeg errors.
 
 Would love your feedback if you get a chance to try it. What video editing capabilities would be most useful in your workflows?
 
@@ -277,7 +264,7 @@ Would you be interested in beta testing? Looking for people who edit video regul
 
 Hey [Name], been following your work on [their project]. I just built mcp-video — an MCP server for video editing.
 
-The architecture is: MCP server wrapping FFmpeg, cinematic planning helpers, and Hyperframes, with a Python client and CLI. 91 tools, 1074 tests collected, progress callbacks, auto-fix errors, Apache 2.0.
+The architecture is: MCP server wrapping FFmpeg, cinematic planning helpers, and Hyperframes, with a Python client and CLI. 91 tools, progress callbacks, auto-fix errors, visual review artifacts, Apache 2.0.
 
 Curious if you've thought about adding video capabilities to [their project]? Would be happy to collaborate or share what I've learned about the MCP tool-building patterns.
 

--- a/mcp_video/__init__.py
+++ b/mcp_video/__init__.py
@@ -1,6 +1,6 @@
 """mcp-video — Video editing MCP server for AI agents."""
 
-__version__ = "1.3.5"
+__version__ = "1.3.6"
 
 from .client import Client
 from .ai_engine import (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-video"
-version = "1.3.5"
+version = "1.3.6"
 description = "Video editing MCP server for AI agents. 91 FFmpeg, creation, and Hyperframes tools, Python client, and CLI. Local, fast, free."
 readme = "README.md"
 license = "Apache-2.0"

--- a/server.json
+++ b/server.json
@@ -2,8 +2,8 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.KyaniteLabs/mcp-video",
   "title": "mcp-video",
-  "description": "Video editing MCP server for AI agents using 87 structured FFmpeg and Hyperframes tools.",
-  "version": "1.3.5",
+  "description": "Video editing MCP server for AI agents using 91 structured FFmpeg, cinematic planning, and Hyperframes tools.",
+  "version": "1.3.6",
   "websiteUrl": "https://kyanitelabs.github.io/mcp-video/",
   "repository": {
     "url": "https://github.com/KyaniteLabs/mcp-video",
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "mcp-video",
-      "version": "1.3.5",
+      "version": "1.3.6",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
## Summary
- bump package, server metadata, and registry metadata to 1.3.6
- add changelog notes for the PUSHING CREATION cinematic creation tools
- remove exact test-count positioning from FAQ and launch copy so capability stays the headline

## Verification
- python3 -m pytest tests/ -x -q --tb=short
- python3 -m build
- python3 .github/scripts/check-built-artifacts.py dist
- python3 -m twine check dist/*
- python3 ./scripts/repo-readiness-audit.py
- git diff --check
- checked PyPI availability for mcp-video 1.3.6

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/mcp-video/pr/253"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->