### PR TITLE
Fix heavyweight optional AI release paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ This project follows a simple release-note style:
 
 ## Unreleased
 
+## 1.3.8 - 2026-05-06
+
+### Fixed
+
+- Fixed AI scene-detection JSON output so perceptual-hash differences are serialized as standard JSON numbers.
+- Added `torchcodec` to stem-separation extras and diagnostics so Demucs output works with current TorchAudio save behavior.
+
 ## 1.3.7 - 2026-05-06
 
 ### Fixed

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -68,7 +68,7 @@ python -m pytest tests/ -v -m "not hyperframes"
 ### 4. AI Stem Separation (`test_43_ai_stem_separation`)
 - Uses Facebook Demucs
 - Separates vocals, drums, bass, other
-- Provided by the `mcp-video[ai]` extra (`demucs`, `torch`, `torchaudio`)
+- Provided by the `mcp-video[ai]` extra (`demucs`, `torch`, `torchaudio`, `torchcodec`)
 
 ### 5. AI Upscale (`test_44_ai_upscale`)
 - OpenCV DNN with FSRCNN model (57KB, fast)

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -80,7 +80,7 @@ Plan video generation like a director of photography before rendering. These too
 | `video_ai_remove_silence` | Auto-remove silent sections with configurable threshold | FFmpeg |
 | `video_ai_transcribe` | Speech-to-text with timestamp alignment | [openai-whisper](https://pypi.org/project/openai-whisper/) |
 | `video_ai_scene_detect` | ML-enhanced scene change detection (perceptual hashing) | [imagehash](https://pypi.org/project/imagehash/), Pillow |
-| `video_ai_stem_separation` | Isolate vocals, drums, bass, other instruments | [demucs](https://pypi.org/project/demucs/) |
+| `video_ai_stem_separation` | Isolate vocals, drums, bass, other instruments | [demucs](https://pypi.org/project/demucs/), Torch, TorchAudio, TorchCodec |
 | `video_ai_upscale` | AI super-resolution upscaling (2x or 4x) | [realesrgan](https://pypi.org/project/realesrgan/) or [opencv-contrib-python](https://pypi.org/project/opencv-contrib-python/) |
 | `video_ai_color_grade` | Auto color grading with style presets or reference matching | FFmpeg |
 | `video_quality_check` | Check brightness, contrast, saturation, audio levels, color balance |

--- a/mcp_video/__init__.py
+++ b/mcp_video/__init__.py
@@ -1,6 +1,6 @@
 """mcp-video — Video editing MCP server for AI agents."""
 
-__version__ = "1.3.7"
+__version__ = "1.3.8"
 
 from .client import Client
 from .ai_engine import (

--- a/mcp_video/ai_engine/scene.py
+++ b/mcp_video/ai_engine/scene.py
@@ -142,7 +142,7 @@ def ai_scene_detect(
             hash_diff = prev_hash - curr_hash
 
             if hash_diff > hash_threshold:
-                scenes.append({"timestamp": hashes[i]["timestamp"], "frame": None, "hash_diff": hash_diff})
+                scenes.append({"timestamp": float(hashes[i]["timestamp"]), "frame": None, "hash_diff": int(hash_diff)})
 
     return scenes
 

--- a/mcp_video/doctor.py
+++ b/mcp_video/doctor.py
@@ -71,6 +71,7 @@ PACKAGE_CHECKS = (
         'Install stem/upscale extras: pip install "mcp-video[stems]" or "mcp-video[upscale]"',
     ),
     ("torchaudio", "torchaudio", "ai", False, 'Install stem-separation extras: pip install "mcp-video[stems]"'),
+    ("torchcodec", "torchcodec", "ai", False, 'Install stem-separation extras: pip install "mcp-video[stems]"'),
     ("imagehash", "imagehash", "ai", False, 'Install AI scene extras: pip install "mcp-video[ai-scene]"'),
 )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-video"
-version = "1.3.7"
+version = "1.3.8"
 description = "Video editing MCP server for AI agents. 91 FFmpeg, creation, and Hyperframes tools, Python client, and CLI. Local, fast, free."
 readme = "README.md"
 license = "Apache-2.0"
@@ -42,7 +42,7 @@ image-ai = ["pillow>=10.0", "scikit-learn>=1.3", "webcolors>=1.13", "anthropic>=
 hyperframes = []  # External: Node.js + Hyperframes CLI (npx hyperframes)
 transcribe = ["openai-whisper>=20231117"]
 ai-scene = ["imagehash>=4.3", "Pillow>=10.0"]
-stems = ["demucs>=4.0", "torch>=2.0", "torchaudio>=2.0"]
+stems = ["demucs>=4.0", "torch>=2.0", "torchaudio>=2.0", "torchcodec>=0.8"]
 upscale = [
     "realesrgan>=0.3",
     "basicsr>=1.4",
@@ -60,6 +60,7 @@ ai = [
     "opencv-contrib-python>=4.10",
     "torch>=2.0",
     "torchaudio>=2.0",
+    "torchcodec>=0.8",
     "imagehash>=4.3",
     "Pillow>=10.0",
 ]
@@ -72,6 +73,7 @@ all-ai = [
     "opencv-contrib-python>=4.10",
     "torch>=2.0",
     "torchaudio>=2.0",
+    "torchcodec>=0.8",
     "imagehash>=4.3",
     "Pillow>=10.0",
 ]

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.KyaniteLabs/mcp-video",
   "title": "mcp-video",
   "description": "Video editing MCP server with 91 FFmpeg, planning, and Hyperframes tools.",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "websiteUrl": "https://kyanitelabs.github.io/mcp-video/",
   "repository": {
     "url": "https://github.com/KyaniteLabs/mcp-video",
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "mcp-video",
-      "version": "1.3.7",
+      "version": "1.3.8",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/tests/test_ai_features.py
+++ b/tests/test_ai_features.py
@@ -524,6 +524,56 @@ def test_ai_scene_detect_caps_ai_frame_extraction_rate(tmp_path, monkeypatch):
     assert vf_arg.startswith(f"fps=1/{expected_interval}")
 
 
+def test_ai_scene_detect_ai_mode_returns_json_safe_hash_diffs(tmp_path, monkeypatch):
+    """Perceptual hash results should not leak NumPy scalars into JSON responses."""
+    import json
+    import numpy as np
+
+    from mcp_video.ai_engine import ai_scene_detect
+
+    video = tmp_path / "video.mp4"
+    video.write_bytes(b"not a real video; subprocess is mocked")
+
+    class FakeHash:
+        def __init__(self, value: int):
+            self.value = value
+
+        def __sub__(self, other):
+            return np.int64(abs(self.value - other.value))
+
+    imagehash_module = types.ModuleType("imagehash")
+    hash_values = iter([FakeHash(0), FakeHash(42)])
+    imagehash_module.phash = lambda _img: next(hash_values)
+    image_module = types.ModuleType("PIL.Image")
+    seen_images = []
+
+    def fake_open(path):
+        seen_images.append(path)
+        return object()
+
+    image_module.open = fake_open
+    pil_module = types.ModuleType("PIL")
+    pil_module.Image = image_module
+    monkeypatch.setitem(sys.modules, "imagehash", imagehash_module)
+    monkeypatch.setitem(sys.modules, "PIL", pil_module)
+    monkeypatch.setitem(sys.modules, "PIL.Image", image_module)
+    monkeypatch.setattr("mcp_video.ai_engine.scene._run_ffprobe_json", lambda _path: {"format": {"duration": "1"}})
+
+    def fake_run(cmd, capture_output, text, timeout):
+        frame_pattern = Path(cmd[-1])
+        frame_pattern.parent.mkdir(parents=True, exist_ok=True)
+        (frame_pattern.parent / "frame_0001.jpg").write_bytes(b"one")
+        (frame_pattern.parent / "frame_0002.jpg").write_bytes(b"two")
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    scenes = ai_scene_detect(str(video), threshold=0.3, use_ai=True)
+
+    assert scenes == [{"timestamp": 0.5, "frame": None, "hash_diff": 42}]
+    json.dumps({"scenes": scenes})
+
+
 def test_require_audio_stream_propagates_probe_errors(monkeypatch):
     from mcp_video.ai_engine.spatial import _require_audio_stream
     from mcp_video.errors import ProcessingError

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -91,6 +91,7 @@ def test_run_diagnostics_checks_optional_packages_without_importing_them():
     assert checks["openai-whisper"]["required"] is False
     assert "mcp-video[transcribe]" in checks["openai-whisper"]["install_hint"]
     assert "mcp-video[stems]" in checks["demucs"]["install_hint"]
+    assert "mcp-video[stems]" in checks["torchcodec"]["install_hint"]
     assert "mcp-video[upscale]" in checks["opencv-contrib-python"]["install_hint"]
     assert "mcp-video[ai-scene]" in checks["imagehash"]["install_hint"]
 


### PR DESCRIPTION
## Why

Release-package smoke testing of v1.3.7 found two real optional-AI defects before this could be called complete: AI scene detection worked in text mode but failed in JSON mode when perceptual hash values came back as NumPy scalars, and Demucs stem separation needed TorchCodec with current TorchAudio save behavior.

## What changed

- Cast AI scene-detection timestamps/hash diffs to plain JSON-safe Python numbers.
- Add `torchcodec` to stem, ai, and all-ai extras plus doctor diagnostics.
- Align docs, changelog, package metadata, and MCP registry metadata for v1.3.8.
- Add focused regression coverage for JSON serialization and the new doctor hint.

## Verification

- [x] `.venv/bin/python -m pytest tests/test_ai_features.py::test_ai_scene_detect_ai_mode_returns_json_safe_hash_diffs tests/test_ai_features.py::test_ai_scene_detect_caps_ai_frame_extraction_rate tests/test_doctor.py -q`
- [x] `.venv/bin/ruff check mcp_video/ tests/`
- [x] `.venv/bin/ruff format --check mcp_video/ tests/`
- [x] `git diff --check`
- [x] source CLI AI-scene JSON smoke against an FFmpeg-generated fixture
- [x] package build + `twine check` + wheel metadata inspection
- [x] `.venv/bin/python -m pytest tests/ -x -q --tb=short`
- [x] `.venv/bin/python ./scripts/repo-readiness-audit.py`

## Maintainer checklist

- [x] Public MCP tool signatures are unchanged, or the compatibility impact is explained.
- [x] New or changed FFmpeg filter strings escape user-controlled values with `_escape_ffmpeg_filter_value()`.
- [x] Subprocess calls include a timeout and route FFmpeg failures through `ProcessingError`.
- [x] New defaults live in `defaults.py`; validation constants live in `validation.py` or `limits.py`.
- [x] No generated media, logs, caches, local research dumps, or build artifacts were committed.
- [x] Documentation, README counts, or roadmap entries were updated when the public surface changed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/mcp-video/pr/257"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->