### PR TITLE
Fix v1.3.6 registry metadata

### DIFF
--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.KyaniteLabs/mcp-video",
   "title": "mcp-video",
-  "description": "Video editing MCP server for AI agents using 91 structured FFmpeg, cinematic planning, and Hyperframes tools.",
+  "description": "Video editing MCP server with 91 FFmpeg, planning, and Hyperframes tools.",
   "version": "1.3.6",
   "websiteUrl": "https://kyanitelabs.github.io/mcp-video/",
   "repository": {


### PR DESCRIPTION
## Summary
- shorten server.json description so it passes the live MCP registry schema
- keep version at 1.3.6; prior release workflow failed before PyPI upload

## What happened
The v1.3.6 GitHub release triggered the publish workflow, but the build job failed at MCP registry metadata validation because the server.json description was too long. PyPI did not publish 1.3.6.

## Verification
- live MCP registry schema validation script
- python3 -m pytest tests/ -x -q --tb=short
- python3 -m build
- python3 .github/scripts/check-built-artifacts.py dist
- python3 -m twine check dist/*
- python3 ./scripts/repo-readiness-audit.py
- git diff --check
- PyPI 1.3.6 availability check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/mcp-video/pr/255"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->