### PR TITLE
Reject invalid layout choices at tool boundaries

### DIFF
--- a/mcp_video/effects_engine/layout.py
+++ b/mcp_video/effects_engine/layout.py
@@ -18,6 +18,18 @@ from ..ffmpeg_helpers import (
 
 logger = logging.getLogger(__name__)
 
+VALID_GRID_LAYOUTS = {"2x2", "3x1", "1x3", "2x3"}
+VALID_PIP_POSITIONS = {"top-left", "top-right", "bottom-left", "bottom-right"}
+
+
+def _validate_choice(name: str, value: str, valid_values: set[str]) -> None:
+    if value not in valid_values:
+        raise MCPVideoError(
+            f"{name} must be one of {sorted(valid_values)}, got {value}",
+            error_type="validation_error",
+            code="invalid_parameter",
+        )
+
 
 def layout_grid(
     clips: list[str],
@@ -42,6 +54,7 @@ def layout_grid(
     """
     if len(clips) == 0:
         raise MCPVideoError("At least one clip required", error_type="validation_error", code="invalid_parameter")
+    _validate_choice("layout", layout, VALID_GRID_LAYOUTS)
 
     if gap < 0 or padding < 0:
         raise MCPVideoError(
@@ -153,6 +166,7 @@ def layout_pip(
     Returns:
         Path to output video
     """
+    _validate_choice("position", position, VALID_PIP_POSITIONS)
     main = _validate_input_path(main)
     pip = _validate_input_path(pip)
     _validate_output_path(output)

--- a/mcp_video/server_tools_effects.py
+++ b/mcp_video/server_tools_effects.py
@@ -13,6 +13,8 @@ from .ffmpeg_helpers import _validate_input_path
 from .limits import MAX_MOGRAPH_FRAMES
 
 VALID_TEXT_ANIMATIONS = {"fade", "glitch", "slide-up", "typewriter"}
+VALID_GRID_LAYOUTS = {"2x2", "3x1", "1x3", "2x3"}
+VALID_PIP_POSITIONS = {"top-left", "top-right", "bottom-left", "bottom-right"}
 
 # ---------------------------------------------------------------------------
 # Visual Effects Tools (P1 Features)
@@ -260,6 +262,12 @@ def video_layout_grid(
     Returns:
         Dict with success status and output_path.
     """
+    if layout not in VALID_GRID_LAYOUTS:
+        raise MCPVideoError(
+            f"layout must be one of {sorted(VALID_GRID_LAYOUTS)}, got {layout}",
+            error_type="validation_error",
+            code="invalid_parameter",
+        )
     for _p in clips:
         _validate_input_path(_p)
     if gap < 0:
@@ -312,6 +320,12 @@ def video_layout_pip(
     Returns:
         Dict with success status and output_path.
     """
+    if position not in VALID_PIP_POSITIONS:
+        raise MCPVideoError(
+            f"position must be one of {sorted(VALID_PIP_POSITIONS)}, got {position}",
+            error_type="validation_error",
+            code="invalid_parameter",
+        )
     main_path = _validate_input_path(main_path)
     pip_path = _validate_input_path(pip_path)
     if not (0.0 < size <= 1.0):

--- a/tests/test_effects_engine.py
+++ b/tests/test_effects_engine.py
@@ -114,6 +114,39 @@ def test_subtitle_text_is_wrapped_for_safe_area():
     assert "The same source becomes\nYouTube, Shorts, and square\nsocial cuts." in wrapped
 
 
+def test_layout_grid_rejects_unknown_layout_before_ffmpeg(tmp_path, monkeypatch):
+    from mcp_video.effects_engine import layout_grid
+    from mcp_video.effects_engine import layout as layout_engine
+
+    clip = tmp_path / "clip.mp4"
+    output = tmp_path / "out.mp4"
+    clip.write_bytes(b"placeholder")
+    monkeypatch.setattr(layout_engine, "_run_command", lambda cmd: output.write_bytes(b"output"))
+
+    with pytest.raises(MCPVideoError, match="layout"):
+        layout_grid([str(clip)], "9x9", str(output))
+
+    assert not output.exists()
+
+
+def test_layout_pip_rejects_unknown_position_before_ffmpeg(tmp_path, monkeypatch):
+    from mcp_video.effects_engine import layout_pip
+    from mcp_video.effects_engine import layout as layout_engine
+
+    main = tmp_path / "main.mp4"
+    pip = tmp_path / "pip.mp4"
+    output = tmp_path / "out.mp4"
+    main.write_bytes(b"placeholder")
+    pip.write_bytes(b"placeholder")
+    monkeypatch.setattr(layout_engine, "_run_ffmpeg", lambda cmd: type("Probe", (), {"stdout": "1920x1080"})())
+    monkeypatch.setattr(layout_engine, "_run_command", lambda cmd: output.write_bytes(b"output"))
+
+    with pytest.raises(MCPVideoError, match="position"):
+        layout_pip(str(main), str(pip), str(output), position="middle")
+
+    assert not output.exists()
+
+
 def test_text_animated_rejects_empty_text_before_ffmpeg(tmp_path, monkeypatch):
     from mcp_video.effects_engine import text_animated
     from mcp_video.effects_engine import text as text_engine

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -38,6 +38,8 @@ from mcp_video.server import (
     video_fade,
     video_filter,
     video_info,
+    video_layout_grid,
+    video_layout_pip,
     video_info_resource,
     video_merge,
     video_mograph_progress,
@@ -182,6 +184,20 @@ class TestVideoAddTextTool:
             result = video_add_text(sample_video, text="Hello")
             assert result["success"] is False
             assert "error" in result
+
+
+class TestVideoLayoutToolValidation:
+    def test_layout_grid_rejects_unknown_layout_before_input_validation(self):
+        result = video_layout_grid(["/tmp/missing.mp4"], "9x9", "/tmp/out.mp4")
+
+        assert result["success"] is False
+        assert "layout" in result["error"]["message"]
+
+    def test_layout_pip_rejects_unknown_position_before_input_validation(self):
+        result = video_layout_pip("/tmp/main.mp4", "/tmp/pip.mp4", "/tmp/out.mp4", position="middle")
+
+        assert result["success"] is False
+        assert "position" in result["error"]["message"]
 
 
 class TestVideoTextAnimatedTool:


### PR DESCRIPTION
## Summary
- reject invalid grid layout names in the MCP tool and engine before file/FFmpeg work
- reject invalid PIP positions in the MCP tool and engine instead of silently defaulting to bottom-right
- add regression coverage for server and engine entrypoints

## Verification
- python3 -m pytest tests/test_effects_engine.py::test_layout_grid_rejects_unknown_layout_before_ffmpeg tests/test_effects_engine.py::test_layout_pip_rejects_unknown_position_before_ffmpeg tests/test_server.py::TestVideoLayoutToolValidation tests/test_client.py::TestClientValidators -q
- python3 -m pytest tests/test_effects_engine.py tests/test_server.py tests/test_client.py -q
- python3 -m ruff check mcp_video/effects_engine/layout.py mcp_video/server_tools_effects.py tests/test_effects_engine.py tests/test_server.py
- python3 -m ruff format --check mcp_video/effects_engine/layout.py mcp_video/server_tools_effects.py tests/test_effects_engine.py tests/test_server.py
- python3 -m pytest tests/ -x -q --tb=short
- python3 -c "import mcp_video"

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/mcp-video/pr/275"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->