### PR TITLE
Reject invalid audio sequence events

### DIFF
--- a/mcp_video/audio_engine/sequencing.py
+++ b/mcp_video/audio_engine/sequencing.py
@@ -8,11 +8,10 @@ from __future__ import annotations
 import tempfile
 import wave
 from pathlib import Path
-
-from ..errors import MCPVideoError
 from typing import Any
 
-
+from ..errors import MCPVideoError
+from ..validation import VALID_AUDIO_SEQUENCE_TYPES, VALID_WAVEFORMS
 from .core import (
     _float_to_pcm,
     _pcm_to_float,
@@ -38,6 +37,53 @@ DEFAULT_CHANNELS = 1
 DEFAULT_SAMPLE_WIDTH = 2  # 16-bit
 
 
+def _validate_audio_sequence(sequence: list[dict[str, Any]]) -> None:
+    """Validate sequence events before generating any output file."""
+    if not isinstance(sequence, list) or not sequence:
+        raise MCPVideoError("Sequence cannot be empty", error_type="validation_error", code="invalid_parameter")
+
+    for i, event in enumerate(sequence):
+        if not isinstance(event, dict):
+            raise MCPVideoError(
+                f"sequence[{i}] must be a dict",
+                error_type="validation_error",
+                code="invalid_parameter",
+            )
+
+        event_type = event.get("type")
+        if event_type not in VALID_AUDIO_SEQUENCE_TYPES:
+            raise MCPVideoError(
+                f"sequence[{i}].type must be one of {sorted(VALID_AUDIO_SEQUENCE_TYPES)}, got {event_type!r}",
+                error_type="validation_error",
+                code="invalid_parameter",
+            )
+
+        at = event.get("at")
+        if not isinstance(at, (int, float)):
+            raise MCPVideoError(
+                f"sequence[{i}].at must be numeric",
+                error_type="validation_error",
+                code="invalid_parameter",
+            )
+
+        duration = event.get("duration", 1.0)
+        if not isinstance(duration, (int, float)) or duration <= 0:
+            raise MCPVideoError(
+                f"sequence[{i}].duration must be > 0",
+                error_type="validation_error",
+                code="invalid_parameter",
+            )
+
+        if event_type == "tone":
+            waveform = event.get("waveform", "sine")
+            if waveform not in VALID_WAVEFORMS:
+                raise MCPVideoError(
+                    f"sequence[{i}].waveform must be one of {sorted(VALID_WAVEFORMS)}, got {waveform!r}",
+                    error_type="validation_error",
+                    code="invalid_parameter",
+                )
+
+
 def audio_sequence(
     sequence: list[dict[str, Any]],
     output: str,
@@ -59,8 +105,7 @@ def audio_sequence(
     Returns:
         Path to generated WAV file
     """
-    if not sequence:
-        raise MCPVideoError("Sequence cannot be empty", error_type="validation_error", code="invalid_parameter")
+    _validate_audio_sequence(sequence)
 
     # Calculate total duration
     max_end = max(event.get("at", 0) + event.get("duration", 1.0) for event in sequence)
@@ -91,8 +136,8 @@ def audio_sequence(
                 pcm = generate_sawtooth(freq, duration, sample_rate, volume)
             elif waveform == "triangle":
                 pcm = generate_triangle(freq, duration, sample_rate, volume)
-            else:
-                pcm = generate_sine(freq, duration, sample_rate, volume)
+            elif waveform == "noise":
+                pcm = generate_noise(duration, sample_rate, volume)
 
             samples = _pcm_to_float(pcm)
 
@@ -122,9 +167,6 @@ def audio_sequence(
             pcm = generate_noise(duration, sample_rate, volume)
             samples = _pcm_to_float(pcm)
             samples = apply_lowpass(samples, 2000, sample_rate)
-
-        else:
-            continue
 
         # Mix into buffer
         for i, sample in enumerate(samples):

--- a/tests/test_audio_sequencing.py
+++ b/tests/test_audio_sequencing.py
@@ -46,14 +46,29 @@ class TestAudioSequence:
         result = audio_sequence(seq, output, sample_rate=8000)
         assert Path(result).exists()
 
-    def test_unknown_event_type_ignored(self, tmp_path):
+    def test_unknown_event_type_rejected(self, tmp_path):
         output = str(tmp_path / "out.wav")
         seq = [
             {"type": "unknown", "at": 0.0, "duration": 0.05},
             {"type": "tone", "at": 0.0, "duration": 0.05, "freq": 440},
         ]
-        result = audio_sequence(seq, output, sample_rate=8000)
-        assert Path(result).exists()
+        with pytest.raises(MCPVideoError, match="type"):
+            audio_sequence(seq, output, sample_rate=8000)
+        assert not Path(output).exists()
+
+    def test_unknown_tone_waveform_rejected(self, tmp_path):
+        output = str(tmp_path / "out.wav")
+        seq = [{"type": "tone", "at": 0.0, "duration": 0.05, "freq": 440, "waveform": "pulse"}]
+        with pytest.raises(MCPVideoError, match="waveform"):
+            audio_sequence(seq, output, sample_rate=8000)
+        assert not Path(output).exists()
+
+    def test_missing_event_type_rejected(self, tmp_path):
+        output = str(tmp_path / "out.wav")
+        seq = [{"at": 0.0, "duration": 0.05, "freq": 440}]
+        with pytest.raises(MCPVideoError, match="type"):
+            audio_sequence(seq, output, sample_rate=8000)
+        assert not Path(output).exists()
 
     def test_normalization_on_clipping(self, tmp_path):
         output = str(tmp_path / "out.wav")

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -425,6 +425,23 @@ class TestClientValidators:
                 assert not isinstance(exc_info.value, ValueError)
 
 
+class TestClientAudioSequenceValidation:
+    def test_audio_sequence_rejects_empty_sequence(self, editor):
+        with pytest.raises(MCPVideoError, match="sequence"):
+            editor.audio_sequence([], output="/tmp/out.wav")
+
+    def test_audio_sequence_rejects_unknown_event_type(self, editor):
+        with pytest.raises(MCPVideoError, match="type"):
+            editor.audio_sequence([{"type": "unknown", "at": 0.0, "duration": 0.1}], output="/tmp/out.wav")
+
+    def test_audio_sequence_rejects_unknown_waveform(self, editor):
+        with pytest.raises(MCPVideoError, match="waveform"):
+            editor.audio_sequence(
+                [{"type": "tone", "at": 0.0, "duration": 0.1, "waveform": "pulse"}],
+                output="/tmp/out.wav",
+            )
+
+
 class TestClientAudioComposeValidation:
     def test_audio_compose_rejects_empty_tracks(self, editor):
         with pytest.raises(MCPVideoError, match="tracks"):


### PR DESCRIPTION
## Summary
- validate direct audio sequence event shape before generating output
- reject unknown or missing event types instead of silently skipping/defaulting
- reject unsupported tone waveforms instead of rendering them as sine

## Verification
- python3 -m pytest tests/test_audio_sequencing.py::TestAudioSequence tests/test_client.py::TestClientAudioSequenceValidation -q
- python3 -m pytest tests/test_audio_sequencing.py tests/test_client.py -q
- python3 -m ruff check .
- python3 -m ruff format --check mcp_video/audio_engine/sequencing.py tests/test_audio_sequencing.py tests/test_client.py
- python3 -m pytest tests/ -x -q --tb=short
- python3 -c "import mcp_video"

## Known unrelated drift
- python3 -m ruff format --check . reports pre-existing formatting drift in examples/agent_cookbook.py; changed files are formatted.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/mcp-video/pr/286"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->