### PR TITLE
Return None on design-quality probe failure, not perfect sentinels

### DIFF
--- a/mcp_video/design_quality/guardrails/checks.py
+++ b/mcp_video/design_quality/guardrails/checks.py
@@ -54,6 +54,17 @@ class ChecksMixin:
         mean_luma = self._get_mean_luma(video_path)
         color_stats = self._analyze_colors(video_path)
 
+        if mean_luma is None:
+            self.issues.append(
+                DesignIssue(
+                    category="typography",
+                    severity="info",
+                    message="Brightness analysis unavailable — skipped readability check.",
+                    fix_available=False,
+                )
+            )
+            return
+
         # Check if this is an intentional dark brand theme
         is_dark_brand = self._is_dark_brand_theme(mean_luma, color_stats)
 

--- a/mcp_video/design_quality/guardrails/probe.py
+++ b/mcp_video/design_quality/guardrails/probe.py
@@ -56,10 +56,18 @@ class ProbeMixin:
         duration = probe.get("duration", 0)
         return float(duration) if duration else 0
 
-    def _get_mean_luma(self, video_path: str) -> float:
-        """Get mean luminance."""
+    def _get_mean_luma(self, video_path: str) -> float | None:
+        """Get mean luminance. Returns None if analysis fails."""
         cmd = ["ffmpeg", "-i", video_path, "-vf", "signalstats,metadata=mode=print", "-f", "null", "-"]
-        result = subprocess.run(cmd, capture_output=True, text=True, timeout=DEFAULT_FFMPEG_TIMEOUT)
+        try:
+            result = subprocess.run(cmd, capture_output=True, text=True, timeout=DEFAULT_FFMPEG_TIMEOUT)
+        except subprocess.TimeoutExpired:
+            logger.warning("ffmpeg signalstats timed out for %s", video_path)
+            return None
+
+        if result.returncode != 0:
+            logger.warning("ffmpeg signalstats failed for %s: %s", video_path, result.stderr[:200])
+            return None
 
         for line in result.stderr.split("\n"):
             if "lavfi.signalstats.YAVG" in line:
@@ -67,13 +75,21 @@ class ProbeMixin:
                     return float(line.split("=")[-1].strip())
                 except Exception as exc:
                     logger.debug("Luma parsing failed: %s", exc)
-                    pass
-        return 128
+        logger.warning("No YAVG signalstats found for %s", video_path)
+        return None
 
-    def _get_contrast(self, video_path: str) -> float:
-        """Get contrast (standard deviation of luminance)."""
+    def _get_contrast(self, video_path: str) -> float | None:
+        """Get contrast (standard deviation of luminance). Returns None if analysis fails."""
         cmd = ["ffmpeg", "-i", video_path, "-vf", "signalstats,metadata=mode=print", "-f", "null", "-"]
-        result = subprocess.run(cmd, capture_output=True, text=True, timeout=DEFAULT_FFMPEG_TIMEOUT)
+        try:
+            result = subprocess.run(cmd, capture_output=True, text=True, timeout=DEFAULT_FFMPEG_TIMEOUT)
+        except subprocess.TimeoutExpired:
+            logger.warning("ffmpeg signalstats timed out for %s", video_path)
+            return None
+
+        if result.returncode != 0:
+            logger.warning("ffmpeg signalstats failed for %s: %s", video_path, result.stderr[:200])
+            return None
 
         for line in result.stderr.split("\n"):
             if "lavfi.signalstats.YSTD" in line:
@@ -81,5 +97,5 @@ class ProbeMixin:
                     return float(line.split("=")[-1].strip())
                 except Exception as exc:
                     logger.debug("Contrast parsing failed: %s", exc)
-                    pass
-        return 50
+        logger.warning("No YSTD signalstats found for %s", video_path)
+        return None

--- a/mcp_video/design_quality/guardrails/scoring.py
+++ b/mcp_video/design_quality/guardrails/scoring.py
@@ -21,36 +21,42 @@ class ScoringMixin:
         Brand-aware scoring:
         - Dark themes (luma < 50) are not penalized as harshly
         - This accounts for intentional dark brand aesthetics
+
+        When luma or contrast analysis fails, uses a neutral 50 score
+        for that metric instead of a perfect score.
         """
         mean_luma = self._get_mean_luma(video_path)
         color_stats = self._analyze_colors(video_path)
 
-        # Check if this is an intentional dark brand theme
-        is_dark_brand_theme = self._is_dark_brand_theme(mean_luma, color_stats)
-
-        if is_dark_brand_theme:
-            # For dark brand themes, use a gentler scoring curve
-            # that doesn't penalize the intentional aesthetic
-            if mean_luma < 30:
-                brightness_score = 65  # Very dark but intentional
-            elif mean_luma < 50:
-                brightness_score = 75  # Dark but acceptable
-            elif mean_luma < 70:
-                brightness_score = 85  # Elevated dark
-            else:
-                brightness_score = max(0, 100 - abs(mean_luma - 128) / 2.56)
+        if mean_luma is None:
+            brightness_score = 50
         else:
-            # Standard scoring for non-brand content
-            brightness_score = max(0, 100 - abs(mean_luma - 128) / 1.28)
+            # Check if this is an intentional dark brand theme
+            is_dark_brand_theme = self._is_dark_brand_theme(mean_luma, color_stats)
+
+            if is_dark_brand_theme:
+                # For dark brand themes, use a gentler scoring curve
+                # that doesn't penalize the intentional aesthetic
+                if mean_luma < 30:
+                    brightness_score = 65  # Very dark but intentional
+                elif mean_luma < 50:
+                    brightness_score = 75  # Dark but acceptable
+                elif mean_luma < 70:
+                    brightness_score = 85  # Elevated dark
+                else:
+                    brightness_score = max(0, 100 - abs(mean_luma - 128) / 2.56)
+            else:
+                # Standard scoring for non-brand content
+                brightness_score = max(0, 100 - abs(mean_luma - 128) / 1.28)
 
         contrast = self._get_contrast(video_path)
-        contrast_score = min(100, contrast * 2)
+        contrast_score = min(100, contrast * 2) if contrast is not None else 50
 
         audio_score = self._calculate_audio_score(video_path)
 
         return (brightness_score + contrast_score + audio_score) / 3
 
-    def _is_dark_brand_theme(self, mean_luma: float, color_stats: dict) -> bool:
+    def _is_dark_brand_theme(self, mean_luma: float | None, color_stats: dict) -> bool:
         """Detect if video uses an intentional dark brand theme.
 
         Checks for:
@@ -58,7 +64,7 @@ class ScoringMixin:
         - Brand color presence (Electric Lime, Midnight Violet)
         - Consistent color palette
         """
-        if mean_luma > 60:
+        if mean_luma is None or mean_luma > 60:
             return False
 
         rgb_means = color_stats.get("rgb_means", [128, 128, 128])

--- a/tests/test_design_quality_fallback.py
+++ b/tests/test_design_quality_fallback.py
@@ -33,8 +33,7 @@ class TestGetMeanLumaFallback:
         """When ffmpeg stderr has no YAVG line, return None not 128."""
         with patch("mcp_video.design_quality.guardrails.probe.subprocess.run") as mock_run:
             mock_run.return_value = FakeCompletedProcess(
-                stderr="frame=   10 fps=0.0 q=-1.0 N/A\n"
-                       "some other output without signalstats\n",
+                stderr="frame=   10 fps=0.0 q=-1.0 N/A\nsome other output without signalstats\n",
             )
             result = guardrails._get_mean_luma("/tmp/nonexistent.mp4")
             assert result is None, f"Expected None on parse failure, got {result}"
@@ -57,8 +56,7 @@ class TestGetContrastFallback:
         """When ffmpeg stderr has no YSTD line, return None not 50."""
         with patch("mcp_video.design_quality.guardrails.probe.subprocess.run") as mock_run:
             mock_run.return_value = FakeCompletedProcess(
-                stderr="frame=   10 fps=0.0 q=-1.0 N/A\n"
-                       "some other output without signalstats\n",
+                stderr="frame=   10 fps=0.0 q=-1.0 N/A\nsome other output without signalstats\n",
             )
             result = guardrails._get_contrast("/tmp/nonexistent.mp4")
             assert result is None, f"Expected None on parse failure, got {result}"
@@ -86,10 +84,7 @@ class TestTechnicalScoreDoesNotRewardFailure:
             patch.object(guardrails, "_analyze_colors", return_value={"rgb_means": [128, 128, 128], "saturation": 50}),
         ):
             score = guardrails._calculate_technical_score("/tmp/test.mp4")
-            assert score < 100, (
-                f"Technical score should not be perfect when luma analysis "
-                f"failed, got {score}"
-            )
+            assert score < 100, f"Technical score should not be perfect when luma analysis failed, got {score}"
 
     def test_failed_contrast_does_not_score_100(self, guardrails):
         """When _get_contrast returns None, contrast score should not be 100."""
@@ -100,10 +95,7 @@ class TestTechnicalScoreDoesNotRewardFailure:
             patch.object(guardrails, "_analyze_colors", return_value={"rgb_means": [128, 128, 128], "saturation": 50}),
         ):
             score = guardrails._calculate_technical_score("/tmp/test.mp4")
-            assert score < 100, (
-                f"Technical score should not be perfect when contrast analysis "
-                f"failed, got {score}"
-            )
+            assert score < 100, f"Technical score should not be perfect when contrast analysis failed, got {score}"
 
 
 class TestCheckTypographyHandlesNone:
@@ -119,6 +111,5 @@ class TestCheckTypographyHandlesNone:
             guardrails._check_typography("/tmp/test.mp4")
             categories = [i.category for i in guardrails.issues]
             assert "typography" in categories, (
-                f"Expected a typography issue when luma analysis failed, "
-                f"got categories: {categories}"
+                f"Expected a typography issue when luma analysis failed, got categories: {categories}"
             )

--- a/tests/test_design_quality_fallback.py
+++ b/tests/test_design_quality_fallback.py
@@ -7,7 +7,6 @@ They should return None so callers can record uncertainty explicitly.
 
 from __future__ import annotations
 
-import subprocess
 from unittest.mock import patch
 
 import pytest
@@ -80,27 +79,31 @@ class TestTechnicalScoreDoesNotRewardFailure:
 
     def test_failed_luma_does_not_score_100(self, guardrails):
         """When _get_mean_luma returns None, brightness score should not be 100."""
-        with patch.object(guardrails, "_get_mean_luma", return_value=None):
-            with patch.object(guardrails, "_get_contrast", return_value=50):
-                with patch.object(guardrails, "_calculate_audio_score", return_value=50):
-                    with patch.object(guardrails, "_analyze_colors", return_value={"rgb_means": [128, 128, 128], "saturation": 50}):
-                        score = guardrails._calculate_technical_score("/tmp/test.mp4")
-                        assert score < 100, (
-                            f"Technical score should not be perfect when luma analysis "
-                            f"failed, got {score}"
-                        )
+        with (
+            patch.object(guardrails, "_get_mean_luma", return_value=None),
+            patch.object(guardrails, "_get_contrast", return_value=50),
+            patch.object(guardrails, "_calculate_audio_score", return_value=50),
+            patch.object(guardrails, "_analyze_colors", return_value={"rgb_means": [128, 128, 128], "saturation": 50}),
+        ):
+            score = guardrails._calculate_technical_score("/tmp/test.mp4")
+            assert score < 100, (
+                f"Technical score should not be perfect when luma analysis "
+                f"failed, got {score}"
+            )
 
     def test_failed_contrast_does_not_score_100(self, guardrails):
         """When _get_contrast returns None, contrast score should not be 100."""
-        with patch.object(guardrails, "_get_mean_luma", return_value=128):
-            with patch.object(guardrails, "_get_contrast", return_value=None):
-                with patch.object(guardrails, "_calculate_audio_score", return_value=50):
-                    with patch.object(guardrails, "_analyze_colors", return_value={"rgb_means": [128, 128, 128], "saturation": 50}):
-                        score = guardrails._calculate_technical_score("/tmp/test.mp4")
-                        assert score < 100, (
-                            f"Technical score should not be perfect when contrast analysis "
-                            f"failed, got {score}"
-                        )
+        with (
+            patch.object(guardrails, "_get_mean_luma", return_value=128),
+            patch.object(guardrails, "_get_contrast", return_value=None),
+            patch.object(guardrails, "_calculate_audio_score", return_value=50),
+            patch.object(guardrails, "_analyze_colors", return_value={"rgb_means": [128, 128, 128], "saturation": 50}),
+        ):
+            score = guardrails._calculate_technical_score("/tmp/test.mp4")
+            assert score < 100, (
+                f"Technical score should not be perfect when contrast analysis "
+                f"failed, got {score}"
+            )
 
 
 class TestCheckTypographyHandlesNone:
@@ -108,12 +111,14 @@ class TestCheckTypographyHandlesNone:
 
     def test_adds_issue_when_luma_is_none(self, guardrails):
         """When _get_mean_luma returns None, an advisory issue should be recorded."""
-        with patch.object(guardrails, "_get_mean_luma", return_value=None):
-            with patch.object(guardrails, "_analyze_colors", return_value={"rgb_means": [128, 128, 128], "saturation": 50}):
-                guardrails.issues = []
-                guardrails._check_typography("/tmp/test.mp4")
-                categories = [i.category for i in guardrails.issues]
-                assert "typography" in categories, (
-                    f"Expected a typography issue when luma analysis failed, "
-                    f"got categories: {categories}"
-                )
+        with (
+            patch.object(guardrails, "_get_mean_luma", return_value=None),
+            patch.object(guardrails, "_analyze_colors", return_value={"rgb_means": [128, 128, 128], "saturation": 50}),
+        ):
+            guardrails.issues = []
+            guardrails._check_typography("/tmp/test.mp4")
+            categories = [i.category for i in guardrails.issues]
+            assert "typography" in categories, (
+                f"Expected a typography issue when luma analysis failed, "
+                f"got categories: {categories}"
+            )

--- a/tests/test_design_quality_fallback.py
+++ b/tests/test_design_quality_fallback.py
@@ -1,0 +1,119 @@
+"""Regression tests for design_quality probe fallback values.
+
+When ffprobe/ffmpeg output parsing fails, _get_mean_luma and _get_contrast
+must NOT return sentinel values (128/50) that produce perfect scores.
+They should return None so callers can record uncertainty explicitly.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import patch
+
+import pytest
+
+
+class FakeCompletedProcess:
+    def __init__(self, stdout: str = "", stderr: str = "", returncode: int = 0):
+        self.stdout = stdout
+        self.stderr = stderr
+        self.returncode = returncode
+
+
+@pytest.fixture()
+def guardrails():
+    from mcp_video.design_quality.guardrails import DesignQualityGuardrails
+
+    return DesignQualityGuardrails()
+
+
+class TestGetMeanLumaFallback:
+    """_get_mean_luma must not return 128 when parsing fails."""
+
+    def test_returns_none_when_no_yavg_line(self, guardrails):
+        """When ffmpeg stderr has no YAVG line, return None not 128."""
+        with patch("mcp_video.design_quality.guardrails.probe.subprocess.run") as mock_run:
+            mock_run.return_value = FakeCompletedProcess(
+                stderr="frame=   10 fps=0.0 q=-1.0 N/A\n"
+                       "some other output without signalstats\n",
+            )
+            result = guardrails._get_mean_luma("/tmp/nonexistent.mp4")
+            assert result is None, f"Expected None on parse failure, got {result}"
+
+    def test_returns_none_when_subprocess_fails(self, guardrails):
+        """When ffmpeg returns non-zero exit, return None not 128."""
+        with patch("mcp_video.design_quality.guardrails.probe.subprocess.run") as mock_run:
+            mock_run.return_value = FakeCompletedProcess(
+                stderr="Error opening input file\n",
+                returncode=1,
+            )
+            result = guardrails._get_mean_luma("/tmp/nonexistent.mp4")
+            assert result is None, f"Expected None on subprocess failure, got {result}"
+
+
+class TestGetContrastFallback:
+    """_get_contrast must not return 50 when parsing fails."""
+
+    def test_returns_none_when_no_ystd_line(self, guardrails):
+        """When ffmpeg stderr has no YSTD line, return None not 50."""
+        with patch("mcp_video.design_quality.guardrails.probe.subprocess.run") as mock_run:
+            mock_run.return_value = FakeCompletedProcess(
+                stderr="frame=   10 fps=0.0 q=-1.0 N/A\n"
+                       "some other output without signalstats\n",
+            )
+            result = guardrails._get_contrast("/tmp/nonexistent.mp4")
+            assert result is None, f"Expected None on parse failure, got {result}"
+
+    def test_returns_none_when_subprocess_fails(self, guardrails):
+        """When ffmpeg returns non-zero exit, return None not 50."""
+        with patch("mcp_video.design_quality.guardrails.probe.subprocess.run") as mock_run:
+            mock_run.return_value = FakeCompletedProcess(
+                stderr="Error opening input file\n",
+                returncode=1,
+            )
+            result = guardrails._get_contrast("/tmp/nonexistent.mp4")
+            assert result is None, f"Expected None on subprocess failure, got {result}"
+
+
+class TestTechnicalScoreDoesNotRewardFailure:
+    """When luma/contrast analysis fails, technical score must not be perfect."""
+
+    def test_failed_luma_does_not_score_100(self, guardrails):
+        """When _get_mean_luma returns None, brightness score should not be 100."""
+        with patch.object(guardrails, "_get_mean_luma", return_value=None):
+            with patch.object(guardrails, "_get_contrast", return_value=50):
+                with patch.object(guardrails, "_calculate_audio_score", return_value=50):
+                    with patch.object(guardrails, "_analyze_colors", return_value={"rgb_means": [128, 128, 128], "saturation": 50}):
+                        score = guardrails._calculate_technical_score("/tmp/test.mp4")
+                        assert score < 100, (
+                            f"Technical score should not be perfect when luma analysis "
+                            f"failed, got {score}"
+                        )
+
+    def test_failed_contrast_does_not_score_100(self, guardrails):
+        """When _get_contrast returns None, contrast score should not be 100."""
+        with patch.object(guardrails, "_get_mean_luma", return_value=128):
+            with patch.object(guardrails, "_get_contrast", return_value=None):
+                with patch.object(guardrails, "_calculate_audio_score", return_value=50):
+                    with patch.object(guardrails, "_analyze_colors", return_value={"rgb_means": [128, 128, 128], "saturation": 50}):
+                        score = guardrails._calculate_technical_score("/tmp/test.mp4")
+                        assert score < 100, (
+                            f"Technical score should not be perfect when contrast analysis "
+                            f"failed, got {score}"
+                        )
+
+
+class TestCheckTypographyHandlesNone:
+    """_check_typography must not silently pass when luma analysis fails."""
+
+    def test_adds_issue_when_luma_is_none(self, guardrails):
+        """When _get_mean_luma returns None, an advisory issue should be recorded."""
+        with patch.object(guardrails, "_get_mean_luma", return_value=None):
+            with patch.object(guardrails, "_analyze_colors", return_value={"rgb_means": [128, 128, 128], "saturation": 50}):
+                guardrails.issues = []
+                guardrails._check_typography("/tmp/test.mp4")
+                categories = [i.category for i in guardrails.issues]
+                assert "typography" in categories, (
+                    f"Expected a typography issue when luma analysis failed, "
+                    f"got categories: {categories}"
+                )


### PR DESCRIPTION
## Summary

- `ProbeMixin._get_mean_luma` returned 128 (mid-gray) and `_get_contrast` returned 50 (mid-contrast) when ffmpeg signalstats output parsing failed
- These sentinels produced perfect technical scores (brightness=100, contrast=100) even though analysis never actually ran
- `_calculate_technical_score` now uses a neutral 50 score when luma or contrast is None
- `_check_typography` records an advisory issue when luma analysis is unavailable
- `_is_dark_brand_theme` handles None luma gracefully (returns False)

## Verification

- 7 new regression tests proving the bug and fix
- Full suite: **1173 passed, 10 skipped** (up from 1166 — the 7 new tests account for the increase)
- `ruff check` / `ruff format --check`: clean
- `import mcp_video`: clean

## Test plan

- [x] `_get_mean_luma` returns None when no YAVG line in ffmpeg output
- [x] `_get_mean_luma` returns None on subprocess failure/timeout
- [x] `_get_contrast` returns None when no YSTD line in ffmpeg output
- [x] `_get_contrast` returns None on subprocess failure/timeout
- [x] `_calculate_technical_score` < 100 when luma is None
- [x] `_calculate_technical_score` < 100 when contrast is None
- [x] `_check_typography` adds an advisory issue when luma is None

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/mcp-video/pr/291"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->