### PR TITLE
Add 12 CRUSH glitch video effects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,8 @@ venv/
 *.png
 !index.html
 .DS_Store
+node_modules/
+package-lock.json
 .worktrees/
 .omx/
 

--- a/mcp_video/_crush_shader/render_frames.mjs
+++ b/mcp_video/_crush_shader/render_frames.mjs
@@ -1,0 +1,281 @@
+#!/usr/bin/env node
+/**
+ * Headless CRUSH shader renderer — processes video frames via WebGL.
+ *
+ * Usage: node render_frames.mjs '<JSON config>'
+ *
+ * Config shape:
+ * {
+ *   "effect": "digital_feedback",
+ *   "inputDir": "/tmp/.../frames",
+ *   "outputDir": "/tmp/.../rendered",
+ *   "frameCount": 120,
+ *   "params": { "u_feedback_mix": 0.5, ... }
+ * }
+ */
+
+import { createCanvas, loadImage } from 'canvas';
+import { readFileSync, writeFileSync } from 'fs';
+import { join, resolve } from 'path';
+import { exit } from 'process';
+
+const ALLOWED_EFFECTS = new Set([
+    'digital_feedback', 'slit_scan', 'depth_splatting', 'point_cloud',
+]);
+
+const CRUSH_JS_SRC = resolve(import.meta.dirname, '../../../../CRUSH_SHADERS/crush-js/src');
+const MAX_FRAMES = 7200;
+const PAST_BUFFER_COUNT = 8;
+
+async function main() {
+    const config = JSON.parse(process.argv[2]);
+    const { effect, inputDir, outputDir, frameCount, params } = config;
+
+    // Validate effect name against allowlist
+    if (!ALLOWED_EFFECTS.has(effect)) {
+        console.error(`Invalid effect: ${effect}. Allowed: ${[...ALLOWED_EFFECTS].join(', ')}`);
+        exit(1);
+    }
+
+    // Cap frame count
+    if (frameCount > MAX_FRAMES) {
+        console.error(`Frame count ${frameCount} exceeds maximum ${MAX_FRAMES}`);
+        exit(1);
+    }
+
+    // Read effect GLSL sources
+    const commonGLSL = readFileSync(join(CRUSH_JS_SRC, 'common.glsl'), 'utf-8');
+    const effectGLSL = readFileSync(join(CRUSH_JS_SRC, 'effects', `${effect}.glsl`), 'utf-8');
+
+    // Create headless canvas at first frame's dimensions
+    const firstFrame = await loadImage(join(inputDir, 'frame_000001.png'));
+    const width = firstFrame.width;
+    const height = firstFrame.height;
+
+    const canvas = createCanvas(width, height);
+    const gl = canvas.getContext('webgl2') || canvas.getContext('webgl');
+
+    if (!gl) {
+        console.error('ERROR: WebGL not available in headless canvas');
+        exit(1);
+    }
+
+    // Compile shaders
+    const vertSrc = `
+        attribute vec2 a_position;
+        varying vec2 v_uv;
+        void main() {
+            v_uv = a_position * 0.5 + 0.5;
+            gl_Position = vec4(a_position, 0.0, 1.0);
+        }
+    `;
+
+    // Build fragment source: prepend common utilities (strip include guard)
+    const commonBody = commonGLSL
+        .replace('#ifndef CRUSH_COMMON_GLSL', '')
+        .replace('#define CRUSH_COMMON_GLSL', '')
+        .replace('#endif', '');
+    const fragSrc = `precision highp float;
+precision highp sampler2D;
+${commonBody}
+${effectGLSL.replace(/uniform sampler2D u_texture;/, 'uniform sampler2D u_texture;\nvarying vec2 v_uv;')
+             .replace(/gl_FragCoord\.xy \/ u_resolution/g, 'v_uv')}
+`;
+
+    const vertShader = compileShader(gl, gl.VERTEX_SHADER, vertSrc);
+    const fragShader = compileShader(gl, gl.FRAGMENT_SHADER, fragSrc);
+    const program = linkProgram(gl, vertShader, fragShader);
+
+    // Setup quad
+    const quadBuffer = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, quadBuffer);
+    gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([
+        -1, -1,  1, -1,  -1, 1,
+        -1,  1,  1, -1,   1, 1,
+    ]), gl.STATIC_DRAW);
+
+    const posLoc = gl.getAttribLocation(program, 'a_position');
+    gl.enableVertexAttribArray(posLoc);
+    gl.vertexAttribPointer(posLoc, 2, gl.FLOAT, false, 0, 0);
+
+    // Create input texture
+    const inputTex = createAndSetupTexture(gl, gl.TEXTURE0);
+
+    // Previous frame texture for digital_feedback
+    const prevTex = createAndSetupTexture(gl, gl.TEXTURE1);
+
+    // Multi-frame history textures for slit_scan
+    const pastTextures = [];
+    for (let i = 0; i < PAST_BUFFER_COUNT; i++) {
+        pastTextures.push(createAndSetupTexture(gl, gl.TEXTURE2 + i));
+    }
+
+    gl.useProgram(program);
+
+    // Introspect uniform types for correct dispatch
+    const uniformTypes = getUniformTypes(gl, program);
+
+    // Circular buffer for past frames (slit_scan)
+    const pastFrameBuffers = [];
+    for (let i = 0; i < PAST_BUFFER_COUNT; i++) {
+        pastFrameBuffers.push(null);
+    }
+    let pastWriteIdx = 0;
+
+    // Process frames
+    for (let i = 0; i < frameCount; i++) {
+        const frameNum = String(i + 1).padStart(6, '0');
+        const framePath = join(inputDir, `frame_${frameNum}.png`);
+
+        try {
+            const img = await loadImage(framePath);
+            const frameCanvas = createCanvas(width, height);
+            const ctx = frameCanvas.getContext('2d');
+            ctx.drawImage(img, 0, 0);
+            const imgData = ctx.getImageData(0, 0, width, height);
+
+            // Upload frame to texture
+            gl.activeTexture(gl.TEXTURE0);
+            gl.bindTexture(gl.TEXTURE_2D, inputTex);
+            gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, width, height, 0, gl.RGBA, gl.UNSIGNED_BYTE, imgData.data);
+
+            // Set sampler uniforms
+            setUniform(gl, program, uniformTypes, 'u_texture', 0);
+            setUniform(gl, program, uniformTypes, 'u_prev_frame', 1);
+            for (let j = 0; j < PAST_BUFFER_COUNT; j++) {
+                setUniform(gl, program, uniformTypes, `u_past_${j}`, 2 + j);
+            }
+            setUniform(gl, program, uniformTypes, 'u_resolution', [width, height]);
+            setUniform(gl, program, uniformTypes, 'u_time', i / 30.0);
+            setUniform(gl, program, uniformTypes, 'u_frame', i);
+
+            // Apply effect params with type-correct dispatch
+            for (const [key, val] of Object.entries(params)) {
+                setUniform(gl, program, uniformTypes, key, val);
+            }
+
+            // Render
+            gl.viewport(0, 0, width, height);
+            gl.drawArrays(gl.TRIANGLES, 0, 6);
+
+            // Read pixels
+            const pixels = new Uint8Array(width * height * 4);
+            gl.readPixels(0, 0, width, height, gl.RGBA, gl.UNSIGNED_BYTE, pixels);
+
+            // Copy to previous frame texture (digital_feedback)
+            gl.activeTexture(gl.TEXTURE1);
+            gl.bindTexture(gl.TEXTURE_2D, prevTex);
+            gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, width, height, 0, gl.RGBA, gl.UNSIGNED_BYTE, pixels);
+
+            // Rotate into past frame buffer (slit_scan)
+            pastFrameBuffers[pastWriteIdx] = new Uint8Array(pixels);
+            pastWriteIdx = (pastWriteIdx + 1) % PAST_BUFFER_COUNT;
+
+            // Upload past frame textures for slit_scan
+            for (let j = 0; j < PAST_BUFFER_COUNT; j++) {
+                // Most recent first: past_0 = frame just before current
+                const bufIdx = (pastWriteIdx - 1 - j + PAST_BUFFER_COUNT * 2) % PAST_BUFFER_COUNT;
+                const pastData = pastFrameBuffers[bufIdx];
+                if (pastData) {
+                    gl.activeTexture(gl.TEXTURE2 + j);
+                    gl.bindTexture(gl.TEXTURE_2D, pastTextures[j]);
+                    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, width, height, 0, gl.RGBA, gl.UNSIGNED_BYTE, pastData);
+                }
+            }
+
+            // Write output PNG
+            const outCanvas = createCanvas(width, height);
+            const outCtx = outCanvas.getContext('2d');
+            const outData = outCtx.createImageData(width, height);
+            outData.data.set(pixels);
+            outCtx.putImageData(outData, 0, 0);
+
+            const outBuf = outCanvas.toBuffer('image/png');
+            writeFileSync(join(outputDir, `frame_${frameNum}.png`), outBuf);
+
+            if ((i + 1) % 30 === 0) {
+                console.log(`Processed ${i + 1}/${frameCount} frames`);
+            }
+        } catch (err) {
+            console.error(`Error processing frame ${frameNum}: ${err.message}`);
+        }
+    }
+
+    console.log(`Done: ${frameCount} frames rendered`);
+}
+
+function createAndSetupTexture(gl, unit) {
+    gl.activeTexture(unit);
+    const tex = gl.createTexture();
+    gl.bindTexture(gl.TEXTURE_2D, tex);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+    return tex;
+}
+
+function getUniformTypes(gl, program) {
+    const types = {};
+    const count = gl.getProgramParameter(program, gl.ACTIVE_UNIFORMS);
+    for (let i = 0; i < count; i++) {
+        const info = gl.getActiveUniform(program, i);
+        if (info) types[info.name] = info.type;
+    }
+    return types;
+}
+
+function setUniform(gl, program, uniformTypes, name, value) {
+    const loc = gl.getUniformLocation(program, name);
+    if (loc === null) return;
+
+    const type = uniformTypes[name];
+
+    if (Array.isArray(value)) {
+        if (value.length === 2) gl.uniform2f(loc, value[0], value[1]);
+        else if (value.length === 3) gl.uniform3f(loc, value[0], value[1], value[2]);
+        else if (value.length === 4) gl.uniform4f(loc, value[0], value[1], value[2], value[3]);
+        return;
+    }
+
+    // Dispatch by GL type: SAMPLER and INT use uniform1i, FLOAT uses uniform1f
+    const glInt = (type === gl.SAMPLER_2D || type === gl.INT
+                   || type === gl.SAMPLER_CUBE || type === gl.UNSIGNED_INT);
+    if (glInt) {
+        gl.uniform1i(loc, Math.round(value));
+    } else {
+        gl.uniform1f(loc, value);
+    }
+}
+
+function compileShader(gl, type, src) {
+    const shader = gl.createShader(type);
+    gl.shaderSource(shader, src);
+    gl.compileShader(shader);
+    if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
+        const info = gl.getShaderInfoLog(shader);
+        gl.deleteShader(shader);
+        console.error(`Shader compile error: ${info}`);
+        exit(1);
+    }
+    return shader;
+}
+
+function linkProgram(gl, vert, frag) {
+    const prog = gl.createProgram();
+    gl.attachShader(prog, vert);
+    gl.attachShader(prog, frag);
+    gl.linkProgram(prog);
+    if (!gl.getProgramParameter(prog, gl.LINK_STATUS)) {
+        const info = gl.getProgramInfoLog(prog);
+        gl.deleteProgram(prog);
+        console.error(`Program link error: ${info}`);
+        exit(1);
+    }
+    return prog;
+}
+
+main().catch(err => {
+    console.error(`Fatal: ${err.message}`);
+    exit(1);
+});

--- a/mcp_video/engine.py
+++ b/mcp_video/engine.py
@@ -84,6 +84,18 @@ from .engine_timeline import _apply_composite_overlays as _apply_composite_overl
 from .engine_timeline import edit_timeline as edit_timeline
 from .engine_transcode import normalize as normalize
 from .engine_watermark import watermark as watermark
+from .engine_glitch import glitch_rgb_shift as glitch_rgb_shift
+from .engine_glitch import glitch_scanline_jitter as glitch_scanline_jitter
+from .engine_glitch import glitch_screen_tearing as glitch_screen_tearing
+from .engine_glitch import glitch_vhs_tracking as glitch_vhs_tracking
+from .engine_glitch import glitch_macroblocking as glitch_macroblocking
+from .engine_glitch import glitch_datamoshing as glitch_datamoshing
+from .engine_glitch import glitch_cmyk_split as glitch_cmyk_split
+from .engine_glitch import glitch_turbulent_displacement as glitch_turbulent_displacement
+from .engine_glitch_shader import glitch_digital_feedback as glitch_digital_feedback
+from .engine_glitch_shader import glitch_slit_scan as glitch_slit_scan
+from .engine_glitch_shader import glitch_depth_splatting as glitch_depth_splatting
+from .engine_glitch_shader import glitch_point_cloud as glitch_point_cloud
 
 apply_mask = _apply_mask
 apply_filter = _apply_filter

--- a/mcp_video/engine_glitch.py
+++ b/mcp_video/engine_glitch.py
@@ -1,0 +1,504 @@
+"""CRUSH glitch effects engine — FFmpeg filter implementations.
+
+Eight glitch/visual corruption effects replicating the CRUSH shader bundle.
+Each effect builds an FFmpeg filter chain and delegates execution to shared
+helpers from ffmpeg_helpers.
+"""
+
+from __future__ import annotations
+
+import math
+
+from .ffmpeg_helpers import (
+    _run_command,
+    _sanitize_ffmpeg_number,
+    _validate_input_path,
+    _validate_output_path,
+)
+
+
+# ---------------------------------------------------------------------------
+# Shared internal helpers
+# ---------------------------------------------------------------------------
+
+_VIDEO_ENCODE_FLAGS = ["-c:a", "copy", "-c:v", "libx264", "-pix_fmt", "yuv420p", "-crf", "23"]
+
+
+def _build_cmd(input_path: str, output: str, vf: str) -> list[str]:
+    """Build a minimal FFmpeg command with the given video filter chain."""
+    return [
+        "ffmpeg", "-y", "-i", input_path,
+        "-vf", vf,
+        *_VIDEO_ENCODE_FLAGS,
+        output,
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Effect 1: RGB Shift (effect id 1)
+# ---------------------------------------------------------------------------
+
+def glitch_rgb_shift(
+    input_path: str,
+    output: str,
+    amount: float = 10.0,
+    angle: float = 0.0,
+    noise: float = 0.0,
+) -> str:
+    """Apply RGB channel shift with optional per-frame noise.
+
+    Args:
+        input_path: Input video path.
+        output: Output video path.
+        amount: Shift distance in pixels. Default 10.0.
+        angle: Shift direction in degrees. Default 0 (horizontal).
+        noise: Per-frame noise amplitude (0-1). Default 0.
+
+    Returns:
+        Path to output video.
+    """
+    input_path = _validate_input_path(input_path)
+    _validate_output_path(output)
+    amount = _sanitize_ffmpeg_number(amount, "amount")
+    angle = _sanitize_ffmpeg_number(angle, "angle")
+    noise = _sanitize_ffmpeg_number(noise, "noise")
+
+    angle_rad = angle * math.pi / 180.0
+    cos_a = math.cos(angle_rad)
+    sin_a = math.sin(angle_rad)
+
+    # Base shift values
+    rh = amount * cos_a
+    rv = amount * sin_a
+    bh = -amount * cos_a
+    bv = -amount * sin_a
+
+    if noise > 0:
+        # Add time-varying noise to shift amounts via random() expression
+        noise_px = noise * amount
+        vf = (
+            f"rgbashift="
+            f"rh='({rh:.2f}+({noise_px:.2f}*(random(0)*2-1)))':"
+            f"rv='({rv:.2f}+({noise_px:.2f}*(random(1)*2-1)))':"
+            f"bh='({bh:.2f}+({noise_px:.2f}*(random(2)*2-1)))':"
+            f"bv='({bv:.2f}+({noise_px:.2f}*(random(3)*2-1)))'"
+        )
+    else:
+        vf = f"rgbashift=rh={rh:.2f}:rv={rv:.2f}:bh={bh:.2f}:bv={bv:.2f}"
+
+    cmd = _build_cmd(input_path, output, vf)
+    _run_command(cmd)
+    return output
+
+
+# ---------------------------------------------------------------------------
+# Effect 2: Scanline Jitter (effect id 6)
+# ---------------------------------------------------------------------------
+
+def glitch_scanline_jitter(
+    input_path: str,
+    output: str,
+    jitter_amount: float = 15.0,
+    frequency: float = 0.3,
+    speed: float = 5.0,
+    row_height: int = 4,
+) -> str:
+    """Apply horizontal jitter to random scanlines.
+
+    Args:
+        input_path: Input video path.
+        output: Output video path.
+        jitter_amount: Max horizontal displacement in pixels. Default 15.
+        frequency: Fraction of rows affected (0-1). Default 0.3.
+        speed: Animation speed multiplier. Default 5.
+        row_height: Height of each jitter band in pixels. Default 4.
+
+    Returns:
+        Path to output video.
+    """
+    input_path = _validate_input_path(input_path)
+    _validate_output_path(output)
+    jitter_amount = _sanitize_ffmpeg_number(jitter_amount, "jitter_amount")
+    frequency = _sanitize_ffmpeg_number(frequency, "frequency")
+    speed = _sanitize_ffmpeg_number(speed, "speed")
+    row_height = int(_sanitize_ffmpeg_number(row_height, "row_height"))
+
+    # geq-based approach: displace X based on row index and time-modulated random
+    # The expression evaluates per-pixel and shifts rows that match the jitter trigger
+    vf = (
+        f"geq="
+        f"r='p("
+        f"X+if(lt(random(floor(Y/{row_height})*T*{speed:.1f})*1.0,{frequency:.2f}),"
+        f"(random(floor(Y/{row_height})*T*{speed:.1f}+100)*2-1)*{jitter_amount:.1f},0)"
+        f",Y)':"
+        f"g='p("
+        f"X+if(lt(random(floor(Y/{row_height})*T*{speed:.1f})*1.0,{frequency:.2f}),"
+        f"(random(floor(Y/{row_height})*T*{speed:.1f}+100)*2-1)*{jitter_amount:.1f},0)"
+        f",Y)':"
+        f"b='p("
+        f"X+if(lt(random(floor(Y/{row_height})*T*{speed:.1f})*1.0,{frequency:.2f}),"
+        f"(random(floor(Y/{row_height})*T*{speed:.1f}+100)*2-1)*{jitter_amount:.1f},0)"
+        f",Y)'"
+    )
+
+    cmd = _build_cmd(input_path, output, vf)
+    _run_command(cmd)
+    return output
+
+
+# ---------------------------------------------------------------------------
+# Effect 3: Screen Tearing (effect id 8)
+# ---------------------------------------------------------------------------
+
+def glitch_screen_tearing(
+    input_path: str,
+    output: str,
+    tear_count: int = 5,
+    offset_range: float = 80.0,
+    speed: float = 3.0,
+) -> str:
+    """Apply horizontal screen tearing at random Y positions.
+
+    Args:
+        input_path: Input video path.
+        output: Output video path.
+        tear_count: Number of tear bands. Default 5.
+        offset_range: Max horizontal offset in pixels. Default 80.
+        speed: Animation speed. Default 3.
+
+    Returns:
+        Path to output video.
+    """
+    input_path = _validate_input_path(input_path)
+    _validate_output_path(output)
+    tear_count = int(_sanitize_ffmpeg_number(tear_count, "tear_count"))
+    offset_range = _sanitize_ffmpeg_number(offset_range, "offset_range")
+    speed = _sanitize_ffmpeg_number(speed, "speed")
+
+    # Build a geq expression that creates tears at Y positions derived from
+    # sin functions at different frequencies. Each tear band displaces X
+    # by a time-varying offset, creating the classic screen-tear look.
+    tear_exprs: list[str] = []
+    for i in range(tear_count):
+        phase = i * 137.5  # golden-angle spacing for variety
+        freq = 0.005 + i * 0.003
+        # Each tear contributes a displacement within a narrow Y band
+        tear_exprs.append(
+            f"(sin(Y*{freq:.4f}+T*{speed:.1f}+{phase:.1f})*"
+            f"step(sin(Y*{freq:.4f}+T*{speed:.1f}+{phase:.1f}),0.95)*"
+            f"{offset_range:.1f}*(random(i*7+T*100)*2-1))"
+        )
+
+    displacement = "+".join(tear_exprs) if tear_exprs else "0"
+
+    vf = (
+        f"geq="
+        f"r='p(X+({displacement}),Y)':"
+        f"g='p(X+({displacement}),Y)':"
+        f"b='p(X+({displacement}),Y)'"
+    )
+
+    cmd = _build_cmd(input_path, output, vf)
+    _run_command(cmd)
+    return output
+
+
+# ---------------------------------------------------------------------------
+# Effect 4: VHS Tracking (effect id 5)
+# ---------------------------------------------------------------------------
+
+def glitch_vhs_tracking(
+    input_path: str,
+    output: str,
+    tracking: float = 0.5,
+    noise_amount: float = 0.03,
+    color_bleed: float = 3.0,
+    roll_speed: float = 2.0,
+) -> str:
+    """Simulate VHS tracking error with color bleed and rolling bands.
+
+    Args:
+        input_path: Input video path.
+        output: Output video path.
+        tracking: Tracking error intensity (0-1). Default 0.5.
+        noise_amount: VHS noise intensity (0-1). Default 0.03.
+        color_bleed: Red channel shift in pixels. Default 3.
+        roll_speed: Vertical roll speed. Default 2.
+
+    Returns:
+        Path to output video.
+    """
+    input_path = _validate_input_path(input_path)
+    _validate_output_path(output)
+    tracking = _sanitize_ffmpeg_number(tracking, "tracking")
+    noise_amount = _sanitize_ffmpeg_number(noise_amount, "noise_amount")
+    color_bleed = _sanitize_ffmpeg_number(color_bleed, "color_bleed")
+    roll_speed = _sanitize_ffmpeg_number(roll_speed, "roll_speed")
+
+    # 1. Rolling horizontal band: sin-based X offset varying with Y and time
+    roll_offset = tracking * 40
+    roll_expr = (
+        f"(sin((Y+T*{roll_speed:.1f}*100)*0.02)*{roll_offset:.1f}*"
+        f"step(sin((Y+T*{roll_speed:.1f}*100)*0.005),0.3))"
+    )
+
+    # 2. geq for the rolling displacement (applied to all channels)
+    # 3. rgbashift for color bleed (red channel offset)
+    # 4. noise filter for VHS grain
+    noise_strength = int(noise_amount * 100)
+
+    vf = (
+        f"geq="
+        f"r='p(X+{roll_expr},Y)':"
+        f"g='p(X+{roll_expr},Y)':"
+        f"b='p(X+{roll_expr},Y)',"
+        f"rgbashift=rh={color_bleed:.1f}:rv={color_bleed * 0.5:.1f}:bh=-{color_bleed * 0.3:.1f},"
+        f"noise=alls={noise_strength}:allf=t+u"
+    )
+
+    cmd = _build_cmd(input_path, output, vf)
+    _run_command(cmd)
+    return output
+
+
+# ---------------------------------------------------------------------------
+# Effect 5: Macroblocking (effect id 3)
+# ---------------------------------------------------------------------------
+
+def glitch_macroblocking(
+    input_path: str,
+    output: str,
+    block_size: int = 16,
+    intensity: float = 0.7,
+    color_reduction: float = 0.3,
+) -> str:
+    """Simulate codec macroblocking artifacts by downscale/upscale + posterize.
+
+    Args:
+        input_path: Input video path.
+        output: Output video path.
+        block_size: Block size in pixels. Default 16.
+        intensity: Blend intensity with original (0-1). Default 0.7.
+        color_reduction: Color level reduction (0-1). Default 0.3.
+
+    Returns:
+        Path to output video.
+    """
+    input_path = _validate_input_path(input_path)
+    _validate_output_path(output)
+    block_size = int(_sanitize_ffmpeg_number(max(2, block_size), "block_size"))
+    intensity = _sanitize_ffmpeg_number(intensity, "intensity")
+    color_reduction = _sanitize_ffmpeg_number(color_reduction, "color_reduction")
+
+    # Posterization: reduce levels based on color_reduction
+    # colorlevels input minimum adjustment pushes values toward quantized steps
+    levels = color_reduction * 0.3  # subtle posterization
+
+    # Scale down then up with neighbor interpolation for blocky look,
+    # then posterize, then blend with original
+    vf = (
+        f"split[orig][blocked];"
+        f"[blocked]"
+        f"scale='iw/{block_size}':'ih/{block_size}':flags=neighbor,"
+        f"scale=iw:ih:flags=neighbor,"
+        f"colorlevels=rimin={levels:.3f}:gimin={levels:.3f}:bimin={levels:.3f}"
+        f"[blk];"
+        f"[orig][blk]blend=all_expr='A*(1-{intensity:.2f})+B*{intensity:.2f}'"
+    )
+
+    cmd = _build_cmd(input_path, output, vf)
+    _run_command(cmd)
+    return output
+
+
+# ---------------------------------------------------------------------------
+# Effect 6: Datamoshing (effect id 4)
+# ---------------------------------------------------------------------------
+
+def glitch_datamoshing(
+    input_path: str,
+    output: str,
+    drift: float = 20.0,
+    iframe_interval: int = 30,
+) -> str:
+    """Simulate datamoshing / P-frame corruption artifacts.
+
+    Uses frame blending with cyclic displacement resets to mimic
+    the look of I-frame corruption spreading through P-frames.
+
+    Args:
+        input_path: Input video path.
+        output: Output video path.
+        drift: Max displacement drift in pixels. Default 20.
+        iframe_interval: Frame interval for displacement resets. Default 30.
+
+    Returns:
+        Path to output video.
+    """
+    input_path = _validate_input_path(input_path)
+    _validate_output_path(output)
+    drift = _sanitize_ffmpeg_number(drift, "drift")
+    iframe_interval = int(_sanitize_ffmpeg_number(max(1, iframe_interval), "iframe_interval"))
+
+    # Build a displacement that grows cyclically (mimicking P-frame drift)
+    # then resets every iframe_interval frames.
+    # Use mod(N,iframe_interval) to get cycle position, scale by drift.
+    # Combine with tblend for frame-merge artifacts.
+    cycle_expr = f"(mod(N,{iframe_interval})/{iframe_interval}*{drift:.1f})"
+
+    # geq displaces X by the cyclic amount, varying direction with sin
+    vf = (
+        f"tblend=all_mode=grainextract,"
+        f"geq="
+        f"r='p(X+{cycle_expr}*sin(T*2),Y+{cycle_expr}*cos(T*3))':"
+        f"g='p(X+{cycle_expr}*sin(T*2+1),Y+{cycle_expr}*cos(T*3+1))':"
+        f"b='p(X+{cycle_expr}*sin(T*2+2),Y+{cycle_expr}*cos(T*3+2))'"
+    )
+
+    cmd = _build_cmd(input_path, output, vf)
+    _run_command(cmd)
+    return output
+
+
+# ---------------------------------------------------------------------------
+# Effect 7: CMYK Split (effect id 13)
+# ---------------------------------------------------------------------------
+
+def glitch_cmyk_split(
+    input_path: str,
+    output: str,
+    amount: float = 8.0,
+    angle: float = 0.0,
+    noise: float = 0.0,
+) -> str:
+    """Apply CMYK-style four-channel split at 90-degree offsets.
+
+    Simulates a four-plate offset print registration error by shifting
+    RGB channels at 90-degree intervals and applying colorchannelmixer
+    adjustments.
+
+    Args:
+        input_path: Input video path.
+        output: Output video path.
+        amount: Shift distance in pixels. Default 8.
+        angle: Base angle in degrees. Default 0.
+        noise: Per-frame noise amplitude (0-1). Default 0.
+
+    Returns:
+        Path to output video.
+    """
+    input_path = _validate_input_path(input_path)
+    _validate_output_path(output)
+    amount = _sanitize_ffmpeg_number(amount, "amount")
+    angle = _sanitize_ffmpeg_number(angle, "angle")
+    noise = _sanitize_ffmpeg_number(noise, "noise")
+
+    base_rad = angle * math.pi / 180.0
+
+    # Four directions at 90-degree intervals: 0, 90, 180, 270
+    # Red shifts at 0, Green at 90, Blue at 180
+    r_cos = math.cos(base_rad)
+    r_sin = math.sin(base_rad)
+    g_cos = math.cos(base_rad + math.pi / 2)
+    g_sin = math.sin(base_rad + math.pi / 2)
+    b_cos = math.cos(base_rad + math.pi)
+    b_sin = math.sin(base_rad + math.pi)
+
+    rh = amount * r_cos
+    rv = amount * r_sin
+    gh = amount * g_cos
+    gv = amount * g_sin
+    bh = amount * b_cos
+    bv = amount * b_sin
+
+    noise_px = noise * amount
+
+    if noise > 0:
+        rgbashift = (
+            f"rgbashift="
+            f"rh='({rh:.2f}+{noise_px:.2f}*(random(0)*2-1))':"
+            f"rv='({rv:.2f}+{noise_px:.2f}*(random(1)*2-1))':"
+            f"gh='({gh:.2f}+{noise_px:.2f}*(random(2)*2-1))':"
+            f"gv='({gv:.2f}+{noise_px:.2f}*(random(3)*2-1))':"
+            f"bh='({bh:.2f}+{noise_px:.2f}*(random(4)*2-1))':"
+            f"bv='({bv:.2f}+{noise_px:.2f}*(random(5)*2-1))'"
+        )
+    else:
+        rgbashift = (
+            f"rgbashift="
+            f"rh={rh:.2f}:rv={rv:.2f}:"
+            f"gh={gh:.2f}:gv={gv:.2f}:"
+            f"bh={bh:.2f}:bv={bv:.2f}"
+        )
+
+    # Boost color saturation to enhance the CMYK print look
+    vf = (
+        f"{rgbashift},"
+        f"colorbalance=rs=0.05:bs=-0.03:gh=0.03"
+    )
+
+    cmd = _build_cmd(input_path, output, vf)
+    _run_command(cmd)
+    return output
+
+
+# ---------------------------------------------------------------------------
+# Effect 8: Turbulent Displacement (effect id 9)
+# ---------------------------------------------------------------------------
+
+def glitch_turbulent_displacement(
+    input_path: str,
+    output: str,
+    amount: float = 20.0,
+    scale: float = 0.01,
+    speed: float = 1.0,
+    octaves: int = 3,
+) -> str:
+    """Apply turbulent displacement using multi-octave sin/cos approximation.
+
+    Uses layered sin/cos expressions at different frequencies to approximate
+    fractional Brownian motion (FBM) noise, then displaces pixels accordingly.
+
+    Args:
+        input_path: Input video path.
+        output: Output video path.
+        amount: Displacement magnitude in pixels. Default 20.
+        scale: Base noise frequency. Default 0.01.
+        speed: Animation speed. Default 1.
+        octaves: Number of noise octaves (1-5). Default 3.
+
+    Returns:
+        Path to output video.
+    """
+    input_path = _validate_input_path(input_path)
+    _validate_output_path(output)
+    amount = _sanitize_ffmpeg_number(amount, "amount")
+    scale = _sanitize_ffmpeg_number(scale, "scale")
+    speed = _sanitize_ffmpeg_number(speed, "speed")
+    octaves = int(_sanitize_ffmpeg_number(octaves, "octaves"))
+    octaves = max(1, min(5, octaves))
+
+    # Build multi-octave displacement expressions
+    # Each octave doubles the frequency and halves the amplitude
+    dx_terms: list[str] = []
+    dy_terms: list[str] = []
+    for i in range(octaves):
+        freq = scale * (2 ** i)
+        amp = 1.0 / (2 ** i)
+        t_offset = i * 1.7  # phase offset per octave for variety
+        dx_terms.append(f"sin(X*{freq:.4f}+Y*{freq * 0.7:.4f}+T*{speed:.1f}+{t_offset:.1f})*{amp:.3f}")
+        dy_terms.append(f"cos(X*{freq * 0.8:.4f}+Y*{freq:.4f}+T*{speed:.1f}+{t_offset + 0.5:.1f})*{amp:.3f}")
+
+    dx_expr = "+".join(dx_terms)
+    dy_expr = "+".join(dy_terms)
+
+    vf = (
+        f"geq="
+        f"r='p(X+({dx_expr})*{amount:.1f},Y+({dy_expr})*{amount:.1f})':"
+        f"g='p(X+({dx_expr})*{amount:.1f},Y+({dy_expr})*{amount:.1f})':"
+        f"b='p(X+({dx_expr})*{amount:.1f},Y+({dy_expr})*{amount:.1f})'"
+    )
+
+    cmd = _build_cmd(input_path, output, vf)
+    _run_command(cmd)
+    return output

--- a/mcp_video/engine_glitch.py
+++ b/mcp_video/engine_glitch.py
@@ -182,11 +182,13 @@ def glitch_screen_tearing(
     for i in range(tear_count):
         phase = i * 137.5  # golden-angle spacing for variety
         freq = 0.005 + i * 0.003
+        seed = i * 7 + 42
         # Each tear contributes a displacement within a narrow Y band
+        # random(N) in geq takes a seed integer; use Y+seed for spatial variation
         tear_exprs.append(
             f"(sin(Y*{freq:.4f}+T*{speed:.1f}+{phase:.1f})*"
-            f"step(sin(Y*{freq:.4f}+T*{speed:.1f}+{phase:.1f}),0.95)*"
-            f"{offset_range:.1f}*(random(i*7+T*100)*2-1))"
+            f"if(gt(sin(Y*{freq:.4f}+T*{speed:.1f}+{phase:.1f}),0.95),1,0)*"
+            f"{offset_range:.1f}*(random(floor(Y)+{seed})*2-1))"
         )
 
     displacement = "+".join(tear_exprs) if tear_exprs else "0"
@@ -236,10 +238,11 @@ def glitch_vhs_tracking(
     roll_speed = _sanitize_ffmpeg_number(roll_speed, "roll_speed")
 
     # 1. Rolling horizontal band: sin-based X offset varying with Y and time
+    # Uses ternary (if(x,1,0)) to create discrete band steps instead of step()
     roll_offset = tracking * 40
     roll_expr = (
         f"(sin((Y+T*{roll_speed:.1f}*100)*0.02)*{roll_offset:.1f}*"
-        f"step(sin((Y+T*{roll_speed:.1f}*100)*0.005),0.3))"
+        f"if(gt(sin((Y+T*{roll_speed:.1f}*100)*0.005),0.3),1,0))"
     )
 
     # 2. geq for the rolling displacement (applied to all channels)
@@ -295,12 +298,14 @@ def glitch_macroblocking(
     levels = color_reduction * 0.3  # subtle posterization
 
     # Scale down then up with neighbor interpolation for blocky look,
-    # then posterize, then blend with original
+    # then posterize, then blend with original.
+    # We use iw*block_size to restore original dimensions after downscale,
+    # since "iw" in the second scale refers to the already-downscaled width.
     vf = (
         f"split[orig][blocked];"
         f"[blocked]"
         f"scale='iw/{block_size}':'ih/{block_size}':flags=neighbor,"
-        f"scale=iw:ih:flags=neighbor,"
+        f"scale='iw*{block_size}':'ih*{block_size}':flags=neighbor,"
         f"colorlevels=rimin={levels:.3f}:gimin={levels:.3f}:bimin={levels:.3f}"
         f"[blk];"
         f"[orig][blk]blend=all_expr='A*(1-{intensity:.2f})+B*{intensity:.2f}'"

--- a/mcp_video/engine_glitch.py
+++ b/mcp_video/engine_glitch.py
@@ -27,8 +27,12 @@ _VIDEO_ENCODE_FLAGS = ["-c:a", "copy", "-c:v", "libx264", "-pix_fmt", "yuv420p",
 def _build_cmd(input_path: str, output: str, vf: str) -> list[str]:
     """Build a minimal FFmpeg command with the given video filter chain."""
     return [
-        "ffmpeg", "-y", "-i", input_path,
-        "-vf", vf,
+        "ffmpeg",
+        "-y",
+        "-i",
+        input_path,
+        "-vf",
+        vf,
         *_VIDEO_ENCODE_FLAGS,
         output,
     ]
@@ -37,6 +41,7 @@ def _build_cmd(input_path: str, output: str, vf: str) -> list[str]:
 # ---------------------------------------------------------------------------
 # Effect 1: RGB Shift (effect id 1)
 # ---------------------------------------------------------------------------
+
 
 def glitch_rgb_shift(
     input_path: str,
@@ -95,6 +100,7 @@ def glitch_rgb_shift(
 # Effect 2: Scanline Jitter (effect id 6)
 # ---------------------------------------------------------------------------
 
+
 def glitch_scanline_jitter(
     input_path: str,
     output: str,
@@ -150,6 +156,7 @@ def glitch_scanline_jitter(
 # Effect 3: Screen Tearing (effect id 8)
 # ---------------------------------------------------------------------------
 
+
 def glitch_screen_tearing(
     input_path: str,
     output: str,
@@ -193,12 +200,7 @@ def glitch_screen_tearing(
 
     displacement = "+".join(tear_exprs) if tear_exprs else "0"
 
-    vf = (
-        f"geq="
-        f"r='p(X+({displacement}),Y)':"
-        f"g='p(X+({displacement}),Y)':"
-        f"b='p(X+({displacement}),Y)'"
-    )
+    vf = f"geq=r='p(X+({displacement}),Y)':g='p(X+({displacement}),Y)':b='p(X+({displacement}),Y)'"
 
     cmd = _build_cmd(input_path, output, vf)
     _run_command(cmd)
@@ -208,6 +210,7 @@ def glitch_screen_tearing(
 # ---------------------------------------------------------------------------
 # Effect 4: VHS Tracking (effect id 5)
 # ---------------------------------------------------------------------------
+
 
 def glitch_vhs_tracking(
     input_path: str,
@@ -268,6 +271,7 @@ def glitch_vhs_tracking(
 # Effect 5: Macroblocking (effect id 3)
 # ---------------------------------------------------------------------------
 
+
 def glitch_macroblocking(
     input_path: str,
     output: str,
@@ -320,6 +324,7 @@ def glitch_macroblocking(
 # Effect 6: Datamoshing (effect id 4)
 # ---------------------------------------------------------------------------
 
+
 def glitch_datamoshing(
     input_path: str,
     output: str,
@@ -368,6 +373,7 @@ def glitch_datamoshing(
 # ---------------------------------------------------------------------------
 # Effect 7: CMYK Split (effect id 13)
 # ---------------------------------------------------------------------------
+
 
 def glitch_cmyk_split(
     input_path: str,
@@ -429,18 +435,10 @@ def glitch_cmyk_split(
             f"bv='({bv:.2f}+{noise_px:.2f}*(random(5)*2-1))'"
         )
     else:
-        rgbashift = (
-            f"rgbashift="
-            f"rh={rh:.2f}:rv={rv:.2f}:"
-            f"gh={gh:.2f}:gv={gv:.2f}:"
-            f"bh={bh:.2f}:bv={bv:.2f}"
-        )
+        rgbashift = f"rgbashift=rh={rh:.2f}:rv={rv:.2f}:gh={gh:.2f}:gv={gv:.2f}:bh={bh:.2f}:bv={bv:.2f}"
 
     # Boost color saturation to enhance the CMYK print look
-    vf = (
-        f"{rgbashift},"
-        f"colorbalance=rs=0.05:bs=-0.03:gh=0.03"
-    )
+    vf = f"{rgbashift},colorbalance=rs=0.05:bs=-0.03:gh=0.03"
 
     cmd = _build_cmd(input_path, output, vf)
     _run_command(cmd)
@@ -450,6 +448,7 @@ def glitch_cmyk_split(
 # ---------------------------------------------------------------------------
 # Effect 8: Turbulent Displacement (effect id 9)
 # ---------------------------------------------------------------------------
+
 
 def glitch_turbulent_displacement(
     input_path: str,
@@ -488,8 +487,8 @@ def glitch_turbulent_displacement(
     dx_terms: list[str] = []
     dy_terms: list[str] = []
     for i in range(octaves):
-        freq = scale * (2 ** i)
-        amp = 1.0 / (2 ** i)
+        freq = scale * (2**i)
+        amp = 1.0 / (2**i)
         t_offset = i * 1.7  # phase offset per octave for variety
         dx_terms.append(f"sin(X*{freq:.4f}+Y*{freq * 0.7:.4f}+T*{speed:.1f}+{t_offset:.1f})*{amp:.3f}")
         dy_terms.append(f"cos(X*{freq * 0.8:.4f}+Y*{freq:.4f}+T*{speed:.1f}+{t_offset + 0.5:.1f})*{amp:.3f}")

--- a/mcp_video/engine_glitch_shader.py
+++ b/mcp_video/engine_glitch_shader.py
@@ -1,0 +1,346 @@
+"""CRUSH GPU shader effects engine — headless WebGL pipeline.
+
+Four GPU-native CRUSH effects that can't be expressed as FFmpeg filter chains:
+- Digital Feedback (effect id 10): iterative frame feedback with scale/rotation
+- Slit-Scan (effect id 7): temporal displacement across multiple past frames
+- Depth Splatting (effect id 11): compute-dispatched point splat from depth map
+- Point Cloud (effect id 14): fragment-shader point cloud rendering
+
+Each effect extracts frames with FFmpeg, renders via a headless Node.js/CRUSH.js
+subprocess, then reassembles with FFmpeg.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from .ffmpeg_helpers import (
+    _run_command,
+    _validate_input_path,
+    _validate_output_path,
+)
+
+# Path to the CRUSH.js module bundled with mcp-video
+_CRUSH_JS_DIR = Path(__file__).resolve().parent / "_crush_shader"
+
+# Headless render script (render_frames.mjs)
+_RENDER_SCRIPT = _CRUSH_JS_DIR / "render_frames.mjs"
+
+_VIDEO_ENCODE_FLAGS = [
+    "-c:a", "copy", "-c:v", "libx264",
+    "-pix_fmt", "yuv420p", "-crf", "23",
+]
+
+
+def _check_node() -> str:
+    """Verify Node.js is available and return its path."""
+    node = shutil.which("node")
+    if not node:
+        raise RuntimeError(
+            "Node.js is required for GPU shader effects. "
+            "Install from https://nodejs.org or run `brew install node`."
+        )
+    return node
+
+
+def _extract_frames(input_path: str, frames_dir: str) -> dict[str, Any]:
+    """Extract video frames as PNG into frames_dir. Returns frame count."""
+    cmd = [
+        "ffmpeg", "-y", "-i", input_path,
+        os.path.join(frames_dir, "frame_%06d.png"),
+    ]
+    _run_command(cmd)
+    frames = sorted(Path(frames_dir).glob("frame_*.png"))
+    return {"frame_count": len(frames)}
+
+
+def _assemble_video(
+    frames_dir: str, audio_path: str | None, output: str, fps: str | None = None,
+) -> dict[str, Any]:
+    """Assemble rendered frames back into video, muxing audio if available."""
+    input_frame = os.path.join(frames_dir, "frame_%06d.png")
+    cmd: list[str] = ["ffmpeg", "-y"]
+
+    # Frame input
+    if fps:
+        cmd += ["-framerate", fps]
+    cmd += ["-i", input_frame]
+
+    # Audio from original if available
+    if audio_path and os.path.exists(audio_path):
+        cmd += ["-i", audio_path, "-map", "0:v", "-map", "1:a"]
+
+    cmd += _VIDEO_ENCODE_FLAGS + [output]
+    _run_command(cmd)
+    return {"output": output}
+
+
+def _extract_audio(input_path: str, audio_path: str) -> bool:
+    """Extract audio track from input. Returns True if audio exists."""
+    cmd = [
+        "ffmpeg", "-y", "-i", input_path,
+        "-vn", "-acodec", "copy", audio_path,
+    ]
+    try:
+        _run_command(cmd)
+        return os.path.exists(audio_path) and os.path.getsize(audio_path) > 0
+    except Exception:
+        return False
+
+
+def _get_fps(input_path: str) -> str:
+    """Get input video framerate."""
+    cmd = [
+        "ffprobe", "-v", "error",
+        "-select_streams", "v:0",
+        "-show_entries", "stream=r_frame_rate",
+        "-of", "json", input_path,
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+    data = json.loads(result.stdout)
+    streams = data.get("streams", [])
+    if streams:
+        return streams[0].get("r_frame_rate", "30/1")
+    return "30/1"
+
+
+def _run_shader_effect(
+    effect_name: str,
+    input_path: str,
+    output: str,
+    params: dict[str, float],
+) -> dict[str, Any]:
+    """Run a CRUSH shader effect via headless Node.js subprocess.
+
+    Steps:
+    1. Extract frames from input video
+    2. Run Node.js render script (loads CRUSH.js, processes each frame)
+    3. Reassemble output video with audio
+    """
+    input_path = _validate_input_path(input_path)
+    output = _validate_output_path(output)
+
+    node = _check_node()
+
+    if not _RENDER_SCRIPT.exists():
+        raise FileNotFoundError(
+            f"CRUSH shader render script not found at {_RENDER_SCRIPT}. "
+            "Run the CRUSH.js setup to install GPU shader support."
+        )
+
+    with tempfile.TemporaryDirectory(prefix="crush_shader_") as tmp:
+        frames_dir = os.path.join(tmp, "frames")
+        rendered_dir = os.path.join(tmp, "rendered")
+        audio_path = os.path.join(tmp, "audio.aac")
+        os.makedirs(frames_dir)
+        os.makedirs(rendered_dir)
+
+        # Get FPS before extraction
+        fps = _get_fps(input_path)
+
+        # Extract audio (best-effort)
+        has_audio = _extract_audio(input_path, audio_path)
+
+        # Extract frames
+        info = _extract_frames(input_path, frames_dir)
+        frame_count = info["frame_count"]
+
+        if frame_count == 0:
+            raise RuntimeError(f"No frames extracted from {input_path}")
+
+        max_frames = 7200
+        if frame_count > max_frames:
+            raise RuntimeError(
+                f"Video has {frame_count} frames; GPU shader pipeline maximum is {max_frames}. "
+                "Trim the video first or use the FFmpeg-based glitch effects instead."
+            )
+
+        # Build params JSON for the render script
+        render_params = {
+            "effect": effect_name,
+            "inputDir": frames_dir,
+            "outputDir": rendered_dir,
+            "frameCount": frame_count,
+            "params": params,
+        }
+
+        # Run Node.js render
+        render_cmd = [node, str(_RENDER_SCRIPT), json.dumps(render_params)]
+        render_result = subprocess.run(
+            render_cmd,
+            capture_output=True,
+            text=True,
+            timeout=300,  # 5 minute max
+        )
+
+        if render_result.returncode != 0:
+            raise RuntimeError(
+                f"CRUSH shader render failed (exit {render_result.returncode}): "
+                f"{render_result.stderr[:500]}"
+            )
+
+        # Check rendered frames
+        rendered = sorted(Path(rendered_dir).glob("frame_*.png"))
+        if not rendered:
+            raise RuntimeError("Shader render produced no output frames")
+
+        # Assemble video
+        _assemble_video(rendered_dir, audio_path if has_audio else None, output, fps)
+
+    return {"output": output, "effect": effect_name, "frames_processed": frame_count}
+
+
+# ---------------------------------------------------------------------------
+# Effect 10: Digital Feedback
+# ---------------------------------------------------------------------------
+
+def glitch_digital_feedback(
+    input_path: str,
+    output: str,
+    feedback_mix: float = 0.5,
+    scale: float = 1.0,
+    rotation: float = 0.0,
+    decay: float = 0.9,
+) -> dict[str, Any]:
+    """Apply iterative digital feedback with scale/rotation transform.
+
+    Each frame blends with a scaled+rotated version of the previous output,
+    creating ghostly trails and recursive patterns.
+
+    Args:
+        input_path: Path to input video.
+        output: Path for output video.
+        feedback_mix: Blend between current and feedback (0-1). Default 0.5.
+        scale: UV scale for previous frame. Default 1.0.
+        rotation: Rotation in degrees. Default 0.0.
+        decay: Ghost trail opacity (0-1). Default 0.9.
+
+    Returns:
+        Dict with output path and metadata.
+    """
+    return _run_shader_effect(
+        "digital_feedback", input_path, output,
+        {
+            "u_feedback_mix": feedback_mix,
+            "u_scale": scale,
+            "u_rotation": rotation,
+            "u_decay": decay,
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# Effect 7: Slit-Scan
+# ---------------------------------------------------------------------------
+
+def glitch_slit_scan(
+    input_path: str,
+    output: str,
+    depth: int = 30,
+    direction: int = 0,
+) -> dict[str, Any]:
+    """Apply temporal slit-scan displacement.
+
+    Each row/column of the output is sampled from a different past frame,
+    creating a time-smeared effect reminiscent of slit-scan photography.
+
+    Args:
+        input_path: Path to input video.
+        output: Path for output video.
+        depth: Number of past frames to use (1-120). Default 30.
+        direction: 0=top-bottom, 1=bottom-top, 2=left-right, 3=right-left. Default 0.
+
+    Returns:
+        Dict with output path and metadata.
+    """
+    return _run_shader_effect(
+        "slit_scan", input_path, output,
+        {
+            "u_depth": float(depth),
+            "u_direction": float(direction),
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# Effect 11: Depth Splatting
+# ---------------------------------------------------------------------------
+
+def glitch_depth_splatting(
+    input_path: str,
+    output: str,
+    depth_scale: float = 1.0,
+    spread: float = 10.0,
+    point_size: float = 3.0,
+    threshold: float = 0.5,
+) -> dict[str, Any]:
+    """Apply depth-based point splatting effect.
+
+    Extracts pseudo-depth from luminance and renders the image as scattered
+    points, creating a 3D particle-like appearance.
+
+    Args:
+        input_path: Path to input video.
+        output: Path for output video.
+        depth_scale: Depth extraction intensity. Default 1.0.
+        spread: Point spread distance in pixels. Default 10.0.
+        point_size: Size of each splatted point. Default 3.0.
+        threshold: Depth cutoff threshold (0-1). Default 0.5.
+
+    Returns:
+        Dict with output path and metadata.
+    """
+    return _run_shader_effect(
+        "depth_splatting", input_path, output,
+        {
+            "u_depth_scale": depth_scale,
+            "u_spread": spread,
+            "u_point_size": point_size,
+            "u_threshold": threshold,
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# Effect 14: Point Cloud
+# ---------------------------------------------------------------------------
+
+def glitch_point_cloud(
+    input_path: str,
+    output: str,
+    density: float = 0.5,
+    point_size: float = 2.0,
+    rotation: float = 0.0,
+    depth: float = 1.0,
+) -> dict[str, Any]:
+    """Apply point cloud rendering effect.
+
+    Samples the image as scattered points arranged in a 3D-rotated grid,
+    with depth-based displacement creating a volumetric look.
+
+    Args:
+        input_path: Path to input video.
+        output: Path for output video.
+        density: Point sampling density (0-1). Default 0.5.
+        point_size: Size of each point. Default 2.0.
+        rotation: 3D rotation angle in degrees. Default 0.0.
+        depth: Depth displacement intensity. Default 1.0.
+
+    Returns:
+        Dict with output path and metadata.
+    """
+    return _run_shader_effect(
+        "point_cloud", input_path, output,
+        {
+            "u_density": density,
+            "u_point_size": point_size,
+            "u_rotation": rotation,
+            "u_depth": depth,
+        },
+    )

--- a/mcp_video/engine_glitch_shader.py
+++ b/mcp_video/engine_glitch_shader.py
@@ -33,8 +33,14 @@ _CRUSH_JS_DIR = Path(__file__).resolve().parent / "_crush_shader"
 _RENDER_SCRIPT = _CRUSH_JS_DIR / "render_frames.mjs"
 
 _VIDEO_ENCODE_FLAGS = [
-    "-c:a", "copy", "-c:v", "libx264",
-    "-pix_fmt", "yuv420p", "-crf", "23",
+    "-c:a",
+    "copy",
+    "-c:v",
+    "libx264",
+    "-pix_fmt",
+    "yuv420p",
+    "-crf",
+    "23",
 ]
 
 
@@ -43,8 +49,7 @@ def _check_node() -> str:
     node = shutil.which("node")
     if not node:
         raise RuntimeError(
-            "Node.js is required for GPU shader effects. "
-            "Install from https://nodejs.org or run `brew install node`."
+            "Node.js is required for GPU shader effects. Install from https://nodejs.org or run `brew install node`."
         )
     return node
 
@@ -52,7 +57,10 @@ def _check_node() -> str:
 def _extract_frames(input_path: str, frames_dir: str) -> dict[str, Any]:
     """Extract video frames as PNG into frames_dir. Returns frame count."""
     cmd = [
-        "ffmpeg", "-y", "-i", input_path,
+        "ffmpeg",
+        "-y",
+        "-i",
+        input_path,
         os.path.join(frames_dir, "frame_%06d.png"),
     ]
     _run_command(cmd)
@@ -61,7 +69,10 @@ def _extract_frames(input_path: str, frames_dir: str) -> dict[str, Any]:
 
 
 def _assemble_video(
-    frames_dir: str, audio_path: str | None, output: str, fps: str | None = None,
+    frames_dir: str,
+    audio_path: str | None,
+    output: str,
+    fps: str | None = None,
 ) -> dict[str, Any]:
     """Assemble rendered frames back into video, muxing audio if available."""
     input_frame = os.path.join(frames_dir, "frame_%06d.png")
@@ -84,8 +95,14 @@ def _assemble_video(
 def _extract_audio(input_path: str, audio_path: str) -> bool:
     """Extract audio track from input. Returns True if audio exists."""
     cmd = [
-        "ffmpeg", "-y", "-i", input_path,
-        "-vn", "-acodec", "copy", audio_path,
+        "ffmpeg",
+        "-y",
+        "-i",
+        input_path,
+        "-vn",
+        "-acodec",
+        "copy",
+        audio_path,
     ]
     try:
         _run_command(cmd)
@@ -97,10 +114,16 @@ def _extract_audio(input_path: str, audio_path: str) -> bool:
 def _get_fps(input_path: str) -> str:
     """Get input video framerate."""
     cmd = [
-        "ffprobe", "-v", "error",
-        "-select_streams", "v:0",
-        "-show_entries", "stream=r_frame_rate",
-        "-of", "json", input_path,
+        "ffprobe",
+        "-v",
+        "error",
+        "-select_streams",
+        "v:0",
+        "-show_entries",
+        "stream=r_frame_rate",
+        "-of",
+        "json",
+        input_path,
     ]
     result = subprocess.run(cmd, capture_output=True, text=True, check=True)
     data = json.loads(result.stdout)
@@ -181,8 +204,7 @@ def _run_shader_effect(
 
         if render_result.returncode != 0:
             raise RuntimeError(
-                f"CRUSH shader render failed (exit {render_result.returncode}): "
-                f"{render_result.stderr[:500]}"
+                f"CRUSH shader render failed (exit {render_result.returncode}): {render_result.stderr[:500]}"
             )
 
         # Check rendered frames
@@ -199,6 +221,7 @@ def _run_shader_effect(
 # ---------------------------------------------------------------------------
 # Effect 10: Digital Feedback
 # ---------------------------------------------------------------------------
+
 
 def glitch_digital_feedback(
     input_path: str,
@@ -225,7 +248,9 @@ def glitch_digital_feedback(
         Dict with output path and metadata.
     """
     return _run_shader_effect(
-        "digital_feedback", input_path, output,
+        "digital_feedback",
+        input_path,
+        output,
         {
             "u_feedback_mix": feedback_mix,
             "u_scale": scale,
@@ -238,6 +263,7 @@ def glitch_digital_feedback(
 # ---------------------------------------------------------------------------
 # Effect 7: Slit-Scan
 # ---------------------------------------------------------------------------
+
 
 def glitch_slit_scan(
     input_path: str,
@@ -260,7 +286,9 @@ def glitch_slit_scan(
         Dict with output path and metadata.
     """
     return _run_shader_effect(
-        "slit_scan", input_path, output,
+        "slit_scan",
+        input_path,
+        output,
         {
             "u_depth": float(depth),
             "u_direction": float(direction),
@@ -271,6 +299,7 @@ def glitch_slit_scan(
 # ---------------------------------------------------------------------------
 # Effect 11: Depth Splatting
 # ---------------------------------------------------------------------------
+
 
 def glitch_depth_splatting(
     input_path: str,
@@ -297,7 +326,9 @@ def glitch_depth_splatting(
         Dict with output path and metadata.
     """
     return _run_shader_effect(
-        "depth_splatting", input_path, output,
+        "depth_splatting",
+        input_path,
+        output,
         {
             "u_depth_scale": depth_scale,
             "u_spread": spread,
@@ -310,6 +341,7 @@ def glitch_depth_splatting(
 # ---------------------------------------------------------------------------
 # Effect 14: Point Cloud
 # ---------------------------------------------------------------------------
+
 
 def glitch_point_cloud(
     input_path: str,
@@ -336,7 +368,9 @@ def glitch_point_cloud(
         Dict with output path and metadata.
     """
     return _run_shader_effect(
-        "point_cloud", input_path, output,
+        "point_cloud",
+        input_path,
+        output,
         {
             "u_density": density,
             "u_point_size": point_size,

--- a/mcp_video/engine_glitch_shader.py
+++ b/mcp_video/engine_glitch_shader.py
@@ -76,7 +76,7 @@ def _assemble_video(
     if audio_path and os.path.exists(audio_path):
         cmd += ["-i", audio_path, "-map", "0:v", "-map", "1:a"]
 
-    cmd += _VIDEO_ENCODE_FLAGS + [output]
+    cmd += [*_VIDEO_ENCODE_FLAGS, output]
     _run_command(cmd)
     return {"output": output}
 

--- a/mcp_video/server.py
+++ b/mcp_video/server.py
@@ -118,6 +118,22 @@ from .server_tools_effects import (
     video_text_animated as video_text_animated,
     video_subtitles_styled as video_subtitles_styled,
 )
+from .server_tools_glitch import (
+    glitch_cmyk_split as glitch_cmyk_split,
+    glitch_datamoshing as glitch_datamoshing,
+    glitch_macroblocking as glitch_macroblocking,
+    glitch_rgb_shift as glitch_rgb_shift,
+    glitch_scanline_jitter as glitch_scanline_jitter,
+    glitch_screen_tearing as glitch_screen_tearing,
+    glitch_turbulent_displacement as glitch_turbulent_displacement,
+    glitch_vhs_tracking as glitch_vhs_tracking,
+)
+from .server_tools_glitch_shader import (
+    glitch_depth_splatting as glitch_depth_splatting,
+    glitch_digital_feedback as glitch_digital_feedback,
+    glitch_point_cloud as glitch_point_cloud,
+    glitch_slit_scan as glitch_slit_scan,
+)
 from .server_tools_ai import (
     video_ai_color_grade as video_ai_color_grade,
     video_ai_remove_silence as video_ai_remove_silence,

--- a/mcp_video/server_tools_glitch.py
+++ b/mcp_video/server_tools_glitch.py
@@ -1,0 +1,374 @@
+"""MCP tool registrations for CRUSH glitch effects."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .errors import MCPVideoError
+from .ffmpeg_helpers import _validate_input_path
+from .paths import _auto_output
+from .server_app import _result, _safe_tool, _validation_error, mcp
+
+
+# ---------------------------------------------------------------------------
+# Glitch Effect Tools
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+@_safe_tool
+def glitch_rgb_shift(
+    input_path: str,
+    output_path: str | None = None,
+    amount: float = 10.0,
+    angle: float = 0.0,
+    noise: float = 0.0,
+) -> dict[str, Any]:
+    """Apply RGB channel shift glitch effect.
+
+    Shifts red and blue channels in opposite directions for a chromatic
+    split look. Optionally adds per-frame noise for a jittery feel.
+
+    Args:
+        input_path: Absolute path to input video.
+        output_path: Absolute path for output video.
+        amount: Shift distance in pixels. Default 10.0.
+        angle: Shift direction in degrees. Default 0 (horizontal).
+        noise: Per-frame noise amplitude (0-1). Default 0.
+
+    Returns:
+        Dict with success status and output_path.
+    """
+    input_path = _validate_input_path(input_path)
+    if amount < 0:
+        raise MCPVideoError(
+            f"amount must be non-negative, got {amount}",
+            error_type="validation_error",
+            code="invalid_parameter",
+        )
+    if not (0.0 <= noise <= 1.0):
+        raise MCPVideoError(
+            f"noise must be between 0.0 and 1.0, got {noise}",
+            error_type="validation_error",
+            code="invalid_parameter",
+        )
+    from .engine_glitch import glitch_rgb_shift as _fn
+
+    output = output_path or _auto_output(input_path, "rgb_shift")
+    return _result(_fn(input_path, output, amount, angle, noise))
+
+
+@mcp.tool()
+@_safe_tool
+def glitch_scanline_jitter(
+    input_path: str,
+    output_path: str | None = None,
+    jitter_amount: float = 15.0,
+    frequency: float = 0.3,
+    speed: float = 5.0,
+    row_height: int = 4,
+) -> dict[str, Any]:
+    """Apply scanline jitter glitch effect.
+
+    Displaces random horizontal rows of pixels for a CRT malfunction look.
+
+    Args:
+        input_path: Absolute path to input video.
+        output_path: Absolute path for output video.
+        jitter_amount: Max horizontal displacement in pixels. Default 15.
+        frequency: Fraction of rows affected (0-1). Default 0.3.
+        speed: Animation speed multiplier. Default 5.
+        row_height: Height of each jitter band in pixels. Default 4.
+
+    Returns:
+        Dict with success status and output_path.
+    """
+    input_path = _validate_input_path(input_path)
+    if jitter_amount < 0:
+        raise MCPVideoError(
+            f"jitter_amount must be non-negative, got {jitter_amount}",
+            error_type="validation_error",
+            code="invalid_parameter",
+        )
+    if not (0.0 <= frequency <= 1.0):
+        raise MCPVideoError(
+            f"frequency must be between 0.0 and 1.0, got {frequency}",
+            error_type="validation_error",
+            code="invalid_parameter",
+        )
+    if row_height < 1:
+        raise MCPVideoError(
+            f"row_height must be at least 1, got {row_height}",
+            error_type="validation_error",
+            code="invalid_parameter",
+        )
+    from .engine_glitch import glitch_scanline_jitter as _fn
+
+    output = output_path or _auto_output(input_path, "scanline_jitter")
+    return _result(_fn(input_path, output, jitter_amount, frequency, speed, row_height))
+
+
+@mcp.tool()
+@_safe_tool
+def glitch_screen_tearing(
+    input_path: str,
+    output_path: str | None = None,
+    tear_count: int = 5,
+    offset_range: float = 80.0,
+    speed: float = 3.0,
+) -> dict[str, Any]:
+    """Apply screen tearing glitch effect.
+
+    Creates horizontal tear bands at varying Y positions that shift
+    left/right over time.
+
+    Args:
+        input_path: Absolute path to input video.
+        output_path: Absolute path for output video.
+        tear_count: Number of tear bands. Default 5.
+        offset_range: Max horizontal offset in pixels. Default 80.
+        speed: Animation speed. Default 3.
+
+    Returns:
+        Dict with success status and output_path.
+    """
+    input_path = _validate_input_path(input_path)
+    if tear_count < 1:
+        raise MCPVideoError(
+            f"tear_count must be at least 1, got {tear_count}",
+            error_type="validation_error",
+            code="invalid_parameter",
+        )
+    if offset_range < 0:
+        raise MCPVideoError(
+            f"offset_range must be non-negative, got {offset_range}",
+            error_type="validation_error",
+            code="invalid_parameter",
+        )
+    from .engine_glitch import glitch_screen_tearing as _fn
+
+    output = output_path or _auto_output(input_path, "screen_tearing")
+    return _result(_fn(input_path, output, tear_count, offset_range, speed))
+
+
+@mcp.tool()
+@_safe_tool
+def glitch_vhs_tracking(
+    input_path: str,
+    output_path: str | None = None,
+    tracking: float = 0.5,
+    noise_amount: float = 0.03,
+    color_bleed: float = 3.0,
+    roll_speed: float = 2.0,
+) -> dict[str, Any]:
+    """Apply VHS tracking error glitch effect.
+
+    Simulates VHS tape tracking problems with color bleed, rolling bands,
+    and analog noise.
+
+    Args:
+        input_path: Absolute path to input video.
+        output_path: Absolute path for output video.
+        tracking: Tracking error intensity (0-1). Default 0.5.
+        noise_amount: VHS noise intensity (0-1). Default 0.03.
+        color_bleed: Red channel shift in pixels. Default 3.
+        roll_speed: Vertical roll speed. Default 2.
+
+    Returns:
+        Dict with success status and output_path.
+    """
+    input_path = _validate_input_path(input_path)
+    if not (0.0 <= tracking <= 1.0):
+        raise MCPVideoError(
+            f"tracking must be between 0.0 and 1.0, got {tracking}",
+            error_type="validation_error",
+            code="invalid_parameter",
+        )
+    if not (0.0 <= noise_amount <= 1.0):
+        raise MCPVideoError(
+            f"noise_amount must be between 0.0 and 1.0, got {noise_amount}",
+            error_type="validation_error",
+            code="invalid_parameter",
+        )
+    from .engine_glitch import glitch_vhs_tracking as _fn
+
+    output = output_path or _auto_output(input_path, "vhs_tracking")
+    return _result(_fn(input_path, output, tracking, noise_amount, color_bleed, roll_speed))
+
+
+@mcp.tool()
+@_safe_tool
+def glitch_macroblocking(
+    input_path: str,
+    output_path: str | None = None,
+    block_size: int = 16,
+    intensity: float = 0.7,
+    color_reduction: float = 0.3,
+) -> dict[str, Any]:
+    """Apply macroblocking glitch effect.
+
+    Simulates codec artifacting by downscaling/upscaling to create blocky
+    pixelation combined with color posterization.
+
+    Args:
+        input_path: Absolute path to input video.
+        output_path: Absolute path for output video.
+        block_size: Block size in pixels. Default 16.
+        intensity: Blend with original (0-1). Default 0.7.
+        color_reduction: Color level reduction (0-1). Default 0.3.
+
+    Returns:
+        Dict with success status and output_path.
+    """
+    input_path = _validate_input_path(input_path)
+    if block_size < 2:
+        raise MCPVideoError(
+            f"block_size must be at least 2, got {block_size}",
+            error_type="validation_error",
+            code="invalid_parameter",
+        )
+    if not (0.0 <= intensity <= 1.0):
+        raise MCPVideoError(
+            f"intensity must be between 0.0 and 1.0, got {intensity}",
+            error_type="validation_error",
+            code="invalid_parameter",
+        )
+    if not (0.0 <= color_reduction <= 1.0):
+        raise MCPVideoError(
+            f"color_reduction must be between 0.0 and 1.0, got {color_reduction}",
+            error_type="validation_error",
+            code="invalid_parameter",
+        )
+    from .engine_glitch import glitch_macroblocking as _fn
+
+    output = output_path or _auto_output(input_path, "macroblocking")
+    return _result(_fn(input_path, output, block_size, intensity, color_reduction))
+
+
+@mcp.tool()
+@_safe_tool
+def glitch_datamoshing(
+    input_path: str,
+    output_path: str | None = None,
+    drift: float = 20.0,
+    iframe_interval: int = 30,
+) -> dict[str, Any]:
+    """Apply datamoshing glitch effect.
+
+    Simulates P-frame corruption where displacement drifts across frames
+    then periodically resets, mimicking real datamosh artifacts.
+
+    Args:
+        input_path: Absolute path to input video.
+        output_path: Absolute path for output video.
+        drift: Max displacement drift in pixels. Default 20.
+        iframe_interval: Frame interval for displacement resets. Default 30.
+
+    Returns:
+        Dict with success status and output_path.
+    """
+    input_path = _validate_input_path(input_path)
+    if drift < 0:
+        raise MCPVideoError(
+            f"drift must be non-negative, got {drift}",
+            error_type="validation_error",
+            code="invalid_parameter",
+        )
+    if iframe_interval < 1:
+        raise MCPVideoError(
+            f"iframe_interval must be at least 1, got {iframe_interval}",
+            error_type="validation_error",
+            code="invalid_parameter",
+        )
+    from .engine_glitch import glitch_datamoshing as _fn
+
+    output = output_path or _auto_output(input_path, "datamoshing")
+    return _result(_fn(input_path, output, drift, iframe_interval))
+
+
+@mcp.tool()
+@_safe_tool
+def glitch_cmyk_split(
+    input_path: str,
+    output_path: str | None = None,
+    amount: float = 8.0,
+    angle: float = 0.0,
+    noise: float = 0.0,
+) -> dict[str, Any]:
+    """Apply CMYK split glitch effect.
+
+    Shifts RGB channels at 90-degree intervals to simulate four-plate
+    offset print registration errors.
+
+    Args:
+        input_path: Absolute path to input video.
+        output_path: Absolute path for output video.
+        amount: Shift distance in pixels. Default 8.
+        angle: Base angle in degrees. Default 0.
+        noise: Per-frame noise amplitude (0-1). Default 0.
+
+    Returns:
+        Dict with success status and output_path.
+    """
+    input_path = _validate_input_path(input_path)
+    if amount < 0:
+        raise MCPVideoError(
+            f"amount must be non-negative, got {amount}",
+            error_type="validation_error",
+            code="invalid_parameter",
+        )
+    if not (0.0 <= noise <= 1.0):
+        raise MCPVideoError(
+            f"noise must be between 0.0 and 1.0, got {noise}",
+            error_type="validation_error",
+            code="invalid_parameter",
+        )
+    from .engine_glitch import glitch_cmyk_split as _fn
+
+    output = output_path or _auto_output(input_path, "cmyk_split")
+    return _result(_fn(input_path, output, amount, angle, noise))
+
+
+@mcp.tool()
+@_safe_tool
+def glitch_turbulent_displacement(
+    input_path: str,
+    output_path: str | None = None,
+    amount: float = 20.0,
+    scale: float = 0.01,
+    speed: float = 1.0,
+    octaves: int = 3,
+) -> dict[str, Any]:
+    """Apply turbulent displacement glitch effect.
+
+    Uses layered sin/cos expressions at different frequencies to approximate
+    fractal Brownian motion noise for organic-looking displacement.
+
+    Args:
+        input_path: Absolute path to input video.
+        output_path: Absolute path for output video.
+        amount: Displacement magnitude in pixels. Default 20.
+        scale: Base noise frequency. Default 0.01.
+        speed: Animation speed. Default 1.
+        octaves: Number of noise octaves (1-5). Default 3.
+
+    Returns:
+        Dict with success status and output_path.
+    """
+    input_path = _validate_input_path(input_path)
+    if amount < 0:
+        raise MCPVideoError(
+            f"amount must be non-negative, got {amount}",
+            error_type="validation_error",
+            code="invalid_parameter",
+        )
+    if not (1 <= octaves <= 5):
+        raise MCPVideoError(
+            f"octaves must be between 1 and 5, got {octaves}",
+            error_type="validation_error",
+            code="invalid_parameter",
+        )
+    from .engine_glitch import glitch_turbulent_displacement as _fn
+
+    output = output_path or _auto_output(input_path, "turbulent")
+    return _result(_fn(input_path, output, amount, scale, speed, octaves))

--- a/mcp_video/server_tools_glitch.py
+++ b/mcp_video/server_tools_glitch.py
@@ -7,7 +7,7 @@ from typing import Any
 from .errors import MCPVideoError
 from .ffmpeg_helpers import _validate_input_path
 from .paths import _auto_output
-from .server_app import _result, _safe_tool, _validation_error, mcp
+from .server_app import _result, _safe_tool, mcp
 
 
 # ---------------------------------------------------------------------------

--- a/mcp_video/server_tools_glitch_shader.py
+++ b/mcp_video/server_tools_glitch_shader.py
@@ -1,0 +1,184 @@
+"""MCP tool registrations for CRUSH GPU shader effects.
+
+Four effects requiring headless WebGL rendering via Node.js + CRUSH.js:
+- Digital Feedback, Slit-Scan, Depth Splatting, Point Cloud
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .errors import MCPVideoError
+from .ffmpeg_helpers import _validate_input_path
+from .paths import _auto_output
+from .server_app import _result, _safe_tool, _validation_error, mcp
+
+
+# ---------------------------------------------------------------------------
+# GPU Shader Effect Tools
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+@_safe_tool
+def glitch_digital_feedback(
+    input_path: str,
+    output_path: str | None = None,
+    feedback_mix: float = 0.5,
+    scale: float = 1.0,
+    rotation: float = 0.0,
+    decay: float = 0.9,
+) -> dict[str, Any]:
+    """Apply digital feedback glitch effect (requires Node.js + GPU).
+
+    Iterative frame feedback with scale/rotation transform. Each frame blends
+    with a scaled+rotated version of the previous output, creating ghostly
+    trails and recursive visual patterns.
+
+    Args:
+        input_path: Absolute path to input video.
+        output_path: Absolute path for output video.
+        feedback_mix: Blend between current and feedback (0-1). Default 0.5.
+        scale: UV scale for previous frame. Default 1.0.
+        rotation: Rotation in degrees. Default 0.0.
+        decay: Ghost trail opacity (0-1). Default 0.9.
+
+    Returns:
+        Dict with success status and output_path.
+    """
+    input_path = _validate_input_path(input_path)
+    if not (0.0 <= feedback_mix <= 1.0):
+        raise MCPVideoError(
+            f"feedback_mix must be between 0.0 and 1.0, got {feedback_mix}",
+            error_type="validation_error",
+            code="invalid_parameter",
+        )
+    if not (0.0 <= decay <= 1.0):
+        raise MCPVideoError(
+            f"decay must be between 0.0 and 1.0, got {decay}",
+            error_type="validation_error",
+            code="invalid_parameter",
+        )
+    from .engine_glitch_shader import glitch_digital_feedback as _fn
+
+    output = output_path or _auto_output(input_path, "digital_feedback")
+    return _result(_fn(input_path, output, feedback_mix, scale, rotation, decay))
+
+
+@mcp.tool()
+@_safe_tool
+def glitch_slit_scan(
+    input_path: str,
+    output_path: str | None = None,
+    depth: int = 30,
+    direction: int = 0,
+) -> dict[str, Any]:
+    """Apply slit-scan temporal displacement effect (requires Node.js + GPU).
+
+    Each row/column of the output is sampled from a different past frame,
+    creating a time-smeared effect reminiscent of slit-scan photography.
+
+    Args:
+        input_path: Absolute path to input video.
+        output_path: Absolute path for output video.
+        depth: Number of past frames to use (1-120). Default 30.
+        direction: 0=top-bottom, 1=bottom-top, 2=left-right, 3=right-left. Default 0.
+
+    Returns:
+        Dict with success status and output_path.
+    """
+    input_path = _validate_input_path(input_path)
+    if not (1 <= depth <= 120):
+        raise MCPVideoError(
+            f"depth must be between 1 and 120, got {depth}",
+            error_type="validation_error",
+            code="invalid_parameter",
+        )
+    if direction not in (0, 1, 2, 3):
+        raise MCPVideoError(
+            f"direction must be 0-3, got {direction}",
+            error_type="validation_error",
+            code="invalid_parameter",
+        )
+    from .engine_glitch_shader import glitch_slit_scan as _fn
+
+    output = output_path or _auto_output(input_path, "slit_scan")
+    return _result(_fn(input_path, output, depth, direction))
+
+
+@mcp.tool()
+@_safe_tool
+def glitch_depth_splatting(
+    input_path: str,
+    output_path: str | None = None,
+    depth_scale: float = 1.0,
+    spread: float = 10.0,
+    point_size: float = 3.0,
+    threshold: float = 0.5,
+) -> dict[str, Any]:
+    """Apply depth-based point splatting effect (requires Node.js + GPU).
+
+    Extracts pseudo-depth from luminance and renders the image as scattered
+    points, creating a 3D particle-like appearance.
+
+    Args:
+        input_path: Absolute path to input video.
+        output_path: Absolute path for output video.
+        depth_scale: Depth extraction intensity. Default 1.0.
+        spread: Point spread distance in pixels. Default 10.0.
+        point_size: Size of each splatted point. Default 3.0.
+        threshold: Depth cutoff threshold (0-1). Default 0.5.
+
+    Returns:
+        Dict with success status and output_path.
+    """
+    input_path = _validate_input_path(input_path)
+    if not (0.0 <= threshold <= 1.0):
+        raise MCPVideoError(
+            f"threshold must be between 0.0 and 1.0, got {threshold}",
+            error_type="validation_error",
+            code="invalid_parameter",
+        )
+    from .engine_glitch_shader import glitch_depth_splatting as _fn
+
+    output = output_path or _auto_output(input_path, "depth_splatting")
+    return _result(_fn(input_path, output, depth_scale, spread, point_size, threshold))
+
+
+@mcp.tool()
+@_safe_tool
+def glitch_point_cloud(
+    input_path: str,
+    output_path: str | None = None,
+    density: float = 0.5,
+    point_size: float = 2.0,
+    rotation: float = 0.0,
+    depth: float = 1.0,
+) -> dict[str, Any]:
+    """Apply point cloud rendering effect (requires Node.js + GPU).
+
+    Samples the image as scattered points arranged in a 3D-rotated grid,
+    with depth-based displacement creating a volumetric look.
+
+    Args:
+        input_path: Absolute path to input video.
+        output_path: Absolute path for output video.
+        density: Point sampling density (0-1). Default 0.5.
+        point_size: Size of each point. Default 2.0.
+        rotation: 3D rotation angle in degrees. Default 0.0.
+        depth: Depth displacement intensity. Default 1.0.
+
+    Returns:
+        Dict with success status and output_path.
+    """
+    input_path = _validate_input_path(input_path)
+    if not (0.0 <= density <= 1.0):
+        raise MCPVideoError(
+            f"density must be between 0.0 and 1.0, got {density}",
+            error_type="validation_error",
+            code="invalid_parameter",
+        )
+    from .engine_glitch_shader import glitch_point_cloud as _fn
+
+    output = output_path or _auto_output(input_path, "point_cloud")
+    return _result(_fn(input_path, output, density, point_size, rotation, depth))

--- a/mcp_video/server_tools_glitch_shader.py
+++ b/mcp_video/server_tools_glitch_shader.py
@@ -11,7 +11,7 @@ from typing import Any
 from .errors import MCPVideoError
 from .ffmpeg_helpers import _validate_input_path
 from .paths import _auto_output
-from .server_app import _result, _safe_tool, _validation_error, mcp
+from .server_app import _result, _safe_tool, mcp
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_public_surface.py
+++ b/tests/test_public_surface.py
@@ -256,7 +256,7 @@ def test_server_tool_registry_keeps_public_tool_names():
     tool_names = {tool.name for tool in asyncio.run(mcp.list_tools())}
 
     assert tool_names >= EXPECTED_SERVER_TOOLS
-    assert len(tool_names) == 103
+    assert len(tool_names) == 115
 
 
 def test_hyperframes_tts_schema_can_list_voices_without_text():
@@ -281,7 +281,7 @@ def test_stdio_server_launches_and_lists_tools_like_registry_clients():
         tool_names = {tool.name for tool in tools_result.tools}
         assert init_result.serverInfo.name == "mcp-video"
         assert tool_names >= EXPECTED_SERVER_TOOLS
-        assert len(tool_names) == 103
+        assert len(tool_names) == 115
 
     asyncio.run(check_server())
 


### PR DESCRIPTION
## Summary
- **8 FFmpeg filter-chain effects**: rgb_shift, scanline_jitter, screen_tearing, vhs_tracking, macroblocking, datamoshing, cmyk_split, turbulent_displacement
- **4 GPU shader pipeline effects** (via headless Node.js/WebGL): digital_feedback, slit_scan, depth_splatting, point_cloud
- GPU effects use CRUSH.js GLSL shaders rendered through a headless WebGL subprocess (extract frames → render → reassemble)
- Full MCP tool registrations with parameter validation for all 12 effects
- Security: effect name allowlist, 7200-frame cap, output path validation

## Test plan
- [x] All imports verified: `from mcp_video.engine import glitch_*` (12 functions)
- [x] All MCP tools registered: `from mcp_video.server_tools_glitch* import glitch_*` (12 tools)
- [x] Pre-commit checks pass
- [ ] Integration test with sample video

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/mcp-video/pr/298"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->