### PR TITLE
Release v1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,14 +11,46 @@ This project follows a simple release-note style:
 
 ## Unreleased
 
+## 1.4.0 - 2026-05-09
+
 ### Added
 
 - Expanded Hyperframes orchestration for the 0.5 surface: snapshots, inspection, metadata, catalog, website capture, local TTS, transcription, background removal, diagnostics, benchmarks, and richer render controls.
 - Added local video repurposing helpers for dry-run manifests and platform-ready variants with thumbnails, storyboards, and optional release checkpoints.
+- Real `analyze_video(include_colors=True)` color extraction — returns actual dominant colors instead of placeholder values.
+- `video_info_detailed` now returns real dominant colors instead of `None`.
 
 ### Changed
 
 - Refreshed README, MCP tool docs, Python client docs, AI discovery, and `llms.txt` so PUSHING CREATION, Hyperframes, and repurposing are described as the current operator paths without centering test-count messaging.
+- Pipeline cleanup `OSError`s are now surfaced as warnings instead of being silently swallowed.
+
+### Fixed
+
+- Fixed green-cast video effects and 24-bit WAV handling in `effect_noise`, `video_overlay`, and audio effects.
+- Fixed 24-bit WAV handling in `audio_compose`.
+- Design quality probe now returns `None` on analysis failure instead of sentinel values (128 luma, 50 contrast) that produced perfect scores.
+- Typography check adds an advisory issue when brightness analysis is unavailable.
+- Reject unsupported Hyperframes render dimensions instead of silently accepting them.
+- Report Hyperframes render artifacts correctly by output format, including `png-sequence` directories.
+- Fail Hyperframes render-and-post/pipeline paths when render artifacts are missing.
+- Reject unknown text animations instead of silently ignoring them.
+- Reject empty animated text at engine and MCP/tool layers.
+- Reject invalid layout/PIP choices at tool and engine boundaries.
+- Validate mograph duration/fps/style and reject unknown progress style.
+- Reject unknown animated text positions.
+- Reject unknown watermark/overlay positions.
+- Reject malformed timeline image overlay position dicts before input probing.
+- Validate convert format/quality before probe/FFmpeg.
+- Validate HLS qualities and segment duration before probe/FFmpeg.
+- Reject unsupported `compare_quality` metrics instead of reporting meaningless `unknown`.
+- Validate `video_batch` operation names before input path validation.
+- Validate malformed subtitle entries/ranges before input path validation.
+- `audio_compose()` rejects missing track files, empty tracks, non-dict entries, non-positive duration, and invalid volume.
+- `audio_sequence()` rejects unknown/missing event types and unsupported tone waveforms.
+- `audio_effects()` rejects unknown/missing effect types.
+- `audio_preset()` rejects invalid pitch and intensity.
+- `audio_synthesize(effects={...})` rejects unknown effect keys.
 
 ## 1.3.10 - 2026-05-07
 

--- a/mcp_video/__init__.py
+++ b/mcp_video/__init__.py
@@ -1,6 +1,6 @@
 """mcp-video — Video editing MCP server for AI agents."""
 
-__version__ = "1.3.10"
+__version__ = "1.4.0"
 
 from .client import Client
 from .ai_engine import (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-video"
-version = "1.3.10"
+version = "1.4.0"
 description = "Video editing MCP server for AI agents. FFmpeg, PUSHING CREATION planning, Hyperframes, repurposing tools, Python client, and CLI. Local, fast, free."
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

Version bump to 1.4.0 with updated CHANGELOG covering all changes since v1.3.10.

### Highlights
- **New features**: Hyperframes 0.5 orchestration, video repurposing helpers, real color extraction in `analyze_video` and `video_info_detailed`
- **30+ hardening fixes** from the release-hardening sweep (PRs #263–#292): green-cast video effects, design quality sentinel values, and comprehensive input validation across audio, video, Hyperframes, timeline, template, and quality comparison paths
- **Pipeline robustness**: cleanup `OSError`s now surfaced as warnings

### Files changed
- `pyproject.toml` — version 1.3.10 → 1.4.0
- `mcp_video/__init__.py` — `__version__` 1.3.10 → 1.4.0
- `CHANGELOG.md` — 1.4.0 release notes

## Test plan
- [x] `python3 -c "from mcp_video import __version__; assert __version__ == '1.4.0'"` — passes
- [x] `python3 -m ruff check .` — clean
- [x] `python3 -m pytest tests/ -x -q --tb=short` — 1173 passed, 10 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/mcp-video/pr/293"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->