### PR TITLE
Reject unknown animated text positions

### DIFF
--- a/mcp_video/client/effects.py
+++ b/mcp_video/client/effects.py
@@ -123,6 +123,15 @@ class ClientEffectsMixin:
     _VALID_PIP_POSITIONS: ClassVar[set[str]] = {"top-left", "top-right", "bottom-left", "bottom-right"}
     _VALID_TEXT_ANIMATIONS: ClassVar[set[str]] = {"fade", "glitch", "slide-up", "typewriter"}
     _VALID_MOGRAPH_STYLES: ClassVar[set[str]] = {"bar", "circle", "dots"}
+    _VALID_TEXT_POSITIONS: ClassVar[set[str]] = {
+        "center",
+        "top",
+        "bottom",
+        "top-left",
+        "top-right",
+        "bottom-left",
+        "bottom-right",
+    }
 
     def layout_grid(
         self,
@@ -213,6 +222,7 @@ class ClientEffectsMixin:
         if not text or not text.strip():
             raise MCPVideoError("Text cannot be empty", error_type="validation_error", code="invalid_parameter")
         self._validate_choice("animation", animation, self._VALID_TEXT_ANIMATIONS)
+        self._validate_choice("position", position, self._VALID_TEXT_POSITIONS)
         from ..effects_engine import text_animated
 
         return self._to_edit_result(

--- a/mcp_video/effects_engine/text.py
+++ b/mcp_video/effects_engine/text.py
@@ -26,6 +26,17 @@ from ..ffmpeg_helpers import (
 
 logger = logging.getLogger(__name__)
 
+VALID_TEXT_POSITIONS = {"center", "top", "bottom", "top-left", "top-right", "bottom-left", "bottom-right"}
+
+
+def _validate_text_position(position: str) -> None:
+    if position not in VALID_TEXT_POSITIONS:
+        raise MCPVideoError(
+            f"position must be one of {sorted(VALID_TEXT_POSITIONS)}, got {position}",
+            error_type="validation_error",
+            code="invalid_parameter",
+        )
+
 
 def _wrap_subtitle_text_for_safe_area(
     text: str,
@@ -444,6 +455,7 @@ def text_animated(
     """
     if not text or not text.strip():
         raise MCPVideoError("Text cannot be empty", error_type="validation_error", code="invalid_parameter")
+    _validate_text_position(position)
 
     video = _validate_input_path(video)
     _validate_output_path(output)

--- a/mcp_video/server_tools_effects.py
+++ b/mcp_video/server_tools_effects.py
@@ -15,6 +15,7 @@ from .limits import MAX_MOGRAPH_FRAMES
 VALID_TEXT_ANIMATIONS = {"fade", "glitch", "slide-up", "typewriter"}
 VALID_GRID_LAYOUTS = {"2x2", "3x1", "1x3", "2x3"}
 VALID_PIP_POSITIONS = {"top-left", "top-right", "bottom-left", "bottom-right"}
+VALID_TEXT_POSITIONS = {"center", "top", "bottom", "top-left", "top-right", "bottom-left", "bottom-right"}
 
 # ---------------------------------------------------------------------------
 # Visual Effects Tools (P1 Features)
@@ -397,6 +398,12 @@ def video_text_animated(
     if animation not in VALID_TEXT_ANIMATIONS:
         raise MCPVideoError(
             f"animation must be one of {sorted(VALID_TEXT_ANIMATIONS)}, got {animation}",
+            error_type="validation_error",
+            code="invalid_parameter",
+        )
+    if position not in VALID_TEXT_POSITIONS:
+        raise MCPVideoError(
+            f"position must be one of {sorted(VALID_TEXT_POSITIONS)}, got {position}",
             error_type="validation_error",
             code="invalid_parameter",
         )

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -413,6 +413,10 @@ class TestClientTextAnimatedValidation:
         with pytest.raises(MCPVideoError, match="animation"):
             editor.text_animated("/tmp/video.mp4", "Hello", "/tmp/out.mp4", animation="spin")
 
+    def test_text_animated_rejects_unknown_position(self, editor):
+        with pytest.raises(MCPVideoError, match="position"):
+            editor.text_animated("/tmp/video.mp4", "Hello", "/tmp/out.mp4", position="middle-ish")
+
 
 class TestClientAgentApiConsistency:
     def test_every_public_client_method_has_contract(self, editor):

--- a/tests/test_effects_engine.py
+++ b/tests/test_effects_engine.py
@@ -188,6 +188,21 @@ def test_text_animated_rejects_empty_text_before_ffmpeg(tmp_path, monkeypatch):
     assert not output_path.exists()
 
 
+def test_text_animated_rejects_unknown_position_before_ffmpeg(tmp_path, monkeypatch):
+    from mcp_video.effects_engine import text_animated
+    from mcp_video.effects_engine import text as text_engine
+
+    input_path = tmp_path / "input.mp4"
+    output_path = tmp_path / "output.mp4"
+    input_path.write_bytes(b"placeholder")
+    monkeypatch.setattr(text_engine, "_run_command", lambda cmd: output_path.write_bytes(b"output"))
+
+    with pytest.raises(MCPVideoError, match="position"):
+        text_animated(str(input_path), "Hello", str(output_path), position="middle-ish")
+
+    assert not output_path.exists()
+
+
 def test_text_animated_rejects_unknown_animation_before_ffmpeg(tmp_path, monkeypatch):
     from mcp_video.effects_engine import text_animated
     from mcp_video.effects_engine import text as text_engine

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -213,6 +213,12 @@ class TestVideoTextAnimatedTool:
         assert result["success"] is False
         assert "Text cannot be empty" in result["error"]["message"]
 
+    def test_rejects_unknown_position_before_input_validation(self):
+        result = video_text_animated("/tmp/missing.mp4", text="Hello", position="middle-ish")
+
+        assert result["success"] is False
+        assert "position" in result["error"]["message"]
+
 
 class TestVideoAddAudioTool:
     def test_returns_success(self, sample_video, sample_audio):


### PR DESCRIPTION
## Summary
- reject invalid animated-text positions in the engine before FFmpeg
- reject invalid positions in the Python client and MCP tool boundary before input-file validation
- add regression coverage for all three entrypoints

## Verification
- python3 -m pytest tests/test_effects_engine.py::test_text_animated_rejects_unknown_position_before_ffmpeg tests/test_effects_engine.py::test_text_animated_rejects_unknown_animation_before_ffmpeg tests/test_client.py::TestClientTextAnimatedValidation tests/test_server.py::TestVideoTextAnimatedTool -q
- python3 -m pytest tests/test_effects_engine.py tests/test_client.py tests/test_server.py -q
- python3 -m ruff check mcp_video/effects_engine/text.py mcp_video/client/effects.py mcp_video/server_tools_effects.py tests/test_effects_engine.py tests/test_client.py tests/test_server.py
- python3 -m ruff format --check mcp_video/effects_engine/text.py mcp_video/client/effects.py mcp_video/server_tools_effects.py tests/test_effects_engine.py tests/test_client.py tests/test_server.py
- python3 -m pytest tests/ -x -q --tb=short
- python3 -c "import mcp_video"

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/mcp-video/pr/277"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->