### PR TITLE
Validate mograph inputs before FFmpeg

### DIFF
--- a/mcp_video/client/effects.py
+++ b/mcp_video/client/effects.py
@@ -122,6 +122,7 @@ class ClientEffectsMixin:
     _VALID_LAYOUTS: ClassVar[set[str]] = {"2x2", "3x1", "1x3", "2x3"}
     _VALID_PIP_POSITIONS: ClassVar[set[str]] = {"top-left", "top-right", "bottom-left", "bottom-right"}
     _VALID_TEXT_ANIMATIONS: ClassVar[set[str]] = {"fade", "glitch", "slide-up", "typewriter"}
+    _VALID_MOGRAPH_STYLES: ClassVar[set[str]] = {"bar", "circle", "dots"}
 
     def layout_grid(
         self,
@@ -273,6 +274,10 @@ class ClientEffectsMixin:
             In the CLI (video-mograph-count), start and end are positional arguments.
             In the Python client, they must be passed as named arguments.
         """
+        if duration <= 0:
+            raise MCPVideoError("duration must be positive", error_type="validation_error", code="invalid_parameter")
+        if fps <= 0:
+            raise MCPVideoError("fps must be positive", error_type="validation_error", code="invalid_parameter")
         from ..effects_engine import mograph_count
 
         return self._to_edit_result(
@@ -290,6 +295,11 @@ class ClientEffectsMixin:
         fps: int = 30,
     ) -> EditResult:
         """Generate progress bar / loading animation."""
+        if duration <= 0:
+            raise MCPVideoError("duration must be positive", error_type="validation_error", code="invalid_parameter")
+        if fps <= 0:
+            raise MCPVideoError("fps must be positive", error_type="validation_error", code="invalid_parameter")
+        self._validate_choice("style", style, self._VALID_MOGRAPH_STYLES)
         from ..effects_engine import mograph_progress
 
         return self._to_edit_result(

--- a/mcp_video/effects_engine/mograph.py
+++ b/mcp_video/effects_engine/mograph.py
@@ -10,9 +10,19 @@ import tempfile
 from pathlib import Path
 from typing import Any
 
+from ..errors import MCPVideoError
 from ..ffmpeg_helpers import _run_command, _escape_ffmpeg_filter_value
 
 logger = logging.getLogger(__name__)
+
+VALID_MOGRAPH_STYLES = {"bar", "circle", "dots"}
+
+
+def _validate_timing(duration: float, fps: int) -> None:
+    if duration <= 0:
+        raise MCPVideoError("duration must be positive", error_type="validation_error", code="invalid_parameter")
+    if fps <= 0:
+        raise MCPVideoError("fps must be positive", error_type="validation_error", code="invalid_parameter")
 
 
 def mograph_count(
@@ -36,6 +46,8 @@ def mograph_count(
     Returns:
         Path to output video
     """
+    _validate_timing(duration, fps)
+
     style = style or {}
     font = style.get("font", "Arial")
     size = style.get("size", 160)
@@ -125,6 +137,14 @@ def mograph_progress(
     Returns:
         Path to output video
     """
+    _validate_timing(duration, fps)
+    if style not in VALID_MOGRAPH_STYLES:
+        raise MCPVideoError(
+            f"style must be one of {sorted(VALID_MOGRAPH_STYLES)}, got {style}",
+            error_type="validation_error",
+            code="invalid_parameter",
+        )
+
     with tempfile.TemporaryDirectory() as tmpdir:
         tmp_path = Path(tmpdir)
         total_frames = int(duration * fps)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -369,6 +369,14 @@ class TestClientValidators:
         with pytest.raises(MCPVideoError, match="quality must be one of"):
             editor.export("video.mp4", quality="superb")
 
+    def test_mograph_count_rejects_non_positive_duration(self, editor):
+        with pytest.raises(MCPVideoError, match="duration"):
+            editor.mograph_count(start=0, end=10, duration=0, output="/tmp/out.mp4")
+
+    def test_mograph_progress_rejects_unknown_style(self, editor):
+        with pytest.raises(MCPVideoError, match="style"):
+            editor.mograph_progress(duration=1.0, output="/tmp/out.mp4", style="spiral")
+
     def test_convert_invalid_format(self, editor):
         with pytest.raises(MCPVideoError, match="format must be one of"):
             editor.convert("video.mp4", format="avi")

--- a/tests/test_effects_engine.py
+++ b/tests/test_effects_engine.py
@@ -114,6 +114,32 @@ def test_subtitle_text_is_wrapped_for_safe_area():
     assert "The same source becomes\nYouTube, Shorts, and square\nsocial cuts." in wrapped
 
 
+def test_mograph_count_rejects_invalid_duration_before_ffmpeg(tmp_path, monkeypatch):
+    from mcp_video.effects_engine import mograph_count
+    from mcp_video.effects_engine import mograph as mograph_engine
+
+    output = tmp_path / "count.mp4"
+    monkeypatch.setattr(mograph_engine, "_run_command", lambda cmd: output.write_bytes(b"output"))
+
+    with pytest.raises(MCPVideoError, match="duration"):
+        mograph_count(0, 10, 0, str(output))
+
+    assert not output.exists()
+
+
+def test_mograph_progress_rejects_unknown_style_before_ffmpeg(tmp_path, monkeypatch):
+    from mcp_video.effects_engine import mograph as mograph_engine
+    from mcp_video.effects_engine import mograph_progress
+
+    output = tmp_path / "progress.mp4"
+    monkeypatch.setattr(mograph_engine, "_run_command", lambda cmd: output.write_bytes(b"output"))
+
+    with pytest.raises(MCPVideoError, match="style"):
+        mograph_progress(1.0, str(output), style="spiral")
+
+    assert not output.exists()
+
+
 def test_layout_grid_rejects_unknown_layout_before_ffmpeg(tmp_path, monkeypatch):
     from mcp_video.effects_engine import layout_grid
     from mcp_video.effects_engine import layout as layout_engine


### PR DESCRIPTION
## Summary
- reject invalid mograph duration/fps at the engine and client layers before FFmpeg
- reject unknown progress styles instead of silently rendering the dots variant
- add regression coverage for client and engine entrypoints

## Verification
- python3 -m pytest tests/test_effects_engine.py::test_mograph_count_rejects_invalid_duration_before_ffmpeg tests/test_effects_engine.py::test_mograph_progress_rejects_unknown_style_before_ffmpeg tests/test_client.py::TestClientValidators::test_mograph_count_rejects_non_positive_duration tests/test_client.py::TestClientValidators::test_mograph_progress_rejects_unknown_style tests/test_server.py::TestServerValidationMograph -q
- python3 -m pytest tests/test_effects_engine.py tests/test_client.py tests/test_server.py tests/test_launch_remediation.py -q
- python3 -m ruff check mcp_video/effects_engine/mograph.py mcp_video/client/effects.py tests/test_effects_engine.py tests/test_client.py
- python3 -m ruff format --check mcp_video/effects_engine/mograph.py mcp_video/client/effects.py tests/test_effects_engine.py tests/test_client.py
- python3 -m pytest tests/ -x -q --tb=short
- python3 -c "import mcp_video"

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/mcp-video/pr/276"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->