### PR TITLE
Fail Hyperframes pipelines on missing renders

### DIFF
--- a/mcp_video/hyperframes_engine.py
+++ b/mcp_video/hyperframes_engine.py
@@ -1040,6 +1040,12 @@ def render_and_post(
     # Step 1: Render with Hyperframes
     render_result = render(project_path)
     hyperframes_output = render_result.output_path
+    if not render_result.success:
+        raise HyperframesRenderError(
+            "hyperframes render",
+            0,
+            f"Render completed but output artifact was not created: {hyperframes_output}",
+        )
 
     # Step 2: Post-process with mcp-video engine
     op_map = _post_process_ops()

--- a/tests/test_hyperframes_engine.py
+++ b/tests/test_hyperframes_engine.py
@@ -1058,6 +1058,27 @@ class TestRenderAndPost:
             assert result.operations == ["convert", "add_audio"]
 
     @patch("mcp_video.hyperframes_engine.shutil.which")
+    def test_raises_when_render_artifact_is_missing(self, mock_which, sample_hyperframes_project):
+        """render_and_post() should not report success when Hyperframes produced no artifact."""
+
+        def _which(name: str):
+            if name in ("node", "npx"):
+                return f"/usr/bin/{name}"
+            return None
+
+        mock_which.side_effect = _which
+
+        project = str(sample_hyperframes_project)
+        fake_cp = _make_completed_process(stdout="rendered but no output")
+
+        with (
+            patch("mcp_video.hyperframes_engine.subprocess.run", return_value=fake_cp),
+            patch("mcp_video.hyperframes_engine._render_output_exists", return_value=False),
+            pytest.raises(HyperframesRenderError, match="output artifact"),
+        ):
+            render_and_post(project, post_process=[])
+
+    @patch("mcp_video.hyperframes_engine.shutil.which")
     def test_unknown_operation(self, mock_which, sample_hyperframes_project):
         """render_and_post() should raise MCPVideoError for unknown operations."""
 


### PR DESCRIPTION
## Summary
- make render-and-post fail immediately if the Hyperframes render step reports success=false
- prevent a missing upstream artifact from becoming a misleading successful pipeline result
- add regression coverage for zero-exit/no-output renders

## Verification
- python3 -m pytest tests/test_hyperframes_engine.py::TestRenderAndPost -q
- python3 -m pytest tests/test_hyperframes_engine.py tests/test_cli_handlers.py tests/test_misc_coverage.py -q
- python3 -m ruff check mcp_video/hyperframes_engine.py tests/test_hyperframes_engine.py
- python3 -m ruff format --check mcp_video/hyperframes_engine.py tests/test_hyperframes_engine.py
- python3 -m pytest tests/ -x -q --tb=short
- python3 -c "import mcp_video"

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/mcp-video/pr/273"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->