### PR TITLE
Reject invalid audio preset controls

### DIFF
--- a/mcp_video/audio_engine/synthesis.py
+++ b/mcp_video/audio_engine/synthesis.py
@@ -169,6 +169,19 @@ def audio_preset(
     """
     from .presets import _PITCH_MULT, get_preset_config
 
+    if pitch not in _PITCH_MULT:
+        raise MCPVideoError(
+            f"pitch must be one of {sorted(_PITCH_MULT)}, got {pitch!r}",
+            error_type="validation_error",
+            code="invalid_parameter",
+        )
+    if not isinstance(intensity, (int, float)) or intensity < 0 or intensity > 1:
+        raise MCPVideoError(
+            f"intensity must be between 0 and 1, got {intensity}",
+            error_type="validation_error",
+            code="invalid_parameter",
+        )
+
     try:
         config = get_preset_config(preset)
     except KeyError as exc:
@@ -178,7 +191,7 @@ def audio_preset(
             code="invalid_parameter",
         ) from None
 
-    mult = _PITCH_MULT.get(pitch, 1.0)
+    mult = _PITCH_MULT[pitch]
     config["frequency"] = config["frequency"] * mult
 
     if duration is not None:

--- a/tests/test_audio_presets.py
+++ b/tests/test_audio_presets.py
@@ -50,6 +50,20 @@ class TestAudioPresetOrchestration:
         result = audio_preset("ui-blip", output, pitch="high")
         assert result == output
 
+    def test_unknown_pitch_rejected(self, tmp_path):
+        output = str(tmp_path / "out.wav")
+        from mcp_video.audio_engine.synthesis import audio_preset
+
+        with pytest.raises(MCPVideoError, match="pitch"):
+            audio_preset("ui-blip", output, pitch="bass")
+
+    def test_invalid_intensity_rejected(self, tmp_path):
+        output = str(tmp_path / "out.wav")
+        from mcp_video.audio_engine.synthesis import audio_preset
+
+        with pytest.raises(MCPVideoError, match="intensity"):
+            audio_preset("typing", output, intensity=2.0)
+
     def test_duration_override(self, tmp_path):
         output = str(tmp_path / "out.wav")
         from mcp_video.audio_engine.synthesis import audio_preset

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -528,6 +528,14 @@ class TestClientAgentApiConsistency:
         with pytest.raises(MCPVideoError, match="audio_preset\\(\\) requires output_path"):
             editor.audio_preset("ui-blip")
 
+    def test_audio_preset_rejects_unknown_pitch(self, editor):
+        with pytest.raises(MCPVideoError, match="pitch"):
+            editor.audio_preset("ui-blip", output_path="/tmp/out.wav", pitch="bass")
+
+    def test_audio_preset_rejects_invalid_intensity(self, editor):
+        with pytest.raises(MCPVideoError, match="intensity"):
+            editor.audio_preset("typing", output_path="/tmp/out.wav", intensity=2.0)
+
     def test_scanlines_accepts_intensity_alias_with_warning(self, editor, monkeypatch):
         monkeypatch.setattr("mcp_video.effects_engine.effect_scanlines", lambda **kwargs: kwargs["output"])
 


### PR DESCRIPTION
## Summary
- reject unknown audio preset pitch values instead of silently falling back to mid pitch
- reject invalid intensity values before rendering
- add direct/client regression coverage for preset validation

## Verification
- python3 -m pytest tests/test_audio_presets.py::TestAudioPresetOrchestration tests/test_client.py::TestClientAgentApiConsistency::test_audio_preset_rejects_unknown_pitch tests/test_client.py::TestClientAgentApiConsistency::test_audio_preset_rejects_invalid_intensity -q
- python3 -m pytest tests/test_audio_presets.py tests/test_client.py -q
- python3 -m ruff check .
- python3 -m pytest tests/ -x -q --tb=short
- python3 -c "import mcp_video"
- python3 -m ruff format --check mcp_video/audio_engine/synthesis.py tests/test_audio_presets.py tests/test_client.py

## Known unrelated drift
- full repo format check still has pre-existing formatting drift in examples/agent_cookbook.py; changed files are formatted.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/mcp-video/pr/288"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->