### PR TITLE
Validate timeline image overlay positions

### DIFF
--- a/mcp_video/engine_timeline.py
+++ b/mcp_video/engine_timeline.py
@@ -20,6 +20,7 @@ from .paths import (
 )
 from .models import (
     _position_coords,
+    _validate_position,
 )
 from .ffmpeg_helpers import (
     _build_ffmpeg_cmd,
@@ -38,6 +39,7 @@ def edit_timeline(timeline: Timeline | dict, output_path: str | None = None) -> 
     """Execute a full timeline-based edit described in JSON."""
     if isinstance(timeline, dict):
         timeline = Timeline.model_validate(timeline)
+    _validate_timeline_positions(timeline)
     tmpdir = tempfile.mkdtemp(prefix="mcp_video_timeline_")
     try:
         video_clips, audio_clips, text_elements, image_overlays = _collect_tracks(timeline, tmpdir)
@@ -67,6 +69,14 @@ def edit_timeline(timeline: Timeline | dict, output_path: str | None = None) -> 
         return export_video(current, output_path=output, quality=timeline.export.quality, format=timeline.export.format)
     finally:
         shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+def _validate_timeline_positions(timeline: Timeline) -> None:
+    for track in timeline.tracks:
+        for elem in track.elements:
+            _validate_position(elem.position)
+        for img in track.images:
+            _validate_position(img.position)
 
 
 def _collect_tracks(timeline: Timeline, tmpdir: str):
@@ -181,10 +191,14 @@ def _image_overlay_position(img: TimelineImageOverlay, overlay_position_map: dic
             return f"(main_w*{img.position['x_pct']}-overlay_w/2):(main_h*{img.position['y_pct']}-overlay_h/2)"
         if "x" in img.position and "y" in img.position:
             return f"{img.position['x']}:{img.position['y']}"
-        return overlay_position_map["center"]
+        raise MCPVideoError(
+            "Position dict must have 'x'+'y' (pixels) or 'x_pct'+'y_pct' (percentage)",
+            error_type="validation_error",
+            code="invalid_position_dict",
+        )
     if img.x is not None and img.y is not None:
         return f"{img.x}:{img.y}"
-    return overlay_position_map.get(img.position, overlay_position_map["center"])
+    return overlay_position_map[img.position]
 
 
 def _image_enable_expression(img: TimelineImageOverlay) -> str:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -228,6 +228,17 @@ class TestClientEdit:
         with pytest.raises(Exception):
             editor.edit({"width": "not_an_int"})
 
+    def test_edit_rejects_invalid_image_position_before_input_validation(self, editor):
+        timeline = {
+            "tracks": [
+                {"type": "video", "clips": [{"source": "/tmp/missing.mp4"}]},
+                {"type": "image", "images": [{"source": "/tmp/logo.png", "position": {"x_pct": 0.5}}]},
+            ]
+        }
+
+        with pytest.raises(MCPVideoError, match="Position dict"):
+            editor.edit(timeline)
+
 
 class TestClientExtractAudio:
     def test_extract_audio_returns_edit_result(self, editor, sample_video):

--- a/tests/test_engine_advanced.py
+++ b/tests/test_engine_advanced.py
@@ -139,6 +139,20 @@ class TestEditTimeline:
         result = edit_timeline(tl)
         assert os.path.isfile(result.output_path)
 
+    def test_timeline_rejects_invalid_image_position_before_input_validation(self):
+        from mcp_video.engine import edit_timeline
+        from mcp_video.errors import MCPVideoError
+
+        timeline = {
+            "tracks": [
+                {"type": "video", "clips": [{"source": "/tmp/missing.mp4"}]},
+                {"type": "image", "images": [{"source": "/tmp/logo.png", "position": {"x_pct": 0.5}}]},
+            ]
+        }
+
+        with pytest.raises(MCPVideoError, match="Position dict"):
+            edit_timeline(timeline)
+
     def test_timeline_with_audio(self, sample_video, sample_audio, tmp_path):
         out = str(tmp_path / "timeline_audio.mp4")
         tl = Timeline(

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -789,6 +789,21 @@ class TestServerValidationAI:
         assert result["success"] is False
 
 
+class TestServerValidationTimelinePosition:
+    def test_edit_rejects_invalid_image_position_before_input_validation(self):
+        timeline = {
+            "tracks": [
+                {"type": "video", "clips": [{"source": "/tmp/missing.mp4"}]},
+                {"type": "image", "images": [{"source": "/tmp/logo.png", "position": {"x_pct": 0.5}}]},
+            ]
+        }
+
+        result = video_edit(timeline)
+
+        assert result["success"] is False
+        assert "Position dict" in result["error"]["message"]
+
+
 class TestServerValidationCompareQuality:
     def test_compare_quality_rejects_bad_metric_before_input_validation(self):
         result = video_compare_quality("/tmp/missing-original.mp4", "/tmp/missing-distorted.mp4", metrics=["vmaf"])


### PR DESCRIPTION
## Summary
- validate timeline text/image positions before track media probing
- reject malformed image overlay position dicts instead of silently centering overlays
- replace the remaining timeline named-position fallback with explicit validated lookup

## Verification
- python3 -m pytest tests/test_engine_advanced.py::TestEditTimeline tests/test_client.py::TestClientEdit tests/test_server.py::TestServerValidationTimelinePosition -q
- python3 -m ruff check mcp_video/engine_timeline.py tests/test_engine_advanced.py tests/test_client.py tests/test_server.py
- python3 -m ruff format --check mcp_video/engine_timeline.py tests/test_engine_advanced.py tests/test_client.py tests/test_server.py
- python3 -m pytest tests/ -x -q --tb=short
- python3 -c "import mcp_video"

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/mcp-video/pr/282"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->