### PR TITLE
Fix green-cast video effects and 24-bit WAV handling

### DIFF
--- a/mcp_video/audio_engine/core.py
+++ b/mcp_video/audio_engine/core.py
@@ -280,7 +280,9 @@ def _float_to_pcm(samples: list[float]) -> bytes:
     return b"".join(pcm_data)
 
 
-def _pcm_to_float(pcm_bytes: bytes, sample_width: int = DEFAULT_SAMPLE_WIDTH, channels: int = DEFAULT_CHANNELS) -> list[float]:
+def _pcm_to_float(
+    pcm_bytes: bytes, sample_width: int = DEFAULT_SAMPLE_WIDTH, channels: int = DEFAULT_CHANNELS
+) -> list[float]:
     """Convert PCM bytes to mono float samples."""
     if sample_width not in {1, 2, 3, 4}:
         raise ValueError(f"Unsupported PCM sample width: {sample_width}")

--- a/mcp_video/audio_engine/core.py
+++ b/mcp_video/audio_engine/core.py
@@ -280,12 +280,33 @@ def _float_to_pcm(samples: list[float]) -> bytes:
     return b"".join(pcm_data)
 
 
-def _pcm_to_float(pcm_bytes: bytes) -> list[float]:
-    """Convert 16-bit PCM bytes to float samples."""
+def _pcm_to_float(pcm_bytes: bytes, sample_width: int = DEFAULT_SAMPLE_WIDTH, channels: int = DEFAULT_CHANNELS) -> list[float]:
+    """Convert PCM bytes to mono float samples."""
+    if sample_width not in {1, 2, 3, 4}:
+        raise ValueError(f"Unsupported PCM sample width: {sample_width}")
+    frame_width = sample_width * channels
     samples = []
-    for i in range(0, len(pcm_bytes), 2):
-        value = struct.unpack("<h", pcm_bytes[i : i + 2])[0]
-        samples.append(value / 32767)
+    for frame_start in range(0, len(pcm_bytes), frame_width):
+        frame = pcm_bytes[frame_start : frame_start + frame_width]
+        if len(frame) < frame_width:
+            break
+        channel_values = []
+        for channel in range(channels):
+            start = channel * sample_width
+            raw = frame[start : start + sample_width]
+            if sample_width == 1:
+                value = raw[0] - 128
+                channel_values.append(value / 128)
+            elif sample_width == 2:
+                value = struct.unpack("<h", raw)[0]
+                channel_values.append(value / 32767)
+            elif sample_width == 3:
+                value = int.from_bytes(raw, "little", signed=True)
+                channel_values.append(value / 8388607)
+            else:
+                value = struct.unpack("<i", raw)[0]
+                channel_values.append(value / 2147483647)
+        samples.append(sum(channel_values) / len(channel_values))
     return samples
 
 

--- a/mcp_video/audio_engine/sequencing.py
+++ b/mcp_video/audio_engine/sequencing.py
@@ -222,8 +222,10 @@ def audio_effects(
     # Read input
     with wave.open(input_path, "rb") as wav_file:
         sample_rate = wav_file.getframerate()
+        sample_width = wav_file.getsampwidth()
+        channels = wav_file.getnchannels()
         frames = wav_file.readframes(wav_file.getnframes())
-        samples = _pcm_to_float(frames)
+        samples = _pcm_to_float(frames, sample_width=sample_width, channels=channels)
 
     # Apply effects chain
     for effect in effects:

--- a/mcp_video/effects_engine/core.py
+++ b/mcp_video/effects_engine/core.py
@@ -221,19 +221,16 @@ def effect_noise(
     """
     input_path = _validate_input_path(input_path)
     _validate_output_path(output)
-    # Use noise filter if available, otherwise usegeq with random
-    seed_expr = "random(0)" if animated else "0"
+    intensity = _sanitize_ffmpeg_number(intensity, "intensity")
+    safe_strength = _sanitize_ffmpeg_number(intensity * 100, "noise_strength")
+    noise_flags = "t+u" if animated else "u"
 
     if mode == "color":
-        # Color noise
-        noise_expr = f"lum(X,Y)+{intensity * 50}*({seed_expr}*2-1)"
-        cb_expr = f"cb(X,Y)+{intensity * 30}*({seed_expr}*2-1)"
-        cr_expr = f"cr(X,Y)+{intensity * 30}*({seed_expr}*2-1)"
-        filters = f"geq=lum='{noise_expr}':cb='{cb_expr}':cr='{cr_expr}'"
+        filters = f"format=yuv420p,noise=alls={safe_strength}:allf={noise_flags}"
+    elif mode in {"film", "digital"}:
+        filters = f"format=yuv420p,noise=c0s={safe_strength}:c0f={noise_flags}"
     else:
-        # Luminance noise only
-        noise_expr = f"lum(X,Y)*(1+{intensity}*({seed_expr}*2-1))"
-        filters = f"geq=lum='{noise_expr}'"
+        filters = f"format=yuv420p,noise=c0s={safe_strength}:c0f={noise_flags}"
 
     cmd = [
         "ffmpeg",

--- a/mcp_video/engine_overlay.py
+++ b/mcp_video/engine_overlay.py
@@ -61,7 +61,9 @@ def overlay_video(
     overlay_chain = _overlay_chain(scale_filter, safe_opacity)
     overlay_pos = _overlay_position(position)
     enable_expr = _enable_expression(start_time, duration)
-    filter_complex = f"[0:v]format=rgba[base];[1:v]{overlay_chain}[ov];[base][ov]overlay={overlay_pos}{enable_expr},format=yuv420p"
+    filter_complex = (
+        f"[0:v]format=rgba[base];[1:v]{overlay_chain}[ov];[base][ov]overlay={overlay_pos}{enable_expr},format=yuv420p"
+    )
 
     with _timed_operation() as timing:
         _run_ffmpeg(

--- a/mcp_video/engine_overlay.py
+++ b/mcp_video/engine_overlay.py
@@ -61,7 +61,7 @@ def overlay_video(
     overlay_chain = _overlay_chain(scale_filter, safe_opacity)
     overlay_pos = _overlay_position(position)
     enable_expr = _enable_expression(start_time, duration)
-    filter_complex = f"[1:v]{overlay_chain}[ov];[0:v][ov]overlay={overlay_pos}{enable_expr}"
+    filter_complex = f"[0:v]format=rgba[base];[1:v]{overlay_chain}[ov];[base][ov]overlay={overlay_pos}{enable_expr},format=yuv420p"
 
     with _timed_operation() as timing:
         _run_ffmpeg(

--- a/tests/test_audio_sequencing.py
+++ b/tests/test_audio_sequencing.py
@@ -1,5 +1,7 @@
 """Tests for audio sequencing, composition, and effects."""
 
+import math
+import wave
 from pathlib import Path
 
 import pytest
@@ -187,3 +189,27 @@ class TestAudioEffects:
             ],
         )
         assert Path(result).exists()
+
+    def test_24_bit_pcm_wav_preserves_frame_count(self, tmp_path):
+        src = tmp_path / "src-24bit.wav"
+        output = tmp_path / "out.wav"
+        sample_rate = 48000
+        input_frames = 2400
+
+        frames = bytearray()
+        for i in range(input_frames):
+            sample = int(0.2 * 8388607 * math.sin(2 * math.pi * 440 * i / sample_rate))
+            frames.extend(sample.to_bytes(3, "little", signed=True))
+
+        with wave.open(str(src), "wb") as wav_file:
+            wav_file.setnchannels(1)
+            wav_file.setsampwidth(3)
+            wav_file.setframerate(sample_rate)
+            wav_file.writeframes(bytes(frames))
+
+        result = audio_effects(str(src), str(output), [{"type": "normalize"}])
+
+        assert Path(result).exists()
+        with wave.open(result, "rb") as wav_file:
+            assert wav_file.getframerate() == sample_rate
+            assert wav_file.getnframes() == input_frames

--- a/tests/test_effects_engine.py
+++ b/tests/test_effects_engine.py
@@ -77,6 +77,31 @@ def test_glow_uses_non_additive_blend_by_default(tmp_path, monkeypatch):
     assert "all_opacity=0.25" in filter_graph
 
 
+def test_film_noise_uses_luma_only_noise_filter(tmp_path, monkeypatch):
+    from mcp_video import effects_engine
+
+    input_path = tmp_path / "input.mp4"
+    output_path = tmp_path / "output.mp4"
+    input_path.write_bytes(b"placeholder")
+    calls = []
+
+    def fake_run_ffmpeg(cmd):
+        calls.append(cmd.copy())
+        Path(cmd[-1]).write_bytes(b"output")
+
+    monkeypatch.setattr(effects_engine.core, "_run_command", fake_run_ffmpeg)
+
+    result = effects_engine.effect_noise(str(input_path), str(output_path), intensity=0.03, mode="film")
+
+    assert result == str(output_path)
+    assert len(calls) == 1
+    filter_graph = calls[0][5]
+    assert "geq=" not in filter_graph
+    assert "noise=c0s=3.0" in filter_graph
+    assert "c1s" not in filter_graph
+    assert "c2s" not in filter_graph
+
+
 def test_subtitle_text_is_wrapped_for_safe_area():
     from mcp_video.effects_engine.text import _wrap_subtitle_payload_for_safe_area
 

--- a/tests/test_engine_overlay.py
+++ b/tests/test_engine_overlay.py
@@ -1,0 +1,34 @@
+"""Tests for overlay filtergraph behavior."""
+
+from types import SimpleNamespace
+
+from mcp_video.engine_overlay import overlay_video
+
+
+def test_overlay_converts_base_and_output_to_stable_pixel_formats(tmp_path, monkeypatch):
+    background = tmp_path / "background.mp4"
+    overlay = tmp_path / "overlay.mp4"
+    output = tmp_path / "output.mp4"
+    background.write_bytes(b"background")
+    overlay.write_bytes(b"overlay")
+    calls = []
+
+    def fake_run_ffmpeg(cmd):
+        calls.append(cmd.copy())
+        output.write_bytes(b"output")
+
+    monkeypatch.setattr("mcp_video.engine_overlay._run_ffmpeg", fake_run_ffmpeg)
+    monkeypatch.setattr(
+        "mcp_video.engine_overlay._build_edit_result",
+        lambda output_path, operation, timing: SimpleNamespace(output_path=output_path, operation=operation),
+    )
+
+    result = overlay_video(str(background), str(overlay), position="center", opacity=0.5, output_path=str(output))
+
+    assert result.output_path == str(output)
+    assert len(calls) == 1
+    filter_graph = calls[0][calls[0].index("-filter_complex") + 1]
+    assert "[0:v]format=rgba[base]" in filter_graph
+    assert "colorchannelmixer=aa=0.50" in filter_graph
+    assert "overlay=(main_w-overlay_w)/2:(main_h-overlay_h)/2" in filter_graph
+    assert filter_graph.endswith(",format=yuv420p")


### PR DESCRIPTION
## Summary
- Fixes #261 by replacing the green-casting `geq` film-noise path with FFmpeg `noise` primitives and stabilizing overlay pixel-format conversion.
- Fixes #262 by decoding WAV input according to actual sample width and channel metadata, including 24-bit PCM from macOS recordings.
- Adds regression coverage for film noise, overlay filtergraph stability, and 24-bit WAV frame preservation.

## Verification
- `python3 -m ruff check mcp_video/audio_engine/core.py mcp_video/audio_engine/sequencing.py mcp_video/effects_engine/core.py mcp_video/engine_overlay.py tests/test_audio_sequencing.py tests/test_effects_engine.py tests/test_engine_overlay.py`
- `python3 -m pytest tests/ -x -q --tb=short` -> 1090 passed, 10 skipped
- `python3 -c "import mcp_video"`
- `PYTHONPATH=$PWD python3 /tmp/repro_mcp_video_bugs.py` -> before [106,98,103], after_noise [106,98,103], after_overlay [106,98,103], audio_ok true

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/mcp-video/pr/263"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->