### PR TITLE
Reject unknown overlay positions

### DIFF
--- a/mcp_video/client/media.py
+++ b/mcp_video/client/media.py
@@ -50,6 +50,7 @@ from ..models import (
     StoryboardResult,
     SubtitleResult,
     ThumbnailResult,
+    _validate_position,
 )
 
 
@@ -271,6 +272,7 @@ class ClientMediaMixin:
         preset: str | None = None,
     ) -> EditResult:
         """Add image watermark."""
+        _validate_position(position)
         return _watermark(
             video,
             image_path=image,
@@ -474,6 +476,7 @@ class ClientMediaMixin:
         preset: str | None = None,
     ) -> EditResult:
         """Picture-in-picture: overlay a video on top of another."""
+        _validate_position(position)
         return _overlay_video(
             background_path=background,
             overlay_path=overlay,

--- a/mcp_video/models.py
+++ b/mcp_video/models.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Literal
+from typing import Any, Literal, get_args
 
 from pydantic import BaseModel, Field
 
@@ -267,6 +267,7 @@ NamedPosition = Literal[
 
 # Position can be a named position string, pixel coordinates, or percentage coordinates
 Position = NamedPosition | dict[str, float]
+VALID_NAMED_POSITIONS = set(get_args(NamedPosition))
 
 # --- Transition types ---
 
@@ -402,11 +403,14 @@ class WatermarkSettings(BaseModel):
 
 
 def _validate_position(position: Position) -> None:
-    """Validate position dict values to prevent FFmpeg filter injection.
-
-    Only validates when position is a dict; named strings are safe by design.
-    """
+    """Validate named and dict positions before building FFmpeg expressions."""
     if not isinstance(position, dict):
+        if position not in VALID_NAMED_POSITIONS:
+            raise _MCPVideoError(
+                f"position must be one of {sorted(VALID_NAMED_POSITIONS)}, got {position}",
+                error_type="validation_error",
+                code="invalid_parameter",
+            )
         return
     if "x_pct" in position and "y_pct" in position:
         for key in ("x_pct", "y_pct"):
@@ -485,7 +489,7 @@ def _position_coords(position: Position, width: int = 0, height: int = 0) -> str
         "bottom-center": "x=(w-text_w)/2:y=h-text_h-10",
         "bottom-right": "x=w-text_w-10:y=h-text_h-10",
     }
-    return mapping.get(position, mapping["center"])
+    return mapping[position]
 
 
 def _resolve_position(
@@ -510,4 +514,4 @@ def _resolve_position(
                 "Position dict must have 'x'+'y' (pixels) or 'x_pct'+'y_pct' (percentage)",
                 code="invalid_position_dict",
             )
-    return position_map.get(position, position_map[default])
+    return position_map[position]

--- a/mcp_video/server_tools_advanced.py
+++ b/mcp_video/server_tools_advanced.py
@@ -29,6 +29,7 @@ from .engine import (
 )
 from .engine import video_batch as _video_batch
 from .errors import MCPVideoError
+from .models import _validate_position
 from .limits import MAX_BATCH_SIZE, MAX_EXPORT_FRAMES_FPS
 from .server_app import _result, _safe_tool, _validation_error, mcp
 from .validation import VALID_LAYOUTS, VALID_PRESETS
@@ -276,6 +277,10 @@ def video_overlay(
         crf: Override CRF value (0-51, lower = better quality). Default 23.
         preset: Override FFmpeg encoding preset (ultrafast, fast, medium, slow, veryslow).
     """
+    try:
+        _validate_position(position)
+    except MCPVideoError as exc:
+        return _validation_error(str(exc))
     if width is not None and width <= 0:
         return _validation_error(f"width must be positive, got {width}")
     if height is not None and height <= 0:

--- a/mcp_video/server_tools_media.py
+++ b/mcp_video/server_tools_media.py
@@ -20,6 +20,7 @@ from .engine import (
     watermark,
 )
 from .errors import MCPVideoError
+from .models import _validate_position
 from .server_app import _error_result, _result, _safe_tool, _validation_error, mcp
 from .templates import TEMPLATES, preview_template
 from .validation import VALID_AUDIO_FORMATS, VALID_FORMATS, VALID_PRESETS
@@ -132,6 +133,10 @@ def video_watermark(
         crf: Override CRF value (0-51, lower = better quality). Default 23.
         preset: Override FFmpeg encoding preset (ultrafast, fast, medium, slow, veryslow).
     """
+    try:
+        _validate_position(position)
+    except MCPVideoError as exc:
+        return _validation_error(str(exc))
     if not 0 <= opacity <= 1:
         return _validation_error(f"opacity must be between 0 and 1, got {opacity}")
     if margin < 0:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -381,6 +381,14 @@ class TestClientValidators:
         with pytest.raises(MCPVideoError, match="qualities"):
             editor.hls_segment("/tmp/video.mp4", qualities=["high", "cinema"])
 
+    def test_watermark_rejects_unknown_position(self, editor):
+        with pytest.raises(MCPVideoError, match="position must be one of"):
+            editor.watermark("/tmp/video.mp4", "/tmp/logo.png", position="middle-ish")
+
+    def test_overlay_video_rejects_unknown_position(self, editor):
+        with pytest.raises(MCPVideoError, match="position must be one of"):
+            editor.overlay_video("/tmp/video.mp4", "/tmp/overlay.mp4", position="middle-ish")
+
     def test_convert_invalid_format(self, editor):
         with pytest.raises(MCPVideoError, match="format must be one of"):
             editor.convert("video.mp4", format="avi")

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -18,6 +18,8 @@ from mcp_video.models import (
     TimelineTransition,
     VideoInfo,
     WatermarkSettings,
+    _position_coords,
+    _resolve_position,
 )
 
 
@@ -228,3 +230,12 @@ class TestValidation:
     def test_invalid_enum_rejected(self, cls, kwargs):
         with pytest.raises(Exception):
             cls(**kwargs)
+
+    def test_position_helpers_reject_unknown_named_position(self):
+        position_map = {"center": "center", "bottom-right": "bottom-right"}
+
+        with pytest.raises(Exception, match="position must be one of"):
+            _position_coords("middle-ish")
+
+        with pytest.raises(Exception, match="position must be one of"):
+            _resolve_position("middle-ish", position_map, "bottom-right")

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -789,6 +789,20 @@ class TestServerValidationAI:
         assert result["success"] is False
 
 
+class TestServerValidationOverlayPosition:
+    def test_watermark_rejects_bad_position_before_input_validation(self):
+        result = video_watermark("/tmp/missing.mp4", "/tmp/logo.png", position="middle-ish")
+
+        assert result["success"] is False
+        assert "position" in result["error"]["message"]
+
+    def test_overlay_rejects_bad_position_before_input_validation(self):
+        result = video_overlay("/tmp/missing.mp4", "/tmp/overlay.mp4", position="middle-ish")
+
+        assert result["success"] is False
+        assert "position" in result["error"]["message"]
+
+
 class TestServerValidationHls:
     def test_rejects_bad_hls_quality_before_input_validation(self):
         result = video_hls_segment("/tmp/missing.mp4", qualities=["high", "cinema"])


### PR DESCRIPTION
## Summary
- make named-position validation reject unknown strings instead of falling back to center/corners
- validate watermark and overlay positions in client and MCP tool entrypoints before file probing
- add regression coverage for model helpers, client methods, and server tools

## Verification
- python3 -m pytest tests/test_models.py::TestValidation::test_position_helpers_reject_unknown_named_position tests/test_client.py::TestClientValidators::test_watermark_rejects_unknown_position tests/test_client.py::TestClientValidators::test_overlay_video_rejects_unknown_position tests/test_server.py::TestServerValidationOverlayPosition -q
- python3 -m pytest tests/test_models.py tests/test_client.py tests/test_server.py -q
- python3 -m ruff check mcp_video/models.py mcp_video/client/media.py mcp_video/server_tools_media.py mcp_video/server_tools_advanced.py tests/test_models.py tests/test_client.py tests/test_server.py
- python3 -m ruff format --check mcp_video/models.py mcp_video/client/media.py mcp_video/server_tools_media.py mcp_video/server_tools_advanced.py tests/test_models.py tests/test_client.py tests/test_server.py
- python3 -m pytest tests/ -x -q --tb=short
- python3 -c "import mcp_video"

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/mcp-video/pr/280"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->