### PR TITLE
Reject unknown synth effect keys

### DIFF
--- a/mcp_video/audio_engine/synthesis.py
+++ b/mcp_video/audio_engine/synthesis.py
@@ -32,6 +32,24 @@ DEFAULT_SAMPLE_RATE = 44100
 DEFAULT_CHANNELS = 1
 DEFAULT_SAMPLE_WIDTH = 2  # 16-bit
 
+VALID_AUDIO_SYNTH_EFFECT_KEYS = {"envelope", "fade_in", "fade_out", "reverb", "lowpass"}
+
+
+def _validate_synth_effects(effects: dict[str, Any] | None) -> None:
+    """Validate synthesis effect keys before generating output."""
+    if effects is None:
+        return
+    if not isinstance(effects, dict):
+        raise MCPVideoError("effects must be a dict", error_type="validation_error", code="invalid_parameter")
+
+    unknown = sorted(set(effects) - VALID_AUDIO_SYNTH_EFFECT_KEYS)
+    if unknown:
+        raise MCPVideoError(
+            f"effects keys must be one of {sorted(VALID_AUDIO_SYNTH_EFFECT_KEYS)}, got unsupported keys {unknown}",
+            error_type="validation_error",
+            code="invalid_parameter",
+        )
+
 
 def audio_synthesize(
     output: str,
@@ -62,6 +80,8 @@ def audio_synthesize(
         Path to generated WAV file
     """
     from ..limits import MAX_AUDIO_DURATION, MIN_FREQUENCY, MAX_FREQUENCY, MIN_SAMPLE_RATE, MAX_SAMPLE_RATE
+
+    _validate_synth_effects(effects)
 
     if not (MIN_FREQUENCY <= frequency <= MAX_FREQUENCY):
         raise MCPVideoError(

--- a/tests/test_adversarial_audit.py
+++ b/tests/test_adversarial_audit.py
@@ -309,6 +309,15 @@ class TestParameterBounds:
         with pytest.raises(MCPVideoError, match=r"[Vv]olume"):
             audio_synthesize("/tmp/test.wav", volume=1.5)
 
+    def test_audio_synthesize_rejects_unknown_effect_key(self, tmp_path) -> None:
+        """Unknown synth effect keys are rejected before producing output."""
+        from mcp_video.audio_engine import audio_synthesize
+
+        output = tmp_path / "out.wav"
+        with pytest.raises(MCPVideoError, match="effects"):
+            audio_synthesize(str(output), effects={"bitcrush": 0.5})
+        assert not output.exists()
+
     def test_audio_valid_bounds(self) -> None:
         """Valid bounds at edges are accepted."""
         from mcp_video.audio_engine import audio_synthesize

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -424,6 +424,10 @@ class TestClientValidators:
                     editor.convert("/nonexistent/video.mp4", format=fmt, quality=q)
                 assert not isinstance(exc_info.value, ValueError)
 
+    def test_audio_synthesize_rejects_unknown_effect_key(self, editor):
+        with pytest.raises(MCPVideoError, match="effects"):
+            editor.audio_synthesize(output="/tmp/out.wav", effects={"bitcrush": 0.5})
+
 
 class TestClientAudioEffectsValidation:
     def test_audio_effects_rejects_unknown_effect_type(self, editor):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -900,6 +900,15 @@ class TestServerToolPathValidation:
 
 
 class TestServerReleaseGuardrails:
+    def test_audio_synthesize_rejects_unknown_effect_key_before_render(self, tmp_path):
+        from mcp_video import server_tools_audio
+
+        result = server_tools_audio.audio_synthesize(str(tmp_path / "out.wav"), effects={"bitcrush": 0.5})
+
+        assert result["success"] is False
+        assert "effects" in result["error"]["message"].lower()
+        assert not (tmp_path / "out.wav").exists()
+
     def test_audio_preset_warns_for_long_procedural_music_bed(self, monkeypatch, tmp_path):
         from mcp_video import server_tools_audio
 


### PR DESCRIPTION
## Summary
- validate audio_synthesize effect dictionaries before generating output
- reject unsupported effect keys instead of silently ignoring requested processing
- cover direct engine, Python client, and MCP server result behavior

## Verification
- python3 -m pytest tests/test_adversarial_audit.py::TestParameterBounds::test_audio_synthesize_rejects_unknown_effect_key tests/test_client.py::TestClientValidators::test_audio_synthesize_rejects_unknown_effect_key tests/test_server.py::TestServerReleaseGuardrails::test_audio_synthesize_rejects_unknown_effect_key_before_render -q
- python3 -m pytest tests/test_adversarial_audit.py tests/test_client.py tests/test_server.py -q
- python3 -m ruff check .
- python3 -m pytest tests/ -x -q --tb=short
- python3 -c "import mcp_video"
- python3 -m ruff format --check mcp_video/audio_engine/synthesis.py tests/test_adversarial_audit.py tests/test_client.py tests/test_server.py

## Known unrelated drift
- full repo format check still has pre-existing formatting drift in examples/agent_cookbook.py; changed files are formatted.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/mcp-video/pr/289"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->