### PR TITLE
Fix operator discovery and prepare v1.3.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ This project follows a simple release-note style:
 
 ## Unreleased
 
+## 1.3.7 - 2026-05-06
+
+### Fixed
+
+- Fixed `search_tools()` / `Client.search_tools()` so discovery includes the full 91-tool MCP surface, including PUSHING CREATION, Hyperframes, audio, and AI tools.
+
 ## 1.3.6 - 2026-05-06
 
 ### Added

--- a/mcp_video/__init__.py
+++ b/mcp_video/__init__.py
@@ -1,6 +1,6 @@
 """mcp-video — Video editing MCP server for AI agents."""
 
-__version__ = "1.3.6"
+__version__ = "1.3.7"
 
 from .client import Client
 from .ai_engine import (

--- a/mcp_video/cli/handlers_hyperframes.py
+++ b/mcp_video/cli/handlers_hyperframes.py
@@ -34,7 +34,7 @@ def handle_hyperframes_commands(args: Any, *, use_json: bool) -> bool:
             width=a.width,
             height=a.height,
             quality=a.quality,
-            format=a.format,
+            format=a.output_format,
             workers=a.workers,
             crf=a.crf,
         )

--- a/mcp_video/cli/parser/hyperframes.py
+++ b/mcp_video/cli/parser/hyperframes.py
@@ -21,7 +21,11 @@ def add_parsers(subparsers: argparse._SubParsersAction) -> None:
         help="Render quality (default: standard)",
     )
     hyperframes_render_p.add_argument(
-        "--format", default="mp4", choices=["mp4", "webm", "mov"], help="Output format (default: mp4)"
+        "--format",
+        dest="output_format",
+        default="mp4",
+        choices=["mp4", "webm", "mov"],
+        help="Output format (default: mp4)",
     )
     hyperframes_render_p.add_argument("--workers", help="Parallel render workers (number or 'auto')")
     hyperframes_render_p.add_argument("--crf", type=int, help="Override encoder CRF")

--- a/mcp_video/server_tools_basic.py
+++ b/mcp_video/server_tools_basic.py
@@ -326,7 +326,7 @@ def search_tools(query: str) -> dict[str, Any]:
     """Search registered MCP tools by keyword.
 
     Use this when you need to find the right tool for a task without reading
-    all 87 tool descriptions. Returns matching tools with their names,
+    all 91 tool descriptions. Returns matching tools with their names,
     descriptions, and required parameters.
 
     Args:
@@ -334,7 +334,16 @@ def search_tools(query: str) -> dict[str, Any]:
     """
     # Ensure all tool modules are loaded so the registry is complete.
     # We import sibling modules (not the facade) to populate the registry.
-    from . import server_tools_advanced, server_tools_effects, server_tools_image, server_tools_media  # noqa: F401
+    from . import (  # noqa: F401
+        server_tools_advanced,
+        server_tools_ai,
+        server_tools_audio,
+        server_tools_creation,
+        server_tools_effects,
+        server_tools_hyperframes,
+        server_tools_image,
+        server_tools_media,
+    )
 
     query_lower = query.lower()
     matches: list[dict[str, Any]] = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-video"
-version = "1.3.6"
+version = "1.3.7"
 description = "Video editing MCP server for AI agents. 91 FFmpeg, creation, and Hyperframes tools, Python client, and CLI. Local, fast, free."
 readme = "README.md"
 license = "Apache-2.0"

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.KyaniteLabs/mcp-video",
   "title": "mcp-video",
   "description": "Video editing MCP server with 91 FFmpeg, planning, and Hyperframes tools.",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "websiteUrl": "https://kyanitelabs.github.io/mcp-video/",
   "repository": {
     "url": "https://github.com/KyaniteLabs/mcp-video",
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "mcp-video",
-      "version": "1.3.6",
+      "version": "1.3.7",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/tests/test_cli_handlers.py
+++ b/tests/test_cli_handlers.py
@@ -4,6 +4,7 @@ These tests verify that each handler module registers the expected commands
 and that dispatch routes to the correct handler.
 """
 
+import json
 import importlib
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -212,6 +213,7 @@ def _make_args(**kwargs):
         "block_name": None,
         "port": None,
         "workers": None,
+        "output_format": "mp4",
         "caption": None,
         "lra": None,
         "metrics": None,
@@ -309,6 +311,36 @@ class TestHandlersHyperframes:
         args = _make_args(command="__no_match__")
         result = handle_hyperframes_commands(args, use_json=False)
         assert result is False
+
+    def test_render_json_uses_output_format_without_clobbering_global_format(self, monkeypatch, capsys):
+        from mcp_video.cli.handlers_hyperframes import handle_hyperframes_commands
+
+        captured = {}
+
+        def fake_render(project_path, **kwargs):
+            captured["project_path"] = project_path
+            captured["kwargs"] = kwargs
+            return {"success": True, "output_path": "/tmp/render.webm"}
+
+        monkeypatch.setattr("mcp_video.hyperframes_engine.render", fake_render)
+        monkeypatch.setattr(
+            "mcp_video.cli.handlers_hyperframes._with_spinner",
+            lambda _label, fn, *args, **kwargs: fn(*args, **kwargs),
+        )
+        args = _make_args(
+            command="hyperframes-render",
+            project_path="/tmp/project",
+            output="/tmp/render.webm",
+            output_format="webm",
+        )
+
+        result = handle_hyperframes_commands(args, use_json=True)
+        data = json.loads(capsys.readouterr().out)
+
+        assert result is True
+        assert data["success"] is True
+        assert captured["project_path"] == "/tmp/project"
+        assert captured["kwargs"]["format"] == "webm"
 
 
 class TestHandlersImage:

--- a/tests/test_cli_parsers.py
+++ b/tests/test_cli_parsers.py
@@ -181,6 +181,14 @@ class TestParserHyperframes:
         }
         assert expected <= names
 
+    def test_render_output_format_does_not_override_global_json_format(self):
+        from mcp_video.cli.parser import build_parser
+
+        args = build_parser().parse_args(["--format", "json", "hyperframes-render", "project", "--format", "webm"])
+
+        assert args.format == "json"
+        assert args.output_format == "webm"
+
 
 class TestParserQuality:
     def test_adds_expected_parsers(self):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -922,3 +922,11 @@ class TestSearchTools:
         assert result["success"] is True
         merge_tool = next(t for t in result["tools"] if t["name"] == "video_merge")
         assert "clips" in merge_tool["required_params"]
+
+    def test_search_includes_creation_tools(self):
+        result = search_tools("style")
+        assert result["success"] is True
+        names = [t["name"] for t in result["tools"]]
+        assert "video_project_create" in names
+        assert "style_pack_read" in names
+        assert "shot_prompt_render" in names


### PR DESCRIPTION
## Summary
- Fix `search_tools()` / `Client.search_tools()` so discovery loads the full MCP tool registry, including PUSHING CREATION, Hyperframes, audio, and AI tools.
- Fix `hyperframes-render --format` so it no longer overwrites the global `--format json` output mode.
- Prepare release metadata for `v1.3.7` because `v1.3.6` is already published.

## Verification
- Executed a real source operator journey through CLI video editing, Python client pipeline and release checkpoint, PUSHING CREATION project/style/storyboard/prompt, MCP stdio discovery/tool calls, and Hyperframes JSON render.
- Ran focused regression tests for discovery and Hyperframes CLI JSON behavior.
- Ran the full test suite, Ruff check/format check, repo readiness audit, local sdist/wheel build, artifact check, Twine metadata check, and release/MCP registry metadata validation.

## Known limits
- Heavy optional AI extras such as Whisper, Demucs, RealESRGAN, and Torch were not installed in the local verification venv; `doctor` reports them as optional missing dependencies.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/mcp-video/pr/256"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->