### PR TITLE
Reject empty animated text at all entrypoints

### DIFF
--- a/mcp_video/effects_engine/text.py
+++ b/mcp_video/effects_engine/text.py
@@ -442,6 +442,9 @@ def text_animated(
     Returns:
         Path to output video
     """
+    if not text or not text.strip():
+        raise MCPVideoError("Text cannot be empty", error_type="validation_error", code="invalid_parameter")
+
     video = _validate_input_path(video)
     _validate_output_path(output)
 

--- a/mcp_video/server_tools_effects.py
+++ b/mcp_video/server_tools_effects.py
@@ -378,6 +378,8 @@ def video_text_animated(
     Returns:
         Dict with success status and output_path.
     """
+    if not text or not text.strip():
+        raise MCPVideoError("Text cannot be empty", error_type="validation_error", code="invalid_parameter")
     if animation not in VALID_TEXT_ANIMATIONS:
         raise MCPVideoError(
             f"animation must be one of {sorted(VALID_TEXT_ANIMATIONS)}, got {animation}",

--- a/tests/test_effects_engine.py
+++ b/tests/test_effects_engine.py
@@ -114,6 +114,21 @@ def test_subtitle_text_is_wrapped_for_safe_area():
     assert "The same source becomes\nYouTube, Shorts, and square\nsocial cuts." in wrapped
 
 
+def test_text_animated_rejects_empty_text_before_ffmpeg(tmp_path, monkeypatch):
+    from mcp_video.effects_engine import text_animated
+    from mcp_video.effects_engine import text as text_engine
+
+    input_path = tmp_path / "input.mp4"
+    output_path = tmp_path / "output.mp4"
+    input_path.write_bytes(b"placeholder")
+    monkeypatch.setattr(text_engine, "_run_command", lambda cmd: Path(cmd[-1]).write_bytes(b"output"))
+
+    with pytest.raises(MCPVideoError, match="Text cannot be empty"):
+        text_animated(str(input_path), "   ", str(output_path))
+
+    assert not output_path.exists()
+
+
 def test_text_animated_rejects_unknown_animation_before_ffmpeg(tmp_path, monkeypatch):
     from mcp_video.effects_engine import text_animated
     from mcp_video.effects_engine import text as text_engine

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -191,6 +191,12 @@ class TestVideoTextAnimatedTool:
         assert result["success"] is False
         assert "animation" in result["error"]["message"]
 
+    def test_rejects_empty_text_before_input_validation(self):
+        result = video_text_animated("/tmp/missing.mp4", text="   ")
+
+        assert result["success"] is False
+        assert "Text cannot be empty" in result["error"]["message"]
+
 
 class TestVideoAddAudioTool:
     def test_returns_success(self, sample_video, sample_audio):


### PR DESCRIPTION
## Summary
- reject blank animated-text content in the low-level engine before FFmpeg
- reject blank text at the MCP tool boundary before input-file validation
- add regression coverage for both entrypoints

## Verification
- python3 -m pytest tests/test_effects_engine.py::test_text_animated_rejects_empty_text_before_ffmpeg tests/test_effects_engine.py::test_text_animated_rejects_unknown_animation_before_ffmpeg tests/test_server.py::TestVideoTextAnimatedTool -q
- python3 -m pytest tests/test_effects_engine.py tests/test_server.py tests/test_client.py::TestClientTextAnimatedValidation -q
- python3 -m ruff check mcp_video/effects_engine/text.py mcp_video/server_tools_effects.py tests/test_effects_engine.py tests/test_server.py
- python3 -m ruff format --check mcp_video/effects_engine/text.py mcp_video/server_tools_effects.py tests/test_effects_engine.py tests/test_server.py
- python3 -m pytest tests/ -x -q --tb=short
- python3 -c "import mcp_video"

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/mcp-video/pr/274"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->