### PR TITLE
Surface pipeline cleanup failures

### DIFF
--- a/mcp_video/client/base.py
+++ b/mcp_video/client/base.py
@@ -150,18 +150,11 @@ class ClientBase:
             cleanup: Remove intermediate files after the pipeline completes.
                 Only the final output and the original input are kept.
         """
-        import os
-
         self._validate_pipeline_steps(steps)
         final_output = self._resolve_alias("output_path", output_path, "output", output)
         result, warnings, saw_quality_gate, intermediates = self._run_pipeline_steps(steps, final_output)
         if cleanup and intermediates:
-            for path in intermediates:
-                try:
-                    if os.path.exists(path):
-                        os.remove(path)
-                except OSError:
-                    pass
+            warnings.extend(self._cleanup_pipeline_intermediates(intermediates))
             result.intermediates = intermediates
         return self._finalize_pipeline_result(result, warnings, saw_quality_gate)
 
@@ -206,6 +199,20 @@ class ClientBase:
                 "pipeline produced no media output", error_type="validation_error", code="no_media_output"
             )
         return result, warnings, saw_quality_gate, intermediates
+
+    @staticmethod
+    def _cleanup_pipeline_intermediates(intermediates: list[str]) -> list[str]:
+        """Delete intermediate media files and return non-fatal cleanup warnings."""
+        import os
+
+        warnings: list[str] = []
+        for path in intermediates:
+            try:
+                if os.path.exists(path):
+                    os.remove(path)
+            except OSError as exc:
+                warnings.append(f"Could not remove pipeline intermediate {path!r}: {exc}")
+        return warnings
 
     def _prepare_pipeline_step(
         self, step: dict[str, Any], current: str | None, final_output: str | None, is_last: bool

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -520,6 +520,42 @@ class TestClientAgentApiConsistency:
         assert any("Stacked visual polish effects" in warning for warning in result.warnings)
         assert any("release checkpoint" in warning for warning in result.warnings)
 
+    def test_pipeline_cleanup_failure_surfaces_warning(self, editor, monkeypatch, tmp_path):
+        intermediate = tmp_path / "scene.mp4"
+        final = tmp_path / "final.mp4"
+
+        monkeypatch.setattr(
+            editor,
+            "create_from_images",
+            lambda **kwargs: editor._to_edit_result(str(intermediate), operation="create_from_images"),
+        )
+        monkeypatch.setattr(
+            editor,
+            "effect_glow",
+            lambda **kwargs: editor._to_edit_result(str(final), operation="effect_glow"),
+        )
+        monkeypatch.setattr(os.path, "exists", lambda path: path == str(intermediate))
+
+        def fail_remove(path):
+            if path == str(intermediate):
+                raise OSError("permission denied")
+            os.remove(path)
+
+        monkeypatch.setattr(os, "remove", fail_remove)
+
+        result = editor.pipeline(
+            [
+                {"op": "create_from_images", "images": ["a.png"], "output_path": str(intermediate)},
+                {"op": "effect_glow"},
+            ],
+            output_path=str(final),
+            cleanup=True,
+        )
+
+        assert result.intermediates == [str(intermediate)]
+        assert any("Could not remove pipeline intermediate" in warning for warning in result.warnings)
+        assert any("permission denied" in warning for warning in result.warnings)
+
     def test_release_checkpoint_runs_quality_then_preview_artifacts(self, editor, monkeypatch, tmp_path):
         video = tmp_path / "video.mp4"
         video.write_bytes(b"placeholder")


### PR DESCRIPTION
## Summary
- surface failed pipeline intermediate cleanup as non-fatal EditResult warnings
- keep cleanup best-effort after successful final output
- add regression for cleanup permission errors

## Verification
- python3 -m pytest tests/test_client.py::TestClientAgentApiConsistency::test_pipeline_cleanup_failure_surfaces_warning -q
- python3 -m pytest tests/test_client.py -q
- python3 -m ruff check mcp_video/client/base.py tests/test_client.py
- python3 -m ruff format --check mcp_video/client/base.py tests/test_client.py
- python3 -m pytest tests/ -x -q --tb=short
- python3 -c "import mcp_video"

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/mcp-video/pr/270"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->