### PR TITLE
docs: intake film noise chromatic distortion bug

### DIFF
--- a/docs/factory/intake/issue-302-effect-noise-with-mode-film-produces-extreme-green.md
+++ b/docs/factory/intake/issue-302-effect-noise-with-mode-film-produces-extreme-green.md
@@ -1,12 +1,12 @@
-        # Factory intake for issue #302: effect_noise with mode='film' produces extreme green/magenta chromatic distortion on image-based videos
+# Factory intake for issue #302: effect_noise with mode='film' produces extreme green/magenta chromatic distortion on image-based videos
 
-        Repository: `KyaniteLabs/mcp-video`
-        Category: `llm_fix`
-        Source issue: `#302`
+Repository: `KyaniteLabs/mcp-video`
+Category: `llm_fix`
+Source issue: `#302`
 
-        ## User request
+## User request
 
-        # Bug Report: `effect_noise` Produces Extreme Green/Magenta Chromatic Distortion
+# Bug Report: `effect_noise` Produces Extreme Green/Magenta Chromatic Distortion
 
 **Repository:** KyaniteLabs/mcp-video  
 **Version:** 1.4.0  
@@ -69,22 +69,22 @@ Investigate the FFmpeg filtergraph in `effect_noise`. The `noise` filter with `c
 2. Adding `format=yuv420p` before noise to ensure consistent chroma subsampling
 3. Using `geq` for monochrome noise across all channels equally
 
-        ## Factory interpretation
+## Factory interpretation
 
-        This issue was picked up by `issue-closer`, but no safe code edit was
-        produced by the configured agent providers. The Factory is therefore
-        converting the issue into an implementation contract instead of silently
-        skipping it.
+This issue was picked up by `issue-closer`, but no safe code edit was
+produced by the configured agent providers. The Factory is therefore
+converting the issue into an implementation contract instead of silently
+skipping it.
 
-        ## Acceptance contract
+## Acceptance contract
 
-        - Confirm the desired behavior from the issue title and body.
-        - Identify the smallest implementation slice that can ship independently.
-        - Add or update tests/proofs for that slice before merging implementation.
-        - Keep credentials, local machine paths, and deployment secrets out of the repo.
-        - Close or update the source issue when the implementation PR lands.
+- Confirm the desired behavior from the issue title and body.
+- Identify the smallest implementation slice that can ship independently.
+- Add or update tests/proofs for that slice before merging implementation.
+- Keep credentials, local machine paths, and deployment secrets out of the repo.
+- Close or update the source issue when the implementation PR lands.
 
-        ## Next Factory action
+## Next Factory action
 
-        Dispatch a repo worker against this contract. If the request is too broad,
-        split it into smaller `agent-ready` issues with concrete acceptance checks.
+Dispatch a repo worker against this contract. If the request is too broad,
+split it into smaller `agent-ready` issues with concrete acceptance checks.

--- a/docs/factory/intake/issue-302-effect-noise-with-mode-film-produces-extreme-green.md
+++ b/docs/factory/intake/issue-302-effect-noise-with-mode-film-produces-extreme-green.md
@@ -1,0 +1,90 @@
+        # Factory intake for issue #302: effect_noise with mode='film' produces extreme green/magenta chromatic distortion on image-based videos
+
+        Repository: `KyaniteLabs/mcp-video`
+        Category: `llm_fix`
+        Source issue: `#302`
+
+        ## User request
+
+        # Bug Report: `effect_noise` Produces Extreme Green/Magenta Chromatic Distortion
+
+**Repository:** KyaniteLabs/mcp-video  
+**Version:** 1.4.0  
+**Labels:** bug, effects
+
+---
+
+## Bug Summary
+
+The `effect_noise` tool with `mode="film"` and `animated=true` applies extreme green/magenta chromatic aberration that completely destroys video content, rather than subtle film grain.
+
+## Reproduction Steps
+
+1. Create a video from a static image using `video_create_from_images`
+2. Apply `effect_noise` with these params:
+   - `intensity: 0.04`
+   - `mode: "film"`
+   - `animated: true`
+3. Output shows psychedelic green/purple color channels, not film grain
+
+## Expected Behavior
+
+Subtle, natural-looking film grain texture overlaid on the video — monochrome noise that slightly varies per frame.
+
+## Actual Behavior
+
+The entire frame is flooded with green and magenta color separation. The effect looks like extreme chromatic aberration or a broken RGB channel offset. Text overlays become unreadable. The distortion is so severe it makes the footage unusable.
+
+### Before effect_noise (clean frame):
+- Dark cinematic image with warm tones
+- White text overlay clearly readable
+
+### After effect_noise (destroyed frame):
+- Entire frame dominated by neon green and purple
+- Text completely lost in the color noise
+- Looks like a broken VHS tape or corrupted video file
+
+## Environment
+
+| Key | Value |
+|-----|-------|
+| mcp-video | 1.4.0 |
+| FFmpeg | 8.1 |
+| OS | macOS |
+| Input | 1280×720 MP4 created from JPEG via `video_create_from_images` |
+
+## Additional Context
+
+The raw images themselves were fine — the bug is specifically in how `effect_noise` processes the video. When I rebuilt the same pipeline *without* the `effect_noise` step, the output was clean and professional. This suggests the FFmpeg filter chain in the noise effect has a color space or chroma subsampling issue when applied to image-to-video sources.
+
+## Workaround
+
+Skip `effect_noise` entirely for image-based videos. The images already have enough texture.
+
+## Suggested Fix
+
+Investigate the FFmpeg filtergraph in `effect_noise`. The `noise` filter with `c0,c1,c2` may be applying independent per-channel noise with `allp` point filter, which can cause channel misalignment. Consider:
+
+1. Using `c0` (luma only) for film grain instead of all planes
+2. Adding `format=yuv420p` before noise to ensure consistent chroma subsampling
+3. Using `geq` for monochrome noise across all channels equally
+
+        ## Factory interpretation
+
+        This issue was picked up by `issue-closer`, but no safe code edit was
+        produced by the configured agent providers. The Factory is therefore
+        converting the issue into an implementation contract instead of silently
+        skipping it.
+
+        ## Acceptance contract
+
+        - Confirm the desired behavior from the issue title and body.
+        - Identify the smallest implementation slice that can ship independently.
+        - Add or update tests/proofs for that slice before merging implementation.
+        - Keep credentials, local machine paths, and deployment secrets out of the repo.
+        - Close or update the source issue when the implementation PR lands.
+
+        ## Next Factory action
+
+        Dispatch a repo worker against this contract. If the request is too broad,
+        split it into smaller `agent-ready` issues with concrete acceptance checks.


### PR DESCRIPTION
<!-- factory-pr: issue=302 issue_repo=KyaniteLabs/mcp-video target_repo=KyaniteLabs/mcp-video category=factory_intake -->

## Why

`effect_noise` with `mode="film"` and `animated=true` is reported to produce extreme green/magenta chromatic distortion on image-based videos instead of subtle film grain. The configured agent providers did not produce a safe implementation patch, so this PR preserves the issue as a concrete Factory intake contract instead of silently dropping it.

Important: this PR does **not** fix issue #302 and must not close it. The issue should stay open until an implementation PR proves the film-noise behavior is corrected with tests and/or media verification.

## What changed

- Added `docs/factory/intake/issue-302-effect-noise-with-mode-film-produces-extreme-green.md` with reproduction steps, expected versus actual behavior, environment notes, workaround, suggested FFmpeg investigation paths, and an acceptance contract for the next implementation worker.
- Restored the intake document headings to column zero after Codex review flagged them as Markdown code blocks.

## Verification

- [ ] `python3 -m pytest tests/ -x -q --tb=short`
- [ ] `python3 -c "import mcp_video"`
- [ ] `./scripts/git-professional-audit.sh`
- [x] Other: `git diff --check` passed for the documentation fix.
- [x] Other: `rg -n '^[[:space:]]{4,}#' docs/factory/intake/issue-302-effect-noise-with-mode-film-produces-extreme-green.md` returned no matches after commit `331cb46`.
- [x] Other: Codex review thread is now outdated on GitHub after the heading fix was pushed.

## Maintainer checklist

- [x] Public MCP tool signatures are unchanged, or the compatibility impact is explained.
- [x] New or changed FFmpeg filter strings escape user-controlled values with `_escape_ffmpeg_filter_value()`.
- [x] Subprocess calls include a timeout and route FFmpeg failures through `ProcessingError`.
- [x] New defaults live in `defaults.py`; validation constants live in `validation.py` or `limits.py`.
- [x] No generated media, logs, caches, local research dumps, or build artifacts were committed.
- [x] Documentation, README counts, or roadmap entries were updated when the public surface changed.

<!-- EMPOWER_ORCHESTRATOR:START -->
## Empower Orchestrator checklist

- [x] I checked whether this PR reveals a repeatable task or recurring agent failure.
- [x] If it does, I either shipped the smallest durable improvement or documented why not.
- [x] Any automation or durable system change included the scale/severity/reversibility/predictability blast-radius check.
- [x] Workers/subagents stayed inside their assigned scope and verification evidence is included before completion claims.
<!-- EMPOWER_ORCHESTRATOR:END -->

Refs #302

_(Factory intake / Matt Pocock / Deep modules, domain language, disciplined diagnosis)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/mcp-video/pr/303"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation for a known issue with the film noise effect causing chromatic distortion, including reproduction steps, workarounds, and technical details.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KyaniteLabs/mcp-video/pull/303?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
