### PR TITLE
Reject missing audio compose tracks

### DIFF
--- a/mcp_video/audio_engine/sequencing.py
+++ b/mcp_video/audio_engine/sequencing.py
@@ -8,9 +8,10 @@ from __future__ import annotations
 import tempfile
 import wave
 from pathlib import Path
-from typing import Any
 
 from ..errors import MCPVideoError
+from typing import Any
+
 
 from .core import (
     _float_to_pcm,
@@ -170,8 +171,18 @@ def audio_compose(
         start_time = track.get("start", 0)
         loop = track.get("loop", False)
 
-        if not file_path or not Path(file_path).exists():
-            continue
+        if not file_path or not isinstance(file_path, str):
+            raise MCPVideoError(
+                "tracks must contain 'file' key with a non-empty path string",
+                error_type="validation_error",
+                code="invalid_parameter",
+            )
+        if not Path(file_path).exists():
+            raise MCPVideoError(
+                f"Audio track file not found: {file_path}",
+                error_type="input_error",
+                code="invalid_input",
+            )
 
         # Read WAV file
         with wave.open(file_path, "rb") as wav_file:

--- a/mcp_video/client/audio.py
+++ b/mcp_video/client/audio.py
@@ -149,6 +149,18 @@ class ClientAudioMixin:
             raise MCPVideoError("tracks cannot be empty", error_type="validation_error", code="empty_tracks")
         if duration <= 0:
             raise MCPVideoError("duration must be > 0", error_type="validation_error", code="invalid_parameter")
+        for i, track in enumerate(tracks):
+            if not isinstance(track, dict):
+                raise MCPVideoError(
+                    f"tracks[{i}] must be a dict", error_type="validation_error", code="invalid_parameter"
+                )
+            track_file = track.get("file")
+            if not track_file or not isinstance(track_file, str):
+                raise MCPVideoError(
+                    f"tracks[{i}].file must be a non-empty path string",
+                    error_type="validation_error",
+                    code="invalid_parameter",
+                )
         from ..audio_engine import audio_compose
 
         return self._to_edit_result(

--- a/tests/test_audio_sequencing.py
+++ b/tests/test_audio_sequencing.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import pytest
 
 from mcp_video.audio_engine.sequencing import audio_compose, audio_effects, audio_sequence
+from mcp_video.errors import MCPVideoError
 from mcp_video.audio_engine.synthesis import audio_synthesize
 
 
@@ -94,15 +95,22 @@ class TestAudioCompose:
         )
         assert Path(result).exists()
 
-    def test_compose_missing_file_skipped(self, tmp_path):
+    def test_compose_missing_file_rejected(self, tmp_path):
         output = str(tmp_path / "out.wav")
-        result = audio_compose(
-            [{"file": "/nonexistent.wav", "volume": 0.5}],
-            duration=0.1,
-            output=output,
-            sample_rate=8000,
-        )
-        assert Path(result).exists()
+        with pytest.raises(MCPVideoError, match="not found"):
+            audio_compose(
+                [{"file": "/nonexistent.wav", "volume": 0.5}],
+                duration=0.1,
+                output=output,
+                sample_rate=8000,
+            )
+        assert not Path(output).exists()
+
+    def test_compose_missing_file_key_rejected(self, tmp_path):
+        output = str(tmp_path / "out.wav")
+        with pytest.raises(MCPVideoError, match="file"):
+            audio_compose([{"volume": 0.5}], duration=0.1, output=output, sample_rate=8000)
+        assert not Path(output).exists()
 
     def test_compose_multiple_tracks(self, tmp_path):
         t1 = _make_wav(str(tmp_path / "t1.wav"), freq=440)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -434,6 +434,10 @@ class TestClientAudioComposeValidation:
         with pytest.raises(MCPVideoError, match="duration"):
             editor.audio_compose([{"file": "/tmp/a.wav"}], duration=0, output="/tmp/out.wav")
 
+    def test_audio_compose_rejects_track_without_file(self, editor):
+        with pytest.raises(MCPVideoError, match="file"):
+            editor.audio_compose([{"volume": 0.5}], duration=1.0, output="/tmp/out.wav")
+
 
 class TestClientTextAnimatedValidation:
     def test_text_animated_rejects_empty_text(self, editor):


### PR DESCRIPTION
## Summary
- reject missing/empty audio compose track files instead of silently skipping them
- add client-side track shape validation before direct compose calls
- update regression coverage for missing files and missing file keys

## Verification
- python3 -m pytest tests/test_audio_sequencing.py::TestAudioCompose tests/test_client.py::TestClientAudioComposeValidation -q
- python3 -m pytest tests/test_audio_sequencing.py tests/test_client.py -q
- python3 -m ruff check mcp_video/audio_engine/sequencing.py mcp_video/client/audio.py tests/test_audio_sequencing.py tests/test_client.py
- python3 -m ruff format --check mcp_video/audio_engine/sequencing.py mcp_video/client/audio.py tests/test_audio_sequencing.py tests/test_client.py
- python3 -m pytest tests/ -x -q --tb=short
- python3 -c "import mcp_video"

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/mcp-video/pr/285"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->