### PR TITLE
Implement analyze-video color extraction

### DIFF
--- a/mcp_video/ai_engine/__init__.py
+++ b/mcp_video/ai_engine/__init__.py
@@ -129,8 +129,12 @@ def _waveform_to_dict(waveform: Any) -> dict[str, Any]:
     }
 
 
-def _placeholder_colors() -> list[Any]:
-    raise NotImplementedError("Color extraction not yet implemented")
+def _extract_video_colors(video_path: Path, n_colors: int = 5) -> dict[str, Any]:
+    """Extract dominant colors for analyze_video using the image engine's video-frame support."""
+    from ..image_engine import extract_colors
+
+    result = extract_colors(str(video_path), n_colors=n_colors)
+    return result.model_dump() if hasattr(result, "model_dump") else dict(result)
 
 
 def _build_transcript_result(
@@ -294,7 +298,7 @@ def analyze_video(
             ("scenes", include_scenes, _scenes),
             ("audio", include_audio, lambda: _waveform_to_dict(_engine.audio_waveform(str(video_path)))),
             ("chapters", include_chapters, _chapters),
-            ("colors", include_colors, _placeholder_colors),
+            ("colors", include_colors, lambda: _extract_video_colors(video_path)),
             ("quality", include_quality, lambda: _quality.quality_check(str(video_path))),
         ]
         results = {name: (_run_analysis(name, fn, errors) if flag else None) for name, flag, fn in analyses}

--- a/tests/test_ai_features.py
+++ b/tests/test_ai_features.py
@@ -1516,6 +1516,22 @@ def test_analyze_video_errors_are_non_fatal():
     assert "mock quality failure" in quality_errors[0]["error"]
 
 
+@requires_ffmpeg
+@requires_ffprobe
+def test_analyze_video_extracts_colors_by_default(monkeypatch):
+    """analyze_video should not swallow a NotImplemented colors placeholder."""
+    from mcp_video.ai_engine import analyze_video
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        video = create_simple_video(str(Path(tmpdir) / "test.mp4"))
+        result = analyze_video(video, include_transcript=False, include_scenes=False, include_audio=False)
+
+    assert result["success"] is True
+    assert result["colors"] is not None
+    assert result["colors"]["colors"]
+    assert not [error for error in result["errors"] if error["section"] == "colors"]
+
+
 def test_validate_analysis_output_paths_blocks_system_prefixes():
     """_validate_analysis_output_paths rejects writes to system directories."""
     from mcp_video.ai_engine import _validate_analysis_output_paths


### PR DESCRIPTION
## Summary
- replace the swallowed `NotImplementedError` colors placeholder in `analyze_video`
- reuse the existing image engine video-frame color extraction path
- add regression coverage that default analyze_video colors returns real color data with no colors-section error

## Verification
- python3 -m pytest tests/test_ai_features.py::test_analyze_video_extracts_colors_by_default -q
- python3 -m pytest tests/test_ai_features.py::test_analyze_video_no_transcript tests/test_ai_features.py::test_analyze_video_errors_are_non_fatal tests/test_ai_features.py::test_analyze_video_extracts_colors_by_default -q
- python3 -m ruff check mcp_video/ai_engine/__init__.py tests/test_ai_features.py
- python3 -m ruff format --check mcp_video/ai_engine/__init__.py tests/test_ai_features.py
- python3 -c "import mcp_video"
- python3 -m pytest tests/ -x -q --tb=short

## Not tested
- color extraction without optional image dependencies installed; that remains the existing image engine dependency-error path
