### PR TITLE
Clarify Python 3.13 upscale diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ This project follows a simple release-note style:
 
 ## Unreleased
 
+## 1.3.10 - 2026-05-07
+
+### Fixed
+
+- Improved `mcp-video doctor` guidance on Python 3.13+ so missing Real-ESRGAN/BasicSR reports explain the BasicSR build guard and point users to the OpenCV fallback or Python 3.11/3.12 for the Real-ESRGAN backend.
+
 ## 1.3.9 - 2026-05-06
 
 ### Fixed

--- a/mcp_video/__init__.py
+++ b/mcp_video/__init__.py
@@ -1,6 +1,6 @@
 """mcp-video — Video editing MCP server for AI agents."""
 
-__version__ = "1.3.9"
+__version__ = "1.3.10"
 
 from .client import Client
 from .ai_engine import (

--- a/mcp_video/doctor.py
+++ b/mcp_video/doctor.py
@@ -18,6 +18,12 @@ VersionRunner = Callable[[list[str]], str | None]
 FindSpecFn = Callable[[str], Any]
 PackageVersionFn = Callable[[str], str | None]
 
+PYTHON_313_UPSCALE_BACKEND_HINT = (
+    "Real-ESRGAN/BasicSR are skipped on Python 3.13+ because BasicSR currently fails to build there. "
+    'The OpenCV fallback is still installed by: pip install "mcp-video[upscale]". '
+    "Use Python 3.11 or 3.12 if you specifically need the Real-ESRGAN backend."
+)
+
 COMMAND_CHECKS = (
     {
         "name": "ffmpeg",
@@ -121,6 +127,8 @@ def _check_package(
     found = find_spec(import_name) is not None
     version = package_version(distribution_name) if found else None
     ok = found and version is not None
+    if not ok and distribution_name in {"realesrgan", "basicsr"} and sys.version_info >= (3, 13):
+        install_hint = PYTHON_313_UPSCALE_BACKEND_HINT
     return {
         "name": distribution_name,
         "category": category,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-video"
-version = "1.3.9"
+version = "1.3.10"
 description = "Video editing MCP server for AI agents. 91 FFmpeg, creation, and Hyperframes tools, Python client, and CLI. Local, fast, free."
 readme = "README.md"
 license = "Apache-2.0"

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.KyaniteLabs/mcp-video",
   "title": "mcp-video",
   "description": "Video editing MCP server with 91 FFmpeg, planning, and Hyperframes tools.",
-  "version": "1.3.9",
+  "version": "1.3.10",
   "websiteUrl": "https://kyanitelabs.github.io/mcp-video/",
   "repository": {
     "url": "https://github.com/KyaniteLabs/mcp-video",
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "mcp-video",
-      "version": "1.3.9",
+      "version": "1.3.10",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -96,6 +96,24 @@ def test_run_diagnostics_checks_optional_packages_without_importing_them():
     assert "mcp-video[ai-scene]" in checks["imagehash"]["install_hint"]
 
 
+def test_run_diagnostics_explains_python313_basicsr_guard(monkeypatch):
+    import mcp_video.doctor as doctor
+
+    monkeypatch.setattr(doctor.sys, "version_info", (3, 13, 12))
+
+    report = doctor.run_diagnostics(
+        which=lambda name: None,
+        version_runner=lambda command: None,
+        find_spec=lambda name: None,
+        package_version=lambda name: None,
+    )
+
+    checks = {check["name"]: check for check in report["checks"]}
+    assert "BasicSR currently fails to build" in checks["basicsr"]["install_hint"]
+    assert "OpenCV fallback" in checks["realesrgan"]["install_hint"]
+    assert "Python 3.11 or 3.12" in checks["basicsr"]["install_hint"]
+
+
 def test_run_diagnostics_requires_matching_distribution_for_package_checks():
     from mcp_video.doctor import run_diagnostics
 


### PR DESCRIPTION
## Why

After v1.3.9, Python 3.13 correctly skips BasicSR/Real-ESRGAN and keeps upscaling available through OpenCV. `mcp-video doctor` still used the generic upscale install hint for missing BasicSR/Real-ESRGAN, which made the intentional Python guard look like an unresolved install problem.

## What changed

- Add a Python 3.13+ doctor hint for missing `basicsr` and `realesrgan`.
- Explain that BasicSR is guarded because it currently fails to build there.
- Point users at the OpenCV fallback and Python 3.11/3.12 for the Real-ESRGAN backend.
- Bump metadata to v1.3.10 and add changelog entry.

## Verification

- [x] `.venv/bin/python -m pytest tests/test_doctor.py tests/test_public_surface.py::test_heavy_ai_extras_keep_python313_installable -q`
- [x] `.venv/bin/ruff check mcp_video/ tests/`
- [x] `.venv/bin/ruff format --check mcp_video/ tests/`
- [x] `git diff --check`
- [x] Python 3.13 `mcp-video --format json doctor` smoke verifying the new hint
- [x] package build + `twine check`
- [x] `.venv/bin/python -m pytest tests/ -x -q --tb=short`
- [x] `.venv/bin/python ./scripts/repo-readiness-audit.py`

## Maintainer checklist

- [x] Public MCP tool signatures are unchanged, or the compatibility impact is explained.
- [x] New or changed FFmpeg filter strings escape user-controlled values with `_escape_ffmpeg_filter_value()`.
- [x] Subprocess calls include a timeout and route FFmpeg failures through `ProcessingError`.
- [x] New defaults live in `defaults.py`; validation constants live in `validation.py` or `limits.py`.
- [x] No generated media, logs, caches, local research dumps, or build artifacts were committed.
- [x] Documentation, README counts, or roadmap entries were updated when the public surface changed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/mcp-video/pr/259"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->