### PR TITLE
Reject unsupported quality metrics

### DIFF
--- a/mcp_video/client/media.py
+++ b/mcp_video/client/media.py
@@ -175,6 +175,7 @@ class ClientMediaMixin:
     _VALID_FORMATS: ClassVar[set[str]] = {"mp4", "webm", "gif", "mov", "hevc", "av1", "prores"}
     _VALID_QUALITIES: ClassVar[set[str]] = {"low", "medium", "high", "ultra"}
     _VALID_HLS_QUALITIES: ClassVar[set[str]] = {"low", "medium", "high", "ultra"}
+    _VALID_QUALITY_METRICS: ClassVar[set[str]] = {"psnr", "ssim"}
 
     def convert(
         self,

--- a/mcp_video/engine_compare_quality.py
+++ b/mcp_video/engine_compare_quality.py
@@ -13,6 +13,21 @@ from .errors import ProcessingError
 from .limits import DEFAULT_FFMPEG_TIMEOUT
 from .models import QualityMetricsResult
 
+SUPPORTED_QUALITY_METRICS = {"psnr", "ssim"}
+
+
+def _validate_quality_metrics(metrics: list[str] | None) -> list[str]:
+    requested_metrics = metrics or ["psnr", "ssim"]
+    resolved = [metric.lower() for metric in requested_metrics]
+    invalid = [metric for metric in resolved if metric not in SUPPORTED_QUALITY_METRICS]
+    if invalid:
+        raise ProcessingError(
+            "compare_quality",
+            1,
+            f"metrics must be one of {sorted(SUPPORTED_QUALITY_METRICS)}, got invalid values: {invalid}",
+        )
+    return resolved
+
 
 def compare_quality(
     original_path: str,
@@ -26,18 +41,11 @@ def compare_quality(
         distorted_path: Path to the distorted/processed video.
         metrics: List of metrics to compute (default: ["psnr", "ssim"]).
     """
+    supported_metrics = _validate_quality_metrics(metrics)
     original_path = _validate_input_path(original_path)
     distorted_path = _validate_input_path(distorted_path)
-    requested_metrics = metrics or ["psnr", "ssim"]
-    supported_metrics = [metric.lower() for metric in requested_metrics if metric.lower() in ("psnr", "ssim")]
 
     computed: dict[str, float] = {}
-    if not supported_metrics:
-        return QualityMetricsResult(
-            metrics=computed,
-            overall_quality="unknown",
-        )
-
     orig_info = probe(original_path)
     target_w = orig_info.width
     target_h = orig_info.height

--- a/mcp_video/server_tools_advanced.py
+++ b/mcp_video/server_tools_advanced.py
@@ -37,6 +37,7 @@ from .validation import VALID_LAYOUTS, VALID_PRESETS
 from .ffmpeg_helpers import _validate_input_path
 
 VALID_HLS_QUALITIES = {"low", "medium", "high", "ultra"}
+VALID_QUALITY_METRICS = {"psnr", "ssim"}
 
 _CLEANUP_MANAGED_SUFFIXES = (
     "_trimmed",
@@ -434,6 +435,11 @@ def video_compare_quality(
         distorted_path: Absolute path to the processed/distorted video.
         metrics: Metrics to compute (default: ['psnr', 'ssim']).
     """
+    invalid_metrics = [metric for metric in metrics or [] if metric.lower() not in VALID_QUALITY_METRICS]
+    if invalid_metrics:
+        return _validation_error(
+            f"metrics must be one of {sorted(VALID_QUALITY_METRICS)}, got invalid values: {invalid_metrics}"
+        )
     original_path = _validate_input_path(original_path)
     distorted_path = _validate_input_path(distorted_path)
     return _result(compare_quality(original_path, distorted_path, metrics=metrics))

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -389,6 +389,10 @@ class TestClientValidators:
         with pytest.raises(MCPVideoError, match="position must be one of"):
             editor.overlay_video("/tmp/video.mp4", "/tmp/overlay.mp4", position="middle-ish")
 
+    def test_compare_quality_rejects_unknown_metric(self, editor):
+        with pytest.raises(MCPVideoError, match="metrics must be one of"):
+            editor.compare_quality("/tmp/a.mp4", "/tmp/b.mp4", metrics=["vmaf"])
+
     def test_convert_invalid_format(self, editor):
         with pytest.raises(MCPVideoError, match="format must be one of"):
             editor.convert("video.mp4", format="avi")

--- a/tests/test_engine_advanced.py
+++ b/tests/test_engine_advanced.py
@@ -1003,18 +1003,18 @@ class TestQualityMetrics:
         result = compare_quality(sample_video, sample_video, metrics=["psnr", "ssim"])
         assert "psnr" in result.metrics or "ssim" in result.metrics
 
-    def test_compare_quality_unsupported_metrics_skip_probe(self, sample_video, monkeypatch):
+    def test_compare_quality_unsupported_metrics_rejected_before_probe(self, sample_video, monkeypatch):
         from mcp_video.engine import compare_quality
         from mcp_video import engine_compare_quality
+        from mcp_video.errors import ProcessingError
 
         def fail_probe(_path):
             raise AssertionError("unsupported metrics should not probe")
 
         monkeypatch.setattr(engine_compare_quality, "probe", fail_probe)
 
-        result = compare_quality(sample_video, sample_video, metrics=["vmaf"])
-        assert result.metrics == {}
-        assert result.overall_quality == "unknown"
+        with pytest.raises(ProcessingError, match="metrics"):
+            compare_quality(sample_video, sample_video, metrics=["vmaf"])
 
     def test_compare_quality_nonexistent_original(self, sample_video):
         from mcp_video.engine import compare_quality

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -789,6 +789,14 @@ class TestServerValidationAI:
         assert result["success"] is False
 
 
+class TestServerValidationCompareQuality:
+    def test_compare_quality_rejects_bad_metric_before_input_validation(self):
+        result = video_compare_quality("/tmp/missing-original.mp4", "/tmp/missing-distorted.mp4", metrics=["vmaf"])
+
+        assert result["success"] is False
+        assert "metrics" in result["error"]["message"]
+
+
 class TestServerValidationOverlayPosition:
     def test_watermark_rejects_bad_position_before_input_validation(self):
         result = video_watermark("/tmp/missing.mp4", "/tmp/logo.png", position="middle-ish")


### PR DESCRIPTION
## Summary
- reject unsupported compare_quality metric names instead of returning successful unknown results
- validate metrics at engine, Python client, and MCP server layers before probe/input work
- update regression coverage for unsupported metric requests

## Verification
- python3 -m pytest tests/test_engine_advanced.py::TestQualityMetrics tests/test_client.py::TestClientValidators::test_compare_quality_rejects_unknown_metric tests/test_server.py::TestServerValidationCompareQuality -q
- python3 -m pytest tests/test_engine_advanced.py tests/test_client.py tests/test_server.py -q
- python3 -m ruff check mcp_video/engine_compare_quality.py mcp_video/client/media.py mcp_video/server_tools_advanced.py tests/test_engine_advanced.py tests/test_client.py tests/test_server.py
- python3 -m ruff format --check mcp_video/engine_compare_quality.py mcp_video/client/media.py mcp_video/server_tools_advanced.py tests/test_engine_advanced.py tests/test_client.py tests/test_server.py
- python3 -m pytest tests/ -x -q --tb=short
- python3 -c "import mcp_video"

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/mcp-video/pr/281"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->