### PR TITLE
Reject invalid audio compose shape

### DIFF
--- a/mcp_video/audio_engine/sequencing.py
+++ b/mcp_video/audio_engine/sequencing.py
@@ -183,6 +183,29 @@ def audio_sequence(
     return write_wav(pcm_data, output, sample_rate)
 
 
+def _validate_audio_compose_tracks(tracks: list[dict[str, Any]], duration: float) -> None:
+    """Validate compose tracks before allocating or writing output."""
+    if duration <= 0:
+        raise MCPVideoError("duration must be > 0", error_type="validation_error", code="invalid_parameter")
+    if not isinstance(tracks, list) or not tracks:
+        raise MCPVideoError("tracks cannot be empty", error_type="validation_error", code="invalid_parameter")
+
+    for i, track in enumerate(tracks):
+        if not isinstance(track, dict):
+            raise MCPVideoError(
+                f"tracks[{i}] must be a dict",
+                error_type="validation_error",
+                code="invalid_parameter",
+            )
+        volume = track.get("volume", 1.0)
+        if not isinstance(volume, (int, float)) or volume < 0 or volume > 1:
+            raise MCPVideoError(
+                f"tracks[{i}].volume must be between 0 and 1, got {volume}",
+                error_type="validation_error",
+                code="invalid_parameter",
+            )
+
+
 def audio_compose(
     tracks: list[dict[str, Any]],
     duration: float,
@@ -204,6 +227,8 @@ def audio_compose(
     Returns:
         Path to generated WAV file
     """
+    _validate_audio_compose_tracks(tracks, duration)
+
     total_samples = int(duration * sample_rate)
     mix_buffer = [0.0] * total_samples
 

--- a/tests/test_audio_sequencing.py
+++ b/tests/test_audio_sequencing.py
@@ -127,6 +127,32 @@ class TestAudioCompose:
             audio_compose([{"volume": 0.5}], duration=0.1, output=output, sample_rate=8000)
         assert not Path(output).exists()
 
+    def test_compose_empty_tracks_rejected(self, tmp_path):
+        output = str(tmp_path / "out.wav")
+        with pytest.raises(MCPVideoError, match="tracks"):
+            audio_compose([], duration=0.1, output=output, sample_rate=8000)
+        assert not Path(output).exists()
+
+    def test_compose_non_dict_track_rejected(self, tmp_path):
+        output = str(tmp_path / "out.wav")
+        with pytest.raises(MCPVideoError, match=r"tracks\[0\]"):
+            audio_compose([None], duration=0.1, output=output, sample_rate=8000)
+        assert not Path(output).exists()
+
+    def test_compose_non_positive_duration_rejected(self, tmp_path):
+        track = _make_wav(str(tmp_path / "track.wav"))
+        output = str(tmp_path / "out.wav")
+        with pytest.raises(MCPVideoError, match="duration"):
+            audio_compose([{"file": track}], duration=0, output=output, sample_rate=8000)
+        assert not Path(output).exists()
+
+    def test_compose_invalid_volume_rejected(self, tmp_path):
+        track = _make_wav(str(tmp_path / "track.wav"))
+        output = str(tmp_path / "out.wav")
+        with pytest.raises(MCPVideoError, match="volume"):
+            audio_compose([{"file": track, "volume": 2.0}], duration=0.1, output=output, sample_rate=8000)
+        assert not Path(output).exists()
+
     def test_compose_multiple_tracks(self, tmp_path):
         t1 = _make_wav(str(tmp_path / "t1.wav"), freq=440)
         t2 = _make_wav(str(tmp_path / "t2.wav"), freq=880)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -469,6 +469,10 @@ class TestClientAudioComposeValidation:
         with pytest.raises(MCPVideoError, match="file"):
             editor.audio_compose([{"volume": 0.5}], duration=1.0, output="/tmp/out.wav")
 
+    def test_audio_compose_rejects_invalid_volume(self, editor):
+        with pytest.raises(MCPVideoError, match="volume"):
+            editor.audio_compose([{"file": "/tmp/a.wav", "volume": 2.0}], duration=1.0, output="/tmp/out.wav")
+
 
 class TestClientTextAnimatedValidation:
     def test_text_animated_rejects_empty_text(self, editor):


### PR DESCRIPTION
## Summary
- validate direct audio compose track shape before allocation and media IO
- reject empty tracks, non-dict tracks, invalid durations, and out-of-range volumes explicitly
- add direct/client regression coverage for compose validation parity

## Verification
- python3 -m pytest tests/test_audio_sequencing.py::TestAudioCompose tests/test_client.py::TestClientAudioComposeValidation -q
- python3 -m pytest tests/test_audio_sequencing.py tests/test_client.py -q
- python3 -m ruff check .
- python3 -m pytest tests/ -x -q --tb=short
- python3 -c "import mcp_video"
- python3 -m ruff format --check mcp_video/audio_engine/sequencing.py tests/test_audio_sequencing.py tests/test_client.py

## Known unrelated drift
- full repo format check still has pre-existing formatting drift in examples/agent_cookbook.py; changed files are formatted.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/mcp-video/pr/290"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->