### PR TITLE
Reject invalid audio effects

### DIFF
--- a/mcp_video/audio_engine/sequencing.py
+++ b/mcp_video/audio_engine/sequencing.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from typing import Any
 
 from ..errors import MCPVideoError
-from ..validation import VALID_AUDIO_SEQUENCE_TYPES, VALID_WAVEFORMS
+from ..validation import VALID_AUDIO_EFFECT_TYPES, VALID_AUDIO_SEQUENCE_TYPES, VALID_WAVEFORMS
 from .core import (
     _float_to_pcm,
     _pcm_to_float,
@@ -257,6 +257,28 @@ def audio_compose(
     return write_wav(pcm_data, output, sample_rate)
 
 
+def _validate_audio_effects(effects: list[dict[str, Any]]) -> None:
+    """Validate effects before reading or writing media."""
+    if not isinstance(effects, list):
+        raise MCPVideoError("effects must be a list", error_type="validation_error", code="invalid_parameter")
+
+    for i, effect in enumerate(effects):
+        if not isinstance(effect, dict):
+            raise MCPVideoError(
+                f"effects[{i}] must be a dict",
+                error_type="validation_error",
+                code="invalid_parameter",
+            )
+
+        effect_type = effect.get("type")
+        if effect_type not in VALID_AUDIO_EFFECT_TYPES:
+            raise MCPVideoError(
+                f"effects[{i}].type must be one of {sorted(VALID_AUDIO_EFFECT_TYPES)}, got {effect_type!r}",
+                error_type="validation_error",
+                code="invalid_parameter",
+            )
+
+
 def audio_effects(
     input_path: str,
     output: str,
@@ -274,6 +296,8 @@ def audio_effects(
     Returns:
         Path to processed WAV file
     """
+    _validate_audio_effects(effects)
+
     # Read input
     with wave.open(input_path, "rb") as wav_file:
         sample_rate = wav_file.getframerate()

--- a/tests/test_audio_sequencing.py
+++ b/tests/test_audio_sequencing.py
@@ -230,6 +230,20 @@ class TestAudioEffects:
         result = audio_effects(src, output, [])
         assert Path(result).exists()
 
+    def test_unknown_effect_rejected(self, tmp_path):
+        src = _make_wav(str(tmp_path / "src.wav"))
+        output = str(tmp_path / "out.wav")
+        with pytest.raises(MCPVideoError, match="type"):
+            audio_effects(src, output, [{"type": "bitcrush"}])
+        assert not Path(output).exists()
+
+    def test_missing_effect_type_rejected(self, tmp_path):
+        src = _make_wav(str(tmp_path / "src.wav"))
+        output = str(tmp_path / "out.wav")
+        with pytest.raises(MCPVideoError, match="type"):
+            audio_effects(src, output, [{"frequency": 1000}])
+        assert not Path(output).exists()
+
     def test_chain_of_effects(self, tmp_path):
         src = _make_wav(str(tmp_path / "src.wav"))
         output = str(tmp_path / "out.wav")

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -425,6 +425,16 @@ class TestClientValidators:
                 assert not isinstance(exc_info.value, ValueError)
 
 
+class TestClientAudioEffectsValidation:
+    def test_audio_effects_rejects_unknown_effect_type(self, editor):
+        with pytest.raises(MCPVideoError, match="type"):
+            editor.audio_effects("/tmp/in.wav", "/tmp/out.wav", [{"type": "bitcrush"}])
+
+    def test_audio_effects_rejects_missing_effect_type(self, editor):
+        with pytest.raises(MCPVideoError, match="type"):
+            editor.audio_effects("/tmp/in.wav", "/tmp/out.wav", [{"frequency": 1000}])
+
+
 class TestClientAudioSequenceValidation:
     def test_audio_sequence_rejects_empty_sequence(self, editor):
         with pytest.raises(MCPVideoError, match="sequence"):


### PR DESCRIPTION
## Summary
- validate direct audio effects chains before media IO
- reject unknown and missing effect types instead of silently skipping them
- add client/direct regression coverage for the validation boundary

## Verification
- python3 -m pytest tests/test_audio_sequencing.py::TestAudioEffects tests/test_client.py::TestClientAudioEffectsValidation -q
- python3 -m pytest tests/test_audio_sequencing.py tests/test_client.py -q
- python3 -m ruff check .
- python3 -m ruff format --check mcp_video/audio_engine/sequencing.py tests/test_audio_sequencing.py tests/test_client.py
- python3 -m pytest tests/ -x -q --tb=short
- python3 -c "import mcp_video"

## Known unrelated drift
- full repo format check still has pre-existing formatting drift in examples/agent_cookbook.py; changed files are formatted.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/mcp-video/pr/287"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->