### PR TITLE
Validate subtitle entries before media paths

### DIFF
--- a/mcp_video/engine_subtitle_generate.py
+++ b/mcp_video/engine_subtitle_generate.py
@@ -31,10 +31,10 @@ def generate_subtitles(
     burn: bool = False,
 ) -> SubtitleResult:
     """Generate SRT subtitles from text entries and optionally burn into video."""
+    _validate_entries(entries)
     input_path = _validate_input_path(input_path)
     if output_path:
         _validate_output_path(output_path)
-    _validate_entries(entries)
 
     srt_file = _write_srt(entries, input_path, output_path)
     if burn:

--- a/mcp_video/server_tools_advanced.py
+++ b/mcp_video/server_tools_advanced.py
@@ -416,8 +416,12 @@ def video_generate_subtitles(
         input_path: Absolute path to the input video.
         burn: If True, burn subtitles into the video (default False).
     """
-    if not isinstance(entries, list) or len(entries) == 0:
-        return _validation_error("entries must be a non-empty list")
+    try:
+        from .engine_subtitle_generate import _validate_entries
+
+        _validate_entries(entries)
+    except MCPVideoError as exc:
+        return _validation_error(str(exc))
     input_path = _validate_input_path(input_path)
     return _result(generate_subtitles(entries, input_path, burn=burn))
 

--- a/tests/test_engine_advanced.py
+++ b/tests/test_engine_advanced.py
@@ -764,6 +764,13 @@ class TestGenerateSubtitles:
         with pytest.raises(MCPVideoError, match=r"start.*end"):
             generate_subtitles(entries, sample_video)
 
+    def test_invalid_entry_rejected_before_input_validation(self):
+        from mcp_video.engine import generate_subtitles
+
+        entries = [{"start": 1.0, "text": "Missing end"}]
+        with pytest.raises(MCPVideoError, match="subtitle entry"):
+            generate_subtitles(entries, "/tmp/missing.mp4")
+
 
 class TestAudioWaveform:
     """Tests for audio waveform extraction."""

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -37,6 +37,7 @@ from mcp_video.server import (
     video_extract_audio,
     video_fade,
     video_filter,
+    video_generate_subtitles,
     video_hls_segment,
     video_info,
     video_layout_grid,
@@ -792,6 +793,20 @@ class TestServerValidationAI:
     def test_scene_detect_rejects_bad_threshold(self, sample_video):
         result = video_ai_scene_detect(sample_video, threshold=5.0)
         assert result["success"] is False
+
+
+class TestServerValidationSubtitles:
+    def test_generate_subtitles_rejects_bad_entry_before_input_validation(self):
+        result = video_generate_subtitles([{"start": 1.0, "text": "Missing end"}], "/tmp/missing.mp4")
+
+        assert result["success"] is False
+        assert "subtitle entry" in result["error"]["message"]
+
+    def test_generate_subtitles_rejects_bad_range_before_input_validation(self):
+        result = video_generate_subtitles([{"start": 2.0, "end": 1.0, "text": "Bad"}], "/tmp/missing.mp4")
+
+        assert result["success"] is False
+        assert "start" in result["error"]["message"]
 
 
 class TestServerValidationTimelinePosition:


### PR DESCRIPTION
## Summary
- validate subtitle entry shape/range before input path probing
- return MCP validation errors for malformed subtitle entries even when media paths are missing
- add engine and server regressions

## Verification
- python3 -m pytest tests/test_engine_advanced.py::TestGenerateSubtitles tests/test_server.py::TestServerValidationSubtitles -q
- python3 -m pytest tests/test_engine_advanced.py tests/test_server.py -q
- python3 -m ruff check mcp_video/engine_subtitle_generate.py mcp_video/server_tools_advanced.py tests/test_engine_advanced.py tests/test_server.py
- python3 -m ruff format --check mcp_video/engine_subtitle_generate.py mcp_video/server_tools_advanced.py tests/test_engine_advanced.py tests/test_server.py
- python3 -m pytest tests/ -x -q --tb=short
- python3 -c "import mcp_video"

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/mcp-video/pr/284"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->