### PR TITLE
Reject unsupported Hyperframes render dimensions

### DIFF
--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -141,7 +141,7 @@ mcp-video [command] [options]
 
 | Command | Description |
 |---------|-------------|
-| `hyperframes-render` | Render a Hyperframes composition to video or PNG sequence (`--composition`, `--resolution`) |
+| `hyperframes-render` | Render a Hyperframes composition to video or PNG sequence (`--composition`, `--resolution`; width/height must map to a preset) |
 | `hyperframes-compositions` | List compositions in a Hyperframes project |
 | `hyperframes-preview` | Launch Hyperframes preview studio |
 | `hyperframes-still` | Render a single frame as an image |

--- a/docs/PYTHON_CLIENT.md
+++ b/docs/PYTHON_CLIENT.md
@@ -224,7 +224,7 @@ print(checkpoint["quality_score"])  # Must pass min_score
 
 | Method | Returns | Description |
 |--------|---------|-------------|
-| `hyperframes_render(project_path, output?, fps?, width?, height?, composition?, quality?, format?, resolution?, workers?, crf?)` | `HyperframesRenderResult` | Render a Hyperframes composition to video or PNG sequence |
+| `hyperframes_render(project_path, output?, fps?, width?, height?, composition?, quality?, format?, resolution?, workers?, crf?)` | `HyperframesRenderResult` | Render a Hyperframes composition to video or PNG sequence; width/height must map to Hyperframes resolution presets |
 | `hyperframes_compositions(project_path)` | `CompositionsResult` | List compositions in a project |
 | `hyperframes_preview(project_path, port?)` | `HyperframesPreviewResult` | Launch live preview studio |
 | `hyperframes_still(project_path, output?, frame?)` | `HyperframesStillResult` | Render a single frame |

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -107,7 +107,7 @@ Create videos programmatically using [Hyperframes](https://hyperframes.io/) — 
 | Tool | Description |
 |------|-------------|
 | `hyperframes_init` | Scaffold a new Hyperframes project (blank, warm-grain, swiss-grid templates; optional media bootstrap, Tailwind, and resolution preset flags) |
-| `hyperframes_render` | Render a Hyperframes composition to video (MP4/WebM/MOV/PNG sequence; optional composition and resolution preset flags) |
+| `hyperframes_render` | Render a Hyperframes composition to video (MP4/WebM/MOV/PNG sequence; optional composition and resolution preset flags; arbitrary width/height pairs are rejected instead of silently ignored) |
 | `hyperframes_snapshot` | Capture actual PNG snapshot paths written by Hyperframes |
 | `hyperframes_still` | Backward-compatible single-frame snapshot helper |
 | `hyperframes_inspect` | Inspect rendered layout for overflow and visual issues |

--- a/mcp_video/hyperframes_engine.py
+++ b/mcp_video/hyperframes_engine.py
@@ -451,6 +451,50 @@ def _resolution_from_dimensions(width: int | None, height: int | None) -> str | 
             return None
 
 
+def _canonical_resolution(value: str | None) -> str | None:
+    """Normalize Hyperframes resolution aliases to canonical presets."""
+    match value:
+        case None:
+            return None
+        case "1080p":
+            return "landscape"
+        case "4k" | "uhd":
+            return "landscape-4k"
+        case _:
+            return value
+
+
+def _resolve_render_resolution(width: int | None, height: int | None, resolution: str | None) -> str | None:
+    """Return the effective Hyperframes resolution without silently ignoring dimensions."""
+    if (width is None) ^ (height is None):
+        raise MCPVideoError(
+            "width and height must be provided together",
+            error_type="validation_error",
+            code="invalid_parameter",
+        )
+
+    if width is None and height is None:
+        return resolution
+
+    dimension_resolution = _resolution_from_dimensions(width, height)
+    if dimension_resolution is None:
+        raise MCPVideoError(
+            "Hyperframes render only supports width/height pairs that map to --resolution presets: "
+            "1920x1080, 1080x1920, 3840x2160, or 2160x3840. Use resolution=... instead of arbitrary dimensions.",
+            error_type="validation_error",
+            code="invalid_parameter",
+        )
+
+    if resolution is not None and _canonical_resolution(resolution) != dimension_resolution:
+        raise MCPVideoError(
+            f"width/height {width}x{height} conflicts with resolution '{resolution}'",
+            error_type="validation_error",
+            code="invalid_parameter",
+        )
+
+    return resolution or dimension_resolution
+
+
 def render(
     project_path: str,
     output_path: str | None = None,
@@ -483,7 +527,7 @@ def render(
         os.makedirs("out", exist_ok=True)
         output_path = os.path.join("out", f"{Path(project_path).name}.mp4")
 
-    effective_resolution = resolution or _resolution_from_dimensions(width, height)
+    effective_resolution = _resolve_render_resolution(width, height, resolution)
 
     start_time = time.time()
     _result, _project = _hyperframes_op(

--- a/tests/test_hyperframes_engine.py
+++ b/tests/test_hyperframes_engine.py
@@ -225,8 +225,8 @@ class TestRender:
                 project,
                 output_path="/tmp/out.mp4",
                 fps=60,
-                width=1280,
-                height=720,
+                width=1080,
+                height=1920,
                 composition="compositions/intro.html",
                 quality="high",
                 format="webm",
@@ -237,7 +237,7 @@ class TestRender:
 
             assert result.output_path == "/tmp/out.mp4"
             assert result.codec == "webm"
-            assert result.resolution == "1280x720"
+            assert result.resolution == "1080x1920"
             cmd = mock_run.call_args[0][0]
             assert cmd[cmd.index("--composition") + 1] == "compositions/intro.html"
             assert cmd[cmd.index("--resolution") + 1] == "portrait"
@@ -279,6 +279,45 @@ class TestRender:
             assert result.resolution == "1920x1080"
             cmd = mock_run.call_args[0][0]
             assert cmd[cmd.index("--resolution") + 1] == "landscape"
+
+    def test_rejects_unmapped_legacy_dimensions_instead_of_silent_noop(self, sample_hyperframes_project):
+        """render() should not claim arbitrary dimensions that Hyperframes CLI cannot apply."""
+        with (
+            _mock_deps_ok(),
+            patch("mcp_video.hyperframes_engine.subprocess.run") as mock_run,
+            pytest.raises(MCPVideoError, match="only supports width/height pairs"),
+        ):
+            render(str(sample_hyperframes_project), output_path="/tmp/out.mp4", width=1280, height=720)
+
+        mock_run.assert_not_called()
+
+    def test_rejects_incomplete_legacy_dimensions(self, sample_hyperframes_project):
+        """render() should not silently ignore a lone width or height."""
+        with (
+            _mock_deps_ok(),
+            patch("mcp_video.hyperframes_engine.subprocess.run") as mock_run,
+            pytest.raises(MCPVideoError, match="width and height must be provided together"),
+        ):
+            render(str(sample_hyperframes_project), output_path="/tmp/out.mp4", width=1920)
+
+        mock_run.assert_not_called()
+
+    def test_rejects_conflicting_dimensions_and_resolution(self, sample_hyperframes_project):
+        """render() should not report dimensions that conflict with the requested preset."""
+        with (
+            _mock_deps_ok(),
+            patch("mcp_video.hyperframes_engine.subprocess.run") as mock_run,
+            pytest.raises(MCPVideoError, match="conflicts with resolution"),
+        ):
+            render(
+                str(sample_hyperframes_project),
+                output_path="/tmp/out.mp4",
+                width=1920,
+                height=1080,
+                resolution="portrait",
+            )
+
+        mock_run.assert_not_called()
 
     def test_resolution_is_none_when_dimensions_missing(self, sample_hyperframes_project):
         """render() should return resolution=None when width/height are not set."""


### PR DESCRIPTION
## Summary\n- close the silent failure left by the release audit: arbitrary width/height values were still accepted even though Hyperframes only applies resolution presets\n- reject incomplete, unsupported, or conflicting render dimension inputs before launching the CLI\n- document that width/height must map to Hyperframes resolution presets\n\n## Verification\n- python3 -m pytest tests/test_hyperframes_engine.py::TestRender -q\n- python3 -m pytest tests/test_hyperframes_engine.py tests/test_cli_parsers.py tests/test_cli_handlers.py tests/test_misc_coverage.py -q\n- python3 -m ruff check mcp_video/ tests/\n- python3 -m ruff format --check mcp_video/ tests/\n- python3 -m pytest tests/ -x -q --tb=short\n- python3 -c "import mcp_video"\n\n## Not tested\n- Real browser-backed Hyperframes render with project assets

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/mcp-video/pr/267"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->