### PR TITLE
Validate convert quality before encoding

### DIFF
--- a/mcp_video/engine_convert.py
+++ b/mcp_video/engine_convert.py
@@ -42,6 +42,20 @@ def convert(
     """
     input_path = _validate_input_path(input_path)
 
+    valid_formats = {"mp4", "webm", "gif", "mov", "hevc", "av1", "prores"}
+    if format not in valid_formats:
+        raise MCPVideoError(
+            f"format must be one of {sorted(valid_formats)}, got {format}",
+            error_type="validation_error",
+            code="invalid_parameter",
+        )
+    if quality not in QUALITY_PRESETS:
+        raise MCPVideoError(
+            f"quality must be one of {sorted(QUALITY_PRESETS)}, got {quality}",
+            error_type="validation_error",
+            code="invalid_parameter",
+        )
+
     if two_pass and format not in ("mp4", "mov"):
         raise MCPVideoError(
             f"Two-pass encoding is only supported for mp4 and mov formats, got '{format}'",

--- a/mcp_video/server_tools_basic.py
+++ b/mcp_video/server_tools_basic.py
@@ -8,6 +8,7 @@ from .engine import add_audio, add_text, convert, merge, probe, resize, speed, t
 from .limits import MAX_RESOLUTION, MAX_SPEED_FACTOR, MIN_SPEED_FACTOR, MIN_CRF, MAX_CRF
 from .server_app import _result, _safe_tool, _validation_error, mcp
 from .validation import VALID_FORMATS, VALID_PRESETS
+from .models import QUALITY_PRESETS
 from .ffmpeg_helpers import _validate_input_path
 
 
@@ -287,6 +288,8 @@ def video_convert(
     """
     if format not in VALID_FORMATS:
         return _validation_error(f"Invalid format: {format}. Must be one of {sorted(VALID_FORMATS)}")
+    if quality not in QUALITY_PRESETS:
+        return _validation_error(f"Invalid quality: {quality}. Must be one of {sorted(QUALITY_PRESETS)}")
     input_path = _validate_input_path(input_path)
     return _result(
         convert(

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -471,6 +471,30 @@ class TestDeinterlaceFilter:
         assert os.path.isfile(result.output_path)
 
 
+class TestConvertValidation:
+    def test_convert_rejects_invalid_quality_before_probe(self, sample_video, monkeypatch):
+        from mcp_video import engine_convert
+        from mcp_video.errors import MCPVideoError
+
+        monkeypatch.setattr(
+            engine_convert, "probe", lambda _path: (_ for _ in ()).throw(AssertionError("probe should not run"))
+        )
+
+        with pytest.raises(MCPVideoError, match="quality"):
+            engine_convert.convert(sample_video, format="mp4", quality="medium-rare")
+
+    def test_convert_rejects_invalid_format_before_probe(self, sample_video, monkeypatch):
+        from mcp_video import engine_convert
+        from mcp_video.errors import MCPVideoError
+
+        monkeypatch.setattr(
+            engine_convert, "probe", lambda _path: (_ for _ in ()).throw(AssertionError("probe should not run"))
+        )
+
+        with pytest.raises(MCPVideoError, match="format"):
+            engine_convert.convert(sample_video, format="exe", quality="high")
+
+
 class TestGifQualityScaling:
     def test_gif_low_quality_is_smaller(self, sample_video):
         low = convert(sample_video, format="gif", quality="low")

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -754,6 +754,11 @@ class TestServerValidationFormat:
         assert result["success"] is False
         assert "format" in result["error"]["message"].lower()
 
+    def test_convert_rejects_bad_quality(self, sample_video):
+        result = video_convert(sample_video, quality="medium-rare")
+        assert result["success"] is False
+        assert "quality" in result["error"]["message"].lower()
+
     def test_extract_audio_rejects_bad_format(self, sample_video):
         result = video_extract_audio(sample_video, format="exe")
         assert result["success"] is False


### PR DESCRIPTION
## Summary
- reject invalid convert quality at the MCP tool boundary instead of returning an internal error
- reject invalid format/quality in the engine before probe or FFmpeg work
- add regression coverage for server and engine entrypoints

## Verification
- python3 -m pytest tests/test_engine.py::TestConvertValidation tests/test_server.py::TestServerValidationFormat tests/test_client.py::TestClientValidators::test_convert_invalid_quality tests/test_client.py::TestClientValidators::test_convert_invalid_format -q
- python3 -m pytest tests/test_engine.py tests/test_server.py tests/test_client.py -q
- python3 -m ruff check mcp_video/engine_convert.py mcp_video/server_tools_basic.py tests/test_engine.py tests/test_server.py
- python3 -m ruff format --check mcp_video/engine_convert.py mcp_video/server_tools_basic.py tests/test_engine.py tests/test_server.py
- python3 -m pytest tests/ -x -q --tb=short
- python3 -c "import mcp_video"

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/mcp-video/pr/278"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->