### PR TITLE
Fix design-quality scoring for audio-first videos

### DIFF
--- a/mcp_video/design_quality/guardrails/probe.py
+++ b/mcp_video/design_quality/guardrails/probe.py
@@ -28,6 +28,8 @@ class ProbeMixin:
             "ffprobe",
             "-v",
             "error",
+            "-select_streams",
+            "v:0",
             "-show_entries",
             "stream=width,height,r_frame_rate,duration",
             "-of",
@@ -47,8 +49,13 @@ class ProbeMixin:
         fps_str = probe.get("r_frame_rate", "30/1")
         if "/" in fps_str:
             num, den = fps_str.split("/")
-            return float(num) / float(den)
-        return float(fps_str)
+            numerator = float(num)
+            denominator = float(den)
+            if numerator <= 0 or denominator <= 0:
+                return 30.0
+            return numerator / denominator
+        fps = float(fps_str)
+        return fps if fps > 0 else 30.0
 
     def _get_duration(self, video_path: str) -> float:
         """Get video duration in seconds."""

--- a/tests/test_design_quality_fallback.py
+++ b/tests/test_design_quality_fallback.py
@@ -98,6 +98,28 @@ class TestTechnicalScoreDoesNotRewardFailure:
             assert score < 100, f"Technical score should not be perfect when contrast analysis failed, got {score}"
 
 
+class TestProbeVideoStreamSelection:
+    """Design quality probing must use the video stream, not the first stream."""
+
+    def test_probe_selects_first_video_stream(self, guardrails):
+        """ffprobe should explicitly select v:0 so audio-first MP4s do not produce 0/0 FPS."""
+        with patch("mcp_video.design_quality.guardrails.probe.subprocess.run") as mock_run:
+            mock_run.return_value = FakeCompletedProcess(
+                stdout='{"streams":[{"width":1280,"height":720,"r_frame_rate":"30000/1001","duration":"8.0"}]}',
+            )
+            result = guardrails._probe_video("/tmp/audio-first.mp4")
+
+        cmd = mock_run.call_args.args[0]
+        assert "-select_streams" in cmd
+        assert cmd[cmd.index("-select_streams") + 1] == "v:0"
+        assert result["width"] == 1280
+
+    def test_get_fps_falls_back_when_probe_reports_zero_rate(self, guardrails):
+        """A 0/0 frame rate should not crash design quality scoring."""
+        with patch.object(guardrails, "_probe_video", return_value={"r_frame_rate": "0/0"}):
+            assert guardrails._get_fps("/tmp/audio-first.mp4") == 30.0
+
+
 class TestCheckTypographyHandlesNone:
     """_check_typography must not silently pass when luma analysis fails."""
 


### PR DESCRIPTION
## Summary
- select the first video stream explicitly in the design-quality ffprobe call
- fall back to 30 fps when probe data reports `0/0` or another non-positive frame rate
- add regression coverage for audio-first MP4s so Content Studio dogfood captures do not crash QA

## Verification
- `/opt/homebrew/opt/python@3.11/bin/python3.11 -m pytest tests/test_design_quality_fallback.py`
- `/opt/homebrew/opt/python@3.11/bin/python3.11 -m ruff check mcp_video/design_quality/guardrails/probe.py tests/test_design_quality_fallback.py`
- `/opt/homebrew/opt/python@3.11/bin/python3.11 -c "import mcp_video; print(mcp_video.__version__)"`
- `/opt/homebrew/opt/python@3.11/bin/python3.11 -m pytest tests/ -x -q --tb=short`
- `git diff --check`

## Dogfood Evidence
The real Content Studio browser recording placed audio before video. Before this fix, `mcp-video --format json video-design-quality-check` returned `float division by zero`; after this fix, it returns `success: true` and the Content Studio QA wrapper reports `ok: true`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/mcp-video/pr/305"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->