### PR TITLE
Report Hyperframes render artifacts by format

### DIFF
--- a/mcp_video/hyperframes_engine.py
+++ b/mcp_video/hyperframes_engine.py
@@ -464,6 +464,27 @@ def _canonical_resolution(value: str | None) -> str | None:
             return value
 
 
+def _default_render_output(project_path: str, output_format: str | None) -> str:
+    """Return a format-appropriate default render artifact path."""
+    os.makedirs("out", exist_ok=True)
+    name = Path(project_path).name
+    match output_format:
+        case "png-sequence":
+            return os.path.join("out", f"{name}_frames")
+        case "webm" | "mov" | "mp4":
+            return os.path.join("out", f"{name}.{output_format}")
+        case _:
+            return os.path.join("out", f"{name}.mp4")
+
+
+def _render_output_exists(output_path: str, output_format: str | None) -> bool:
+    """Return true when the expected Hyperframes artifact exists."""
+    if output_format == "png-sequence":
+        output_dir = Path(output_path)
+        return output_dir.is_dir() and any(output_dir.glob("*.png"))
+    return os.path.isfile(output_path)
+
+
 def _resolve_render_resolution(width: int | None, height: int | None, resolution: str | None) -> str | None:
     """Return the effective Hyperframes resolution without silently ignoring dimensions."""
     if (width is None) ^ (height is None):
@@ -524,8 +545,7 @@ def render(
 ) -> HyperframesRenderResult:
     """Render a Hyperframes composition to video."""
     if output_path is None:
-        os.makedirs("out", exist_ok=True)
-        output_path = os.path.join("out", f"{Path(project_path).name}.mp4")
+        output_path = _default_render_output(project_path, format)
 
     effective_resolution = _resolve_render_resolution(width, height, resolution)
 
@@ -568,7 +588,7 @@ def render(
     if width and height:
         reported_resolution = f"{width}x{height}"
 
-    if not os.path.isfile(output_path):
+    if not _render_output_exists(output_path, format):
         return HyperframesRenderResult(
             output_path=output_path,
             codec=format or "h264",

--- a/tests/test_hyperframes_engine.py
+++ b/tests/test_hyperframes_engine.py
@@ -336,6 +336,71 @@ class TestRender:
             )
             assert result.resolution is None
 
+    def test_png_sequence_output_directory_counts_as_success(self, sample_hyperframes_project, tmp_path):
+        """render() should treat a PNG sequence output directory as the artifact."""
+        project = str(sample_hyperframes_project)
+        output_dir = tmp_path / "frames"
+
+        def fake_run(cmd, **_kwargs):
+            assert cmd[cmd.index("--format") + 1] == "png-sequence"
+            Path(cmd[cmd.index("--output") + 1]).mkdir(parents=True)
+            (Path(cmd[cmd.index("--output") + 1]) / "frame-000001.png").write_bytes(b"png")
+            return _make_completed_process(stdout="Rendered PNG sequence.")
+
+        with (
+            _mock_deps_ok(),
+            patch("mcp_video.hyperframes_engine.subprocess.run", side_effect=fake_run),
+        ):
+            result = render(project, output_path=str(output_dir), format="png-sequence")
+
+        assert result.success is True
+        assert result.output_path == str(output_dir)
+        assert result.size_mb is None
+
+    def test_png_sequence_default_output_is_directory(self, sample_hyperframes_project, tmp_path, monkeypatch):
+        """render() should not default PNG sequences to an .mp4-looking path."""
+        project = str(sample_hyperframes_project)
+        monkeypatch.chdir(tmp_path)
+
+        def fake_run(cmd, **_kwargs):
+            output = Path(cmd[cmd.index("--output") + 1])
+            output.mkdir(parents=True)
+            (output / "frame-000001.png").write_bytes(b"png")
+            return _make_completed_process(stdout="Rendered PNG sequence.")
+
+        with (
+            _mock_deps_ok(),
+            patch("mcp_video.hyperframes_engine.subprocess.run", side_effect=fake_run),
+        ):
+            result = render(project, format="png-sequence")
+
+        assert result.success is True
+        assert result.output_path.endswith("_frames")
+        assert Path(result.output_path).is_dir()
+
+    def test_format_specific_default_output_uses_matching_extension(
+        self, sample_hyperframes_project, tmp_path, monkeypatch
+    ):
+        """render() should not default WebM/MOV requests to an .mp4 path."""
+        project = str(sample_hyperframes_project)
+        monkeypatch.chdir(tmp_path)
+
+        def fake_run(cmd, **_kwargs):
+            output = Path(cmd[cmd.index("--output") + 1])
+            output.parent.mkdir(parents=True, exist_ok=True)
+            output.write_bytes(b"webm")
+            return _make_completed_process(stdout="Rendered WebM.")
+
+        with (
+            _mock_deps_ok(),
+            patch("mcp_video.hyperframes_engine.subprocess.run", side_effect=fake_run),
+        ):
+            result = render(project, format="webm")
+
+        assert result.success is True
+        assert result.output_path.endswith(".webm")
+        assert not result.output_path.endswith(".mp4")
+
 
 # ---------------------------------------------------------------------------
 # Test: compositions


### PR DESCRIPTION
## Summary
- treat Hyperframes png-sequence output directories containing PNG frames as successful render artifacts
- default png-sequence renders to an output directory instead of an .mp4-looking path
- default WebM/MOV render outputs to matching extensions

## Verification
- python3 -m pytest tests/test_hyperframes_engine.py::TestRender -q
- python3 -m pytest tests/test_hyperframes_engine.py tests/test_cli_parsers.py tests/test_misc_coverage.py -q
- python3 -m ruff check mcp_video/hyperframes_engine.py tests/test_hyperframes_engine.py
- python3 -m ruff format --check mcp_video/hyperframes_engine.py tests/test_hyperframes_engine.py
- python3 -m pytest tests/ -x -q --tb=short
- python3 -c "import mcp_video"

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/mcp-video/pr/272"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->