### PR TITLE
Validate HLS quality options

### DIFF
--- a/mcp_video/client/media.py
+++ b/mcp_video/client/media.py
@@ -173,6 +173,7 @@ class ClientMediaMixin:
 
     _VALID_FORMATS: ClassVar[set[str]] = {"mp4", "webm", "gif", "mov", "hevc", "av1", "prores"}
     _VALID_QUALITIES: ClassVar[set[str]] = {"low", "medium", "high", "ultra"}
+    _VALID_HLS_QUALITIES: ClassVar[set[str]] = {"low", "medium", "high", "ultra"}
 
     def convert(
         self,
@@ -657,6 +658,14 @@ class ClientMediaMixin:
         qualities: list[str] | None = None,
     ) -> EditResult:
         """Segment a video into HLS (HTTP Live Streaming) format."""
+        if segment_duration <= 0:
+            raise MCPVideoError(
+                f"segment_duration must be positive, got {segment_duration}",
+                error_type="validation_error",
+                code="invalid_parameter",
+            )
+        for quality in qualities or []:
+            self._validate_choice("qualities", quality, self._VALID_HLS_QUALITIES)
         return _hls_segment(
             video,
             output_dir=output_dir,

--- a/mcp_video/engine_hls.py
+++ b/mcp_video/engine_hls.py
@@ -8,7 +8,29 @@ from .engine_probe import probe
 from .engine_runtime_utils import _build_edit_result, _timed_operation
 from .ffmpeg_helpers import _build_ffmpeg_cmd, _run_ffmpeg
 from .ffmpeg_helpers import _validate_input_path
+from .errors import MCPVideoError
 from .models import EditResult
+
+VALID_HLS_QUALITIES = {"low", "medium", "high", "ultra"}
+HLS_HEIGHTS = {"low": 480, "medium": 720, "high": 1080, "ultra": 1080}
+
+
+def _validate_hls_options(segment_duration: int, qualities: list[str] | None) -> list[str]:
+    if segment_duration <= 0:
+        raise MCPVideoError(
+            f"segment_duration must be positive, got {segment_duration}",
+            error_type="validation_error",
+            code="invalid_parameter",
+        )
+    resolved = qualities or ["high"]
+    invalid = [quality for quality in resolved if quality not in VALID_HLS_QUALITIES]
+    if invalid:
+        raise MCPVideoError(
+            f"qualities must be one of {sorted(VALID_HLS_QUALITIES)}, got invalid values: {invalid}",
+            error_type="validation_error",
+            code="invalid_parameter",
+        )
+    return resolved
 
 
 def hls_segment(
@@ -31,6 +53,7 @@ def hls_segment(
     Returns:
         EditResult with the playlist path as ``output_path``.
     """
+    qualities = _validate_hls_options(segment_duration, qualities)
     input_path = _validate_input_path(input_path)
     _info = probe(input_path)
 
@@ -40,7 +63,6 @@ def hls_segment(
     os.makedirs(output_dir, exist_ok=True)
 
     playlist_path = os.path.join(output_dir, playlist_name)
-    qualities = qualities or ["high"]
 
     with _timed_operation() as timing:
         for quality in qualities:
@@ -48,8 +70,7 @@ def hls_segment(
             os.makedirs(q_dir, exist_ok=True)
 
             # Map quality to scale height
-            height_map = {"low": 480, "medium": 720, "high": 1080, "ultra": 1080}
-            target_h = height_map.get(quality, 1080)
+            target_h = HLS_HEIGHTS[quality]
             scale_filter = f"scale=-2:{target_h}"
 
             _run_ffmpeg(
@@ -81,8 +102,7 @@ def hls_segment(
             variant_playlist = os.path.join(q_dir, "playlist.m3u8")
             if os.path.isfile(variant_playlist):
                 # Infer bandwidth roughly from height
-                height_map = {"low": 480, "medium": 720, "high": 1080, "ultra": 1080}
-                bw = height_map.get(quality, 1080) * 3000  # rough kbps
+                bw = HLS_HEIGHTS[quality] * 3000  # rough kbps
                 master_lines.append(f"#EXT-X-STREAM-INF:BANDWIDTH={bw}")
                 master_lines.append(os.path.join(quality, "playlist.m3u8"))
         with open(playlist_path, "w") as f:

--- a/mcp_video/server_tools_advanced.py
+++ b/mcp_video/server_tools_advanced.py
@@ -32,7 +32,10 @@ from .errors import MCPVideoError
 from .limits import MAX_BATCH_SIZE, MAX_EXPORT_FRAMES_FPS
 from .server_app import _result, _safe_tool, _validation_error, mcp
 from .validation import VALID_LAYOUTS, VALID_PRESETS
+
 from .ffmpeg_helpers import _validate_input_path
+
+VALID_HLS_QUALITIES = {"low", "medium", "high", "ultra"}
 
 _CLEANUP_MANAGED_SUFFIXES = (
     "_trimmed",
@@ -158,6 +161,13 @@ def video_hls_segment(
         playlist_name: Name of the master playlist file.
         qualities: List of quality levels (e.g. ["low", "medium", "high"]).
     """
+    if segment_duration <= 0:
+        return _validation_error(f"segment_duration must be positive, got {segment_duration}")
+    invalid_qualities = [quality for quality in qualities or [] if quality not in VALID_HLS_QUALITIES]
+    if invalid_qualities:
+        return _validation_error(
+            f"qualities must be one of {sorted(VALID_HLS_QUALITIES)}, got invalid values: {invalid_qualities}"
+        )
     input_path = _validate_input_path(input_path)
     return _result(
         hls_segment(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -377,6 +377,10 @@ class TestClientValidators:
         with pytest.raises(MCPVideoError, match="style"):
             editor.mograph_progress(duration=1.0, output="/tmp/out.mp4", style="spiral")
 
+    def test_hls_segment_rejects_unknown_quality(self, editor):
+        with pytest.raises(MCPVideoError, match="qualities"):
+            editor.hls_segment("/tmp/video.mp4", qualities=["high", "cinema"])
+
     def test_convert_invalid_format(self, editor):
         with pytest.raises(MCPVideoError, match="format must be one of"):
             editor.convert("video.mp4", format="avi")

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -471,6 +471,30 @@ class TestDeinterlaceFilter:
         assert os.path.isfile(result.output_path)
 
 
+class TestHlsValidation:
+    def test_hls_rejects_unknown_quality_before_probe(self, sample_video, monkeypatch):
+        from mcp_video import engine_hls
+        from mcp_video.errors import MCPVideoError
+
+        monkeypatch.setattr(
+            engine_hls, "probe", lambda _path: (_ for _ in ()).throw(AssertionError("probe should not run"))
+        )
+
+        with pytest.raises(MCPVideoError, match="qualities"):
+            engine_hls.hls_segment(sample_video, qualities=["high", "cinema"])
+
+    def test_hls_rejects_non_positive_segment_duration_before_probe(self, sample_video, monkeypatch):
+        from mcp_video import engine_hls
+        from mcp_video.errors import MCPVideoError
+
+        monkeypatch.setattr(
+            engine_hls, "probe", lambda _path: (_ for _ in ()).throw(AssertionError("probe should not run"))
+        )
+
+        with pytest.raises(MCPVideoError, match="segment_duration"):
+            engine_hls.hls_segment(sample_video, segment_duration=0)
+
+
 class TestConvertValidation:
     def test_convert_rejects_invalid_quality_before_probe(self, sample_video, monkeypatch):
         from mcp_video import engine_convert

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -37,6 +37,7 @@ from mcp_video.server import (
     video_extract_audio,
     video_fade,
     video_filter,
+    video_hls_segment,
     video_info,
     video_layout_grid,
     video_layout_pip,
@@ -786,6 +787,20 @@ class TestServerValidationAI:
     def test_scene_detect_rejects_bad_threshold(self, sample_video):
         result = video_ai_scene_detect(sample_video, threshold=5.0)
         assert result["success"] is False
+
+
+class TestServerValidationHls:
+    def test_rejects_bad_hls_quality_before_input_validation(self):
+        result = video_hls_segment("/tmp/missing.mp4", qualities=["high", "cinema"])
+
+        assert result["success"] is False
+        assert "qualities" in result["error"]["message"]
+
+    def test_rejects_bad_segment_duration_before_input_validation(self):
+        result = video_hls_segment("/tmp/missing.mp4", segment_duration=0)
+
+        assert result["success"] is False
+        assert "segment_duration" in result["error"]["message"]
 
 
 class TestServerValidationSplitScreen:


### PR DESCRIPTION
## Summary
- reject unknown HLS quality labels before probing or FFmpeg work
- reject non-positive HLS segment durations at engine, client, and MCP server entrypoints
- replace silent height fallback with an explicit HLS quality/height map

## Verification
- python3 -m pytest tests/test_engine.py::TestHlsValidation tests/test_client.py::TestClientValidators::test_hls_segment_rejects_unknown_quality tests/test_server.py::TestServerValidationHls -q
- python3 -m pytest tests/test_engine.py tests/test_client.py tests/test_server.py -q
- python3 -m ruff check mcp_video/engine_hls.py mcp_video/client/media.py mcp_video/server_tools_advanced.py tests/test_engine.py tests/test_client.py tests/test_server.py
- python3 -m ruff format --check mcp_video/engine_hls.py mcp_video/client/media.py mcp_video/server_tools_advanced.py tests/test_engine.py tests/test_client.py tests/test_server.py
- python3 -m pytest tests/ -x -q --tb=short
- python3 -c "import mcp_video"

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/mcp-video/pr/279"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->