### PR TITLE
Reject unknown text animations

### DIFF
--- a/mcp_video/client/effects.py
+++ b/mcp_video/client/effects.py
@@ -121,6 +121,7 @@ class ClientEffectsMixin:
 
     _VALID_LAYOUTS: ClassVar[set[str]] = {"2x2", "3x1", "1x3", "2x3"}
     _VALID_PIP_POSITIONS: ClassVar[set[str]] = {"top-left", "top-right", "bottom-left", "bottom-right"}
+    _VALID_TEXT_ANIMATIONS: ClassVar[set[str]] = {"fade", "glitch", "slide-up", "typewriter"}
 
     def layout_grid(
         self,
@@ -210,6 +211,7 @@ class ClientEffectsMixin:
         """Add animated text to video."""
         if not text or not text.strip():
             raise MCPVideoError("Text cannot be empty", error_type="validation_error", code="invalid_parameter")
+        self._validate_choice("animation", animation, self._VALID_TEXT_ANIMATIONS)
         from ..effects_engine import text_animated
 
         return self._to_edit_result(

--- a/mcp_video/effects_engine/text.py
+++ b/mcp_video/effects_engine/text.py
@@ -14,7 +14,7 @@ from pathlib import Path
 from typing import Any
 
 from ..defaults import DEFAULT_SAFE_SUBTITLE_FONT_SIZE, DEFAULT_SUBTITLE_MAX_CHARS_PER_LINE, DEFAULT_SUBTITLE_MAX_LINES
-from ..errors import InputFileError
+from ..errors import InputFileError, MCPVideoError
 from ..ffmpeg_helpers import _sanitize_ffmpeg_number
 from ..ffmpeg_helpers import (
     _validate_input_path,
@@ -445,7 +445,13 @@ def text_animated(
     video = _validate_input_path(video)
     _validate_output_path(output)
 
-    strategy = _ANIMATION_STRATEGIES.get(animation, _build_fade_filter)
+    strategy = _ANIMATION_STRATEGIES.get(animation)
+    if strategy is None:
+        raise MCPVideoError(
+            f"animation must be one of {sorted(_ANIMATION_STRATEGIES)}, got {animation}",
+            error_type="validation_error",
+            code="invalid_parameter",
+        )
     filter_complex, cmd_path = strategy(
         text=text,
         font=font,

--- a/mcp_video/server_tools_effects.py
+++ b/mcp_video/server_tools_effects.py
@@ -12,6 +12,8 @@ from .validation import VALID_MOGRAPH_STYLES
 from .ffmpeg_helpers import _validate_input_path
 from .limits import MAX_MOGRAPH_FRAMES
 
+VALID_TEXT_ANIMATIONS = {"fade", "glitch", "slide-up", "typewriter"}
+
 # ---------------------------------------------------------------------------
 # Visual Effects Tools (P1 Features)
 # ---------------------------------------------------------------------------
@@ -376,6 +378,12 @@ def video_text_animated(
     Returns:
         Dict with success status and output_path.
     """
+    if animation not in VALID_TEXT_ANIMATIONS:
+        raise MCPVideoError(
+            f"animation must be one of {sorted(VALID_TEXT_ANIMATIONS)}, got {animation}",
+            error_type="validation_error",
+            code="invalid_parameter",
+        )
     input_path = _validate_input_path(input_path)
     if not (8 <= size <= 500):
         raise MCPVideoError(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -401,6 +401,10 @@ class TestClientTextAnimatedValidation:
         with pytest.raises(MCPVideoError, match=r"[Tt]ext"):
             editor.text_animated("/tmp/video.mp4", "", "/tmp/out.mp4")
 
+    def test_text_animated_rejects_unknown_animation(self, editor):
+        with pytest.raises(MCPVideoError, match="animation"):
+            editor.text_animated("/tmp/video.mp4", "Hello", "/tmp/out.mp4", animation="spin")
+
 
 class TestClientAgentApiConsistency:
     def test_every_public_client_method_has_contract(self, editor):

--- a/tests/test_effects_engine.py
+++ b/tests/test_effects_engine.py
@@ -2,7 +2,9 @@
 
 from pathlib import Path
 
-from mcp_video.errors import ProcessingError
+import pytest
+
+from mcp_video.errors import MCPVideoError, ProcessingError
 
 
 def test_chromatic_aberration_falls_back_when_chromashift_missing(tmp_path, monkeypatch):
@@ -110,6 +112,21 @@ def test_subtitle_text_is_wrapped_for_safe_area():
     wrapped = _wrap_subtitle_payload_for_safe_area(source, max_chars_per_line=28)
 
     assert "The same source becomes\nYouTube, Shorts, and square\nsocial cuts." in wrapped
+
+
+def test_text_animated_rejects_unknown_animation_before_ffmpeg(tmp_path, monkeypatch):
+    from mcp_video.effects_engine import text_animated
+    from mcp_video.effects_engine import text as text_engine
+
+    input_path = tmp_path / "input.mp4"
+    output_path = tmp_path / "output.mp4"
+    input_path.write_bytes(b"placeholder")
+    monkeypatch.setattr(text_engine, "_run_command", lambda cmd: Path(cmd[-1]).write_bytes(b"output"))
+
+    with pytest.raises(MCPVideoError, match="animation"):
+        text_animated(str(input_path), "Hello", str(output_path), animation="spin")
+
+    assert not output_path.exists()
 
 
 def test_webvtt_metadata_blocks_are_preserved_during_safe_area_wrap():

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -53,6 +53,7 @@ from mcp_video.server import (
     video_stabilize,
     video_storyboard,
     video_template_preview,
+    video_text_animated,
     video_thumbnail,
     video_trim,
     video_watermark,
@@ -181,6 +182,14 @@ class TestVideoAddTextTool:
             result = video_add_text(sample_video, text="Hello")
             assert result["success"] is False
             assert "error" in result
+
+
+class TestVideoTextAnimatedTool:
+    def test_rejects_unknown_animation_before_input_validation(self):
+        result = video_text_animated("/tmp/missing.mp4", text="Hello", animation="spin")
+
+        assert result["success"] is False
+        assert "animation" in result["error"]["message"]
 
 
 class TestVideoAddAudioTool:


### PR DESCRIPTION
## Summary
- reject unsupported text animation names in the Python client before file validation
- reject unsupported names at the MCP tool boundary and low-level engine
- add regressions so misspellings no longer silently render the fade preset

## Verification
- python3 -m pytest tests/test_client.py::TestClientTextAnimatedValidation tests/test_effects_engine.py::test_text_animated_rejects_unknown_animation_before_ffmpeg tests/test_server.py::TestVideoTextAnimatedTool::test_rejects_unknown_animation_before_input_validation -q
- python3 -m pytest tests/test_client.py tests/test_effects_engine.py tests/test_server.py -q
- python3 -m ruff check mcp_video/effects_engine/text.py mcp_video/client/effects.py mcp_video/server_tools_effects.py tests/test_client.py tests/test_effects_engine.py tests/test_server.py
- python3 -m ruff format --check mcp_video/effects_engine/text.py mcp_video/client/effects.py mcp_video/server_tools_effects.py tests/test_client.py tests/test_effects_engine.py tests/test_server.py
- python3 -m pytest tests/ -x -q --tb=short
- python3 -c "import mcp_video"

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/mcp-video/pr/271"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->