### PR TITLE
Return real colors from detailed video info

### DIFF
--- a/mcp_video/effects_engine/utility.py
+++ b/mcp_video/effects_engine/utility.py
@@ -9,10 +9,63 @@ import logging
 import subprocess
 from typing import Any
 
-from ..errors import MCPVideoError
+from ..errors import MCPVideoError, ProcessingError
 from ..ffmpeg_helpers import _validate_input_path, _run_command, _run_ffmpeg
+from ..limits import DEFAULT_FFMPEG_TIMEOUT
 
 logger = logging.getLogger(__name__)
+
+
+def _rgb_to_hex(rgb: bytes) -> str:
+    """Convert three RGB bytes to a hex color string."""
+    return f"#{rgb[0]:02X}{rgb[1]:02X}{rgb[2]:02X}"
+
+
+def _extract_representative_colors(video: str, duration: float, max_colors: int = 3) -> list[str]:
+    """Extract simple representative frame colors without optional image dependencies."""
+    if max_colors < 1:
+        return []
+
+    sample_times = [0.0]
+    if duration > 0:
+        sample_times = [max(0.0, duration * ratio) for ratio in (0.1, 0.5, 0.9)]
+
+    colors: list[str] = []
+    for timestamp in sample_times:
+        cmd = [
+            "ffmpeg",
+            "-ss",
+            f"{timestamp:.3f}",
+            "-i",
+            video,
+            "-frames:v",
+            "1",
+            "-vf",
+            "scale=1:1",
+            "-f",
+            "rawvideo",
+            "-pix_fmt",
+            "rgb24",
+            "-",
+        ]
+        try:
+            result = subprocess.run(cmd, capture_output=True, timeout=DEFAULT_FFMPEG_TIMEOUT)
+        except subprocess.TimeoutExpired as exc:
+            raise ProcessingError(
+                " ".join(cmd), -1, f"FFmpeg command timed out after {DEFAULT_FFMPEG_TIMEOUT}s"
+            ) from exc
+        if result.returncode != 0:
+            raise ProcessingError(" ".join(cmd), result.returncode, result.stderr.decode(errors="replace"))
+        if len(result.stdout) < 3:
+            raise ProcessingError(" ".join(cmd), result.returncode, "FFmpeg returned no RGB frame data")
+
+        color = _rgb_to_hex(result.stdout[:3])
+        if color not in colors:
+            colors.append(color)
+        if len(colors) >= max_colors:
+            break
+
+    return colors
 
 
 def video_info_detailed(video: str) -> dict[str, Any]:
@@ -100,6 +153,8 @@ def video_info_detailed(video: str) -> dict[str, Any]:
         logger = logging.getLogger(__name__)
         logger.warning("Scene detection failed (optional): %s", e)
 
+    dominant_colors = _extract_representative_colors(video, duration)
+
     return {
         "duration": duration,
         "fps": fps,
@@ -107,7 +162,7 @@ def video_info_detailed(video: str) -> dict[str, Any]:
         "bitrate": bitrate,
         "has_audio": audio_stream is not None,
         "scene_changes": scene_changes[:10],  # Limit to first 10
-        "dominant_colors": None,  # Frame analysis not yet implemented
+        "dominant_colors": dominant_colors,
     }
 
 

--- a/tests/test_ai_features.py
+++ b/tests/test_ai_features.py
@@ -1532,6 +1532,21 @@ def test_analyze_video_extracts_colors_by_default(monkeypatch):
     assert not [error for error in result["errors"] if error["section"] == "colors"]
 
 
+@requires_ffmpeg
+@requires_ffprobe
+def test_video_info_detailed_returns_representative_colors():
+    """video_info_detailed should not advertise dominant_colors as an unimplemented None."""
+    from mcp_video.effects_engine import video_info_detailed
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        video = create_simple_video(str(Path(tmpdir) / "test.mp4"))
+        result = video_info_detailed(video)
+
+    assert result["dominant_colors"]
+    assert result["dominant_colors"][0].startswith("#")
+    assert result["dominant_colors"][0] != "#000000"
+
+
 def test_validate_analysis_output_paths_blocks_system_prefixes():
     """_validate_analysis_output_paths rejects writes to system directories."""
     from mcp_video.ai_engine import _validate_analysis_output_paths


### PR DESCRIPTION
## Summary
- replace the advertised-but-unimplemented `dominant_colors: None` placeholder in `video_info_detailed`
- extract real representative frame colors with FFmpeg without adding optional image dependencies
- add regression coverage that detailed video info returns a non-empty hex color list

## Verification
- python3 -m pytest tests/test_ai_features.py::test_video_info_detailed_returns_representative_colors -q
- python3 -m pytest tests/test_ai_features.py::test_video_info_detailed_returns_representative_colors tests/test_ai_features.py::test_analyze_video_extracts_colors_by_default -q
- python3 -m pytest tests/ -x -q --tb=short
- python3 -m ruff check mcp_video/ tests/
- python3 -m ruff format --check mcp_video/ tests/
- python3 -c "import mcp_video"

## Not tested
- videos with corrupt frames where FFmpeg cannot decode representative samples

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/mcp-video/pr/269"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->