### PR TITLE
Keep all-AI installs working on Python 3.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ This project follows a simple release-note style:
 
 ## Unreleased
 
+## 1.3.9 - 2026-05-06
+
+### Fixed
+
+- Fixed `mcp-video[all-ai]` and `mcp-video[upscale]` installs on Python 3.13 by guarding Real-ESRGAN/BasicSR dependencies behind the Python versions where BasicSR still builds, while keeping the OpenCV upscaling fallback installable.
+
 ## 1.3.8 - 2026-05-06
 
 ### Fixed

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -72,7 +72,7 @@ python -m pytest tests/ -v -m "not hyperframes"
 
 ### 5. AI Upscale (`test_44_ai_upscale`)
 - OpenCV DNN with FSRCNN model (57KB, fast)
-- Real-ESRGAN fallback (if basicsr fixed)
+- Real-ESRGAN path only where BasicSR can build; Python 3.13 uses the OpenCV fallback
 - 2x and 4x upscaling
 - Provided by the `mcp-video[ai]` extra (`opencv-contrib-python`, `numpy`)
 
@@ -105,7 +105,7 @@ ffmpeg -filters | grep vidstab
 pip install "mcp-video[ai]"
 
 # Or install individual packages if you only need a subset
-pip install demucs torch torchaudio openai-whisper realesrgan basicsr imagehash numpy opencv-contrib-python
+pip install demucs torch torchaudio torchcodec openai-whisper imagehash numpy opencv-contrib-python
 ```
 
 ## Test Fixtures

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -81,7 +81,7 @@ Plan video generation like a director of photography before rendering. These too
 | `video_ai_transcribe` | Speech-to-text with timestamp alignment | [openai-whisper](https://pypi.org/project/openai-whisper/) |
 | `video_ai_scene_detect` | ML-enhanced scene change detection (perceptual hashing) | [imagehash](https://pypi.org/project/imagehash/), Pillow |
 | `video_ai_stem_separation` | Isolate vocals, drums, bass, other instruments | [demucs](https://pypi.org/project/demucs/), Torch, TorchAudio, TorchCodec |
-| `video_ai_upscale` | AI super-resolution upscaling (2x or 4x) | [realesrgan](https://pypi.org/project/realesrgan/) or [opencv-contrib-python](https://pypi.org/project/opencv-contrib-python/) |
+| `video_ai_upscale` | AI super-resolution upscaling (2x or 4x) | [opencv-contrib-python](https://pypi.org/project/opencv-contrib-python/); Real-ESRGAN/BasicSR where supported |
 | `video_ai_color_grade` | Auto color grading with style presets or reference matching | FFmpeg |
 | `video_quality_check` | Check brightness, contrast, saturation, audio levels, color balance |
 | `video_design_quality_check` | Full design quality analysis: layout, typography, color, motion, composition |
@@ -94,7 +94,7 @@ Install only the AI dependencies you need:
 pip install "mcp-video[transcribe]"  # Whisper transcription
 pip install "mcp-video[ai-scene]"    # perceptual scene hashing
 pip install "mcp-video[stems]"       # Demucs stem separation
-pip install "mcp-video[upscale]"     # Real-ESRGAN/OpenCV upscaling
+pip install "mcp-video[upscale]"     # OpenCV upscaling; Real-ESRGAN/BasicSR where supported
 pip install "mcp-video[ai]"          # all AI extras, kept for compatibility
 ```
 

--- a/docs/adr/0005-basicsr-python-314-exclusion.md
+++ b/docs/adr/0005-basicsr-python-314-exclusion.md
@@ -1,3 +1,3 @@
-# BasicSR Python 3.14 Exclusion
+# BasicSR Python 3.13+ Exclusion
 
-`basicsr>=1.4` cannot build from source on Python 3.14 due to Cython compatibility issues. It is excluded via environment marker `python_version < '3.14'` in `pyproject.toml`. The `uv.lock` file cannot be regenerated on Python 3.14; lockfile maintenance must happen on Python 3.12 or 3.13. This is a temporary constraint until `basicsr` publishes a compatible release.
+`basicsr>=1.4` cannot build from source on Python 3.13+ with current isolated-build tooling; its setup script raises `KeyError: '__version__'` before dependency resolution can complete. It is excluded via environment marker `python_version < '3.13'` in `pyproject.toml` so `mcp-video[upscale]`, `mcp-video[ai]`, and `mcp-video[all-ai]` remain installable on current Python through the OpenCV upscaling fallback. This is a temporary constraint until `basicsr` publishes a compatible release.

--- a/mcp_video/__init__.py
+++ b/mcp_video/__init__.py
@@ -1,6 +1,6 @@
 """mcp-video — Video editing MCP server for AI agents."""
 
-__version__ = "1.3.8"
+__version__ = "1.3.9"
 
 from .client import Client
 from .ai_engine import (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-video"
-version = "1.3.8"
+version = "1.3.9"
 description = "Video editing MCP server for AI agents. 91 FFmpeg, creation, and Hyperframes tools, Python client, and CLI. Local, fast, free."
 readme = "README.md"
 license = "Apache-2.0"
@@ -44,8 +44,8 @@ transcribe = ["openai-whisper>=20231117"]
 ai-scene = ["imagehash>=4.3", "Pillow>=10.0"]
 stems = ["demucs>=4.0", "torch>=2.0", "torchaudio>=2.0", "torchcodec>=0.8"]
 upscale = [
-    "realesrgan>=0.3",
-    "basicsr>=1.4",
+    "realesrgan>=0.3; python_version < '3.13'",
+    "basicsr>=1.4; python_version < '3.13'",
     "numpy>=2.0.0",
     "opencv-contrib-python>=4.10",
     "torch>=2.0",
@@ -54,8 +54,8 @@ upscale = [
 ai = [
     "openai-whisper>=20231117",
     "demucs>=4.0",
-    "realesrgan>=0.3",
-    "basicsr>=1.4",
+    "realesrgan>=0.3; python_version < '3.13'",
+    "basicsr>=1.4; python_version < '3.13'",
     "numpy>=2.0.0",
     "opencv-contrib-python>=4.10",
     "torch>=2.0",
@@ -67,8 +67,8 @@ ai = [
 all-ai = [
     "openai-whisper>=20231117",
     "demucs>=4.0",
-    "realesrgan>=0.3",
-    "basicsr>=1.4",
+    "realesrgan>=0.3; python_version < '3.13'",
+    "basicsr>=1.4; python_version < '3.13'",
     "numpy>=2.0.0",
     "opencv-contrib-python>=4.10",
     "torch>=2.0",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.KyaniteLabs/mcp-video",
   "title": "mcp-video",
   "description": "Video editing MCP server with 91 FFmpeg, planning, and Hyperframes tools.",
-  "version": "1.3.8",
+  "version": "1.3.9",
   "websiteUrl": "https://kyanitelabs.github.io/mcp-video/",
   "repository": {
     "url": "https://github.com/KyaniteLabs/mcp-video",
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "mcp-video",
-      "version": "1.3.8",
+      "version": "1.3.9",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/tests/test_public_surface.py
+++ b/tests/test_public_surface.py
@@ -5,6 +5,7 @@ import subprocess
 import sys
 import asyncio
 import json
+import tomllib
 from pathlib import Path
 
 from mcp import ClientSession, StdioServerParameters
@@ -292,6 +293,17 @@ def test_server_json_and_readme_match_registry_identity():
     assert server["packages"][0]["runtimeHint"] == "uvx"
     assert server["packages"][0]["transport"]["type"] == "stdio"
     assert f"mcp-name: {server['name']}" in readme
+
+
+def test_heavy_ai_extras_keep_python313_installable():
+    pyproject = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    optional_deps = pyproject["project"]["optional-dependencies"]
+
+    for extra in ("upscale", "ai", "all-ai"):
+        dependencies = optional_deps[extra]
+        assert "opencv-contrib-python>=4.10" in dependencies
+        assert "realesrgan>=0.3; python_version < '3.13'" in dependencies
+        assert "basicsr>=1.4; python_version < '3.13'" in dependencies
 
 
 def test_module_reexports():


### PR DESCRIPTION
## Why

The final PyPI smoke for v1.3.8 found one remaining packaging defect: `mcp-video[all-ai]` still fails on Python 3.13 because BasicSR crashes during isolated build metadata generation before mcp-video can install.

## What changed

- Guard Real-ESRGAN and BasicSR dependencies with `python_version < "3.13"` in `upscale`, `ai`, and `all-ai`.
- Keep OpenCV, Torch, TorchCodec, Whisper, Demucs, and ImageHash in the current-Python aggregate AI install path.
- Bump release metadata to v1.3.9 and update docs/ADR language to match the actual Python 3.13 behavior.
- Add a regression test that locks the install-contract markers.

## Verification

- [x] `.venv/bin/python -m pytest tests/test_public_surface.py::test_heavy_ai_extras_keep_python313_installable tests/test_doctor.py -q`
- [x] `.venv/bin/ruff check mcp_video/ tests/`
- [x] `.venv/bin/ruff format --check mcp_video/ tests/`
- [x] `git diff --check`
- [x] package build + `twine check` + wheel metadata inspection
- [x] clean Python 3.13 local wheel install with `mcp-video[all-ai]==1.3.9`
- [x] OpenCV upscale smoke from that all-AI venv
- [x] `.venv/bin/python -m pytest tests/ -x -q --tb=short`
- [x] `.venv/bin/python ./scripts/repo-readiness-audit.py`

## Maintainer checklist

- [x] Public MCP tool signatures are unchanged, or the compatibility impact is explained.
- [x] New or changed FFmpeg filter strings escape user-controlled values with `_escape_ffmpeg_filter_value()`.
- [x] Subprocess calls include a timeout and route FFmpeg failures through `ProcessingError`.
- [x] New defaults live in `defaults.py`; validation constants live in `validation.py` or `limits.py`.
- [x] No generated media, logs, caches, local research dumps, or build artifacts were committed.
- [x] Documentation, README counts, or roadmap entries were updated when the public surface changed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/mcp-video/pr/258"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->