### PR TITLE
Validate batch operation names first

### DIFF
--- a/mcp_video/engine_batch.py
+++ b/mcp_video/engine_batch.py
@@ -18,6 +18,28 @@ from .errors import MCPVideoError
 from .ffmpeg_helpers import _validate_input_path, _validate_output_path
 from .models import EditResult
 
+VALID_BATCH_OPERATIONS = {
+    "trim",
+    "resize",
+    "convert",
+    "filter",
+    "blur",
+    "color_grade",
+    "watermark",
+    "speed",
+    "fade",
+    "normalize_audio",
+}
+
+
+def _validate_batch_operation(operation: str) -> None:
+    if operation not in VALID_BATCH_OPERATIONS:
+        raise MCPVideoError(
+            f"Unknown operation '{operation}'. Valid operations: {sorted(VALID_BATCH_OPERATIONS)}",
+            error_type="validation_error",
+            code="invalid_operation",
+        )
+
 
 def video_batch(
     inputs: list[str],
@@ -33,6 +55,7 @@ def video_batch(
         }
 
     params = params or {}
+    _validate_batch_operation(operation)
     if output_dir:
         try:
             output_dir = _validate_output_path(output_dir)
@@ -57,11 +80,6 @@ def video_batch(
             if output_dir:
                 os.makedirs(output_dir, exist_ok=True)
             result = _run_batch_operation(input_path, operation, params, output_dir)
-            if result is None:
-                results.append({"input": input_path, "success": False, "error": f"Unknown operation: {operation}"})
-                failed += 1
-                continue
-
             results.append({"input": input_path, "success": True, "output_path": result.output_path})
             succeeded += 1
         except Exception as e:
@@ -83,7 +101,7 @@ def _run_batch_operation(
     operation: str,
     params: dict[str, Any],
     output_dir: str | None,
-) -> EditResult | None:
+) -> EditResult:
     def _batch_output(ext: str | None = None) -> str | None:
         if output_dir:
             name = os.path.splitext(os.path.basename(input_path))[0]
@@ -153,4 +171,8 @@ def _run_batch_operation(
         )
     if operation == "normalize_audio":
         return normalize_audio(input_path, target_lufs=params.get("target_lufs", -16.0), output_path=_batch_output())
-    return None
+    raise MCPVideoError(
+        f"Unknown operation '{operation}'. Valid operations: {sorted(VALID_BATCH_OPERATIONS)}",
+        error_type="validation_error",
+        code="invalid_operation",
+    )

--- a/mcp_video/server_tools_advanced.py
+++ b/mcp_video/server_tools_advanced.py
@@ -28,6 +28,7 @@ from .engine import (
     write_metadata,
 )
 from .engine import video_batch as _video_batch
+from .engine_batch import VALID_BATCH_OPERATIONS
 from .errors import MCPVideoError
 from .models import _validate_position
 from .limits import MAX_BATCH_SIZE, MAX_EXPORT_FRAMES_FPS
@@ -559,18 +560,6 @@ def video_batch(
         params: Parameters for the operation.
         output_dir: Directory for output files. Auto-generated if omitted.
     """
-    VALID_BATCH_OPERATIONS = {
-        "trim",
-        "resize",
-        "convert",
-        "filter",
-        "blur",
-        "color_grade",
-        "watermark",
-        "speed",
-        "fade",
-        "normalize_audio",
-    }
     if operation not in VALID_BATCH_OPERATIONS:
         return _validation_error(
             f"Unknown operation '{operation}'. Valid operations: {sorted(VALID_BATCH_OPERATIONS)}",

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -350,6 +350,10 @@ class TestClientBatch:
         assert result["success"] is True
         assert result["succeeded"] == 1
 
+    def test_batch_unknown_operation_rejected_before_input_validation(self, editor):
+        with pytest.raises(MCPVideoError, match="Unknown operation"):
+            editor.batch(["/tmp/missing.mp4"], operation="nonexistent")
+
 
 class TestClientValidators:
     """Tests for parameter validation in the Python client."""

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -548,6 +548,12 @@ class TestBatchOutputDirValidation:
         assert result["failed"] == 1
         assert result["results"][0]["success"] is False
 
+    def test_batch_unknown_operation_rejected_before_input_validation(self):
+        from mcp_video.engine import video_batch
+
+        with pytest.raises(MCPVideoError, match="Unknown operation"):
+            video_batch(["/tmp/missing.mp4"], operation="nonexistent")
+
     def test_batch_rejects_invalid_output_dir(self, sample_video):
         from mcp_video.engine import video_batch
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -591,6 +591,11 @@ class TestVideoBatchTool:
         assert result["success"] is False
         assert "error" in result
 
+    def test_batch_unknown_operation_rejected_before_input_validation(self):
+        result = video_batch(["/tmp/missing.mp4"], operation="nonexistent")
+        assert result["success"] is False
+        assert result["error"]["code"] == "invalid_operation"
+
     def test_batch_partial_failure(self, sample_video):
         result = video_batch(
             [sample_video, "/nonexistent/video.mp4"],


### PR DESCRIPTION
## Summary
- centralize valid batch operations in the engine
- reject unknown batch operation names before input path validation
- reuse the engine allowlist in MCP server validation and add engine/client/server regressions

## Verification
- python3 -m pytest tests/test_engine.py::TestBatchOutputDirValidation tests/test_client.py::TestClientBatch tests/test_server.py::TestVideoBatchTool -q
- python3 -m ruff check mcp_video/engine_batch.py mcp_video/server_tools_advanced.py tests/test_engine.py tests/test_client.py tests/test_server.py
- python3 -m ruff format --check mcp_video/engine_batch.py mcp_video/server_tools_advanced.py tests/test_engine.py tests/test_client.py tests/test_server.py
- python3 -m pytest tests/ -x -q --tb=short
- python3 -c "import mcp_video"

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/mcp-video/pr/283"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->