### PR TITLE
Expose Hyperframes runtime data across public tools

### DIFF
--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -141,11 +141,11 @@ mcp-video [command] [options]
 
 | Command | Description |
 |---------|-------------|
-| `hyperframes-render` | Render a Hyperframes composition to video or PNG sequence (`--composition`, `--resolution`; width/height must map to a preset) |
+| `hyperframes-render` | Render a Hyperframes composition to video or PNG sequence (`--composition`, `--resolution`, `--variables`, `--variables-file`; width/height must map to a preset) |
 | `hyperframes-compositions` | List compositions in a Hyperframes project |
 | `hyperframes-preview` | Launch Hyperframes preview studio |
-| `hyperframes-still` | Render a single frame as an image |
-| `hyperframes-snapshot` | Capture one or more rendered PNG snapshots |
+| `hyperframes-still` | Render a single frame as an image; accepts `--variables` and `--variables-file` runtime data |
+| `hyperframes-snapshot` | Capture one or more rendered PNG snapshots; accepts `--variables` and `--variables-file` runtime data |
 | `hyperframes-inspect` | Inspect rendered layout overflow and visual issues |
 | `hyperframes-info` | Show Hyperframes project metadata |
 | `hyperframes-catalog` | Browse catalog blocks and components |

--- a/docs/PYTHON_CLIENT.md
+++ b/docs/PYTHON_CLIENT.md
@@ -224,11 +224,11 @@ print(checkpoint["quality_score"])  # Must pass min_score
 
 | Method | Returns | Description |
 |--------|---------|-------------|
-| `hyperframes_render(project_path, output?, fps?, width?, height?, composition?, quality?, format?, resolution?, workers?, crf?)` | `HyperframesRenderResult` | Render a Hyperframes composition to video or PNG sequence; width/height must map to Hyperframes resolution presets |
+| `hyperframes_render(project_path, output?, fps?, width?, height?, composition?, quality?, format?, resolution?, workers?, crf?, variables?, variables_file?)` | `HyperframesRenderResult` | Render a Hyperframes composition to video or PNG sequence; width/height must map to Hyperframes resolution presets; `variables` or `variables_file` passes runtime data |
 | `hyperframes_compositions(project_path)` | `CompositionsResult` | List compositions in a project |
 | `hyperframes_preview(project_path, port?)` | `HyperframesPreviewResult` | Launch live preview studio |
-| `hyperframes_still(project_path, output?, frame?)` | `HyperframesStillResult` | Render a single frame |
-| `hyperframes_snapshot(project_path, frames?, at?)` | `HyperframesSnapshotResult` | Capture actual PNG snapshot paths |
+| `hyperframes_still(project_path, output?, frame?, variables?, variables_file?)` | `HyperframesStillResult` | Render a single frame with optional runtime data |
+| `hyperframes_snapshot(project_path, frames?, at?, variables?, variables_file?)` | `HyperframesSnapshotResult` | Capture actual PNG snapshot paths with optional runtime data |
 | `hyperframes_inspect(project_path, samples?, strict?)` | `HyperframesJsonResult` | Inspect rendered layout issues |
 | `hyperframes_info(project_path)` | `HyperframesJsonResult` | Read project metadata |
 | `hyperframes_catalog(item_type?, tag?)` | `HyperframesJsonResult` | Browse blocks/components |

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -107,9 +107,9 @@ Create videos programmatically using [Hyperframes](https://hyperframes.io/) — 
 | Tool | Description |
 |------|-------------|
 | `hyperframes_init` | Scaffold a new Hyperframes project (blank, warm-grain, swiss-grid templates; optional media bootstrap, Tailwind, and resolution preset flags) |
-| `hyperframes_render` | Render a Hyperframes composition to video (MP4/WebM/MOV/PNG sequence; optional composition and resolution preset flags; arbitrary width/height pairs are rejected instead of silently ignored) |
-| `hyperframes_snapshot` | Capture actual PNG snapshot paths written by Hyperframes |
-| `hyperframes_still` | Backward-compatible single-frame snapshot helper |
+| `hyperframes_render` | Render a Hyperframes composition to video (MP4/WebM/MOV/PNG sequence; optional composition, resolution preset, and runtime `variables` / `variables_file` flags; arbitrary width/height pairs are rejected instead of silently ignored) |
+| `hyperframes_snapshot` | Capture actual PNG snapshot paths written by Hyperframes with optional runtime `variables` / `variables_file` data |
+| `hyperframes_still` | Backward-compatible single-frame snapshot helper with optional runtime `variables` / `variables_file` data |
 | `hyperframes_inspect` | Inspect rendered layout for overflow and visual issues |
 | `hyperframes_info` | Read project metadata |
 | `hyperframes_catalog` | Browse catalog blocks/components, including social overlays and caption styles |

--- a/mcp_video/cli/handlers_hyperframes.py
+++ b/mcp_video/cli/handlers_hyperframes.py
@@ -22,6 +22,12 @@ def handle_hyperframes_commands(args: Any, *, use_json: bool) -> bool:
     """Handle Hyperframes commands extracted from the main dispatcher."""
     runner = CommandRunner(args, use_json)
 
+    def _variables(a: Any, json_mode: bool) -> Any | None:
+        value = getattr(a, "variables", None)
+        if value is None:
+            return None
+        return _parse_json_arg(value, "variables", json_mode)
+
     def _render(a, j):
         from ..hyperframes_engine import render
 
@@ -39,6 +45,8 @@ def handle_hyperframes_commands(args: Any, *, use_json: bool) -> bool:
             resolution=getattr(a, "resolution", None),
             workers=a.workers,
             crf=a.crf,
+            variables=_variables(a, j),
+            variables_file=getattr(a, "variables_file", None),
         )
         _out(r, j, lambda res: _format_hyperframes_render(res, a.project_path))
 
@@ -74,7 +82,13 @@ def handle_hyperframes_commands(args: Any, *, use_json: bool) -> bool:
         from ..hyperframes_engine import still
 
         r = _with_spinner(
-            f"Rendering still frame {a.frame}...", still, a.project_path, output_path=a.output, frame=a.frame
+            f"Rendering still frame {a.frame}...",
+            still,
+            a.project_path,
+            output_path=a.output,
+            frame=a.frame,
+            variables=_variables(a, j),
+            variables_file=getattr(a, "variables_file", None),
         )
         _out(r, j, lambda res: _format_hyperframes_still(res, a.project_path))
 
@@ -83,7 +97,15 @@ def handle_hyperframes_commands(args: Any, *, use_json: bool) -> bool:
     def _snapshot(a, j):
         from ..hyperframes_engine import snapshot
 
-        r = _with_spinner("Capturing Hyperframes snapshots...", snapshot, a.project_path, frames=a.frames, at=a.at)
+        r = _with_spinner(
+            "Capturing Hyperframes snapshots...",
+            snapshot,
+            a.project_path,
+            frames=a.frames,
+            at=a.at,
+            variables=_variables(a, j),
+            variables_file=getattr(a, "variables_file", None),
+        )
         _out(r, j, print, json_transform=lambda r: r.model_dump() if hasattr(r, "model_dump") else r)
 
     runner.register("hyperframes-snapshot", _snapshot)

--- a/mcp_video/cli/parser/hyperframes.py
+++ b/mcp_video/cli/parser/hyperframes.py
@@ -35,6 +35,8 @@ def add_parsers(subparsers: argparse._SubParsersAction) -> None:
     )
     hyperframes_render_p.add_argument("--workers", help="Parallel render workers (number or 'auto')")
     hyperframes_render_p.add_argument("--crf", type=int, help="Override encoder CRF")
+    hyperframes_render_p.add_argument("--variables", help="Inline JSON runtime data for the composition")
+    hyperframes_render_p.add_argument("--variables-file", help="Path to JSON runtime data for the composition")
 
     # hyperframes-compositions
     hyperframes_comps_p = subparsers.add_parser(
@@ -54,11 +56,15 @@ def add_parsers(subparsers: argparse._SubParsersAction) -> None:
     hyperframes_still_p.add_argument("project_path", help="Path to Hyperframes project")
     hyperframes_still_p.add_argument("-o", "--output", help="Output image file path")
     hyperframes_still_p.add_argument("--frame", type=int, default=0, help="Frame number to render (default: 0)")
+    hyperframes_still_p.add_argument("--variables", help="Inline JSON runtime data for the composition")
+    hyperframes_still_p.add_argument("--variables-file", help="Path to JSON runtime data for the composition")
 
     snapshot_p = subparsers.add_parser("hyperframes-snapshot", help="Capture key frames as PNG screenshots")
     snapshot_p.add_argument("project_path", help="Path to Hyperframes project")
     snapshot_p.add_argument("--frames", type=int, default=5, help="Number of evenly-spaced frames")
     snapshot_p.add_argument("--at", nargs="+", type=float, help="Specific timestamps in seconds")
+    snapshot_p.add_argument("--variables", help="Inline JSON runtime data for the composition")
+    snapshot_p.add_argument("--variables-file", help="Path to JSON runtime data for the composition")
 
     inspect_p = subparsers.add_parser("hyperframes-inspect", help="Inspect Hyperframes layout overflow")
     inspect_p.add_argument("project_path", help="Path to Hyperframes project")

--- a/mcp_video/client/hyperframes.py
+++ b/mcp_video/client/hyperframes.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from ..errors import MCPVideoError
 
 
@@ -21,6 +23,8 @@ class ClientHyperframesMixin:
         resolution: str | None = None,
         workers: str | int | None = None,
         crf: int | None = None,
+        variables: Any | None = None,
+        variables_file: str | None = None,
     ) -> dict:
         """Render a Hyperframes composition to video."""
         from ..hyperframes_engine import render
@@ -37,6 +41,8 @@ class ClientHyperframesMixin:
             resolution=resolution,
             workers=workers,
             crf=crf,
+            variables=variables,
+            variables_file=variables_file,
         )
 
     def hyperframes_compositions(self, project_path: str) -> dict:
@@ -56,11 +62,13 @@ class ClientHyperframesMixin:
         project_path: str,
         output: str | None = None,
         frame: int = 0,
+        variables: Any | None = None,
+        variables_file: str | None = None,
     ) -> dict:
         """Render a single frame as image."""
         from ..hyperframes_engine import still
 
-        return still(project_path, output_path=output, frame=frame)
+        return still(project_path, output_path=output, frame=frame, variables=variables, variables_file=variables_file)
 
     def hyperframes_snapshot(
         self,
@@ -68,11 +76,20 @@ class ClientHyperframesMixin:
         frames: int = 5,
         at: list[float] | None = None,
         timeout_ms: int | None = None,
+        variables: Any | None = None,
+        variables_file: str | None = None,
     ) -> dict:
         """Capture key frames as PNG screenshots for visual verification."""
         from ..hyperframes_engine import snapshot
 
-        return snapshot(project_path, frames=frames, at=at, timeout_ms=timeout_ms)
+        return snapshot(
+            project_path,
+            frames=frames,
+            at=at,
+            timeout_ms=timeout_ms,
+            variables=variables,
+            variables_file=variables_file,
+        )
 
     def hyperframes_inspect(
         self,

--- a/mcp_video/hyperframes_engine.py
+++ b/mcp_video/hyperframes_engine.py
@@ -157,6 +157,8 @@ _SCHEMA: dict[str, dict[str, Any]] = {
             "frames": "frames",
             "at": "at_csv",
             "timeout": "timeout_ms",
+            "variables": "variables",
+            "variables-file": "variables_file",
         },
         "timeout": 120,
     },
@@ -387,6 +389,8 @@ def _hyperframes_op(
 
 def _format_cli_value(value: Any) -> str:
     """Format Hyperframes CLI flag values without introducing false precision."""
+    if isinstance(value, (dict, list)):
+        return json.dumps(value, sort_keys=True, separators=(",", ":"))
     if isinstance(value, float) and value.is_integer():
         return str(int(value))
     return str(value)
@@ -536,7 +540,7 @@ def render(
     workers: str | int | None = None,
     crf: int | None = None,
     video_bitrate: str | None = None,
-    variables: str | None = None,
+    variables: Any | None = None,
     variables_file: str | None = None,
     docker: bool = False,
     hdr: bool = False,
@@ -710,6 +714,8 @@ def still(
     project_path: str,
     output_path: str | None = None,
     frame: int = 0,
+    variables: Any | None = None,
+    variables_file: str | None = None,
 ) -> HyperframesStillResult:
     """Render a single frame from a Hyperframes composition.
 
@@ -718,7 +724,7 @@ def still(
     generated frame path instead of echoing a requested-but-unwritten path.
     """
     seconds = frame / 30.0
-    snap = snapshot(project_path, at=[seconds], frames=1)
+    snap = snapshot(project_path, at=[seconds], frames=1, variables=variables, variables_file=variables_file)
     actual_output = snap.frame_paths[0] if snap.frame_paths else output_path or ""
 
     return HyperframesStillResult(
@@ -732,6 +738,8 @@ def snapshot(
     frames: int = 5,
     at: list[float] | None = None,
     timeout_ms: int | None = None,
+    variables: Any | None = None,
+    variables_file: str | None = None,
 ) -> HyperframesSnapshotResult:
     """Capture key frames as PNG screenshots for visual verification."""
     _require_hyperframes_deps()
@@ -745,6 +753,8 @@ def snapshot(
         frames=frames if at_csv is None else None,
         at_csv=at_csv,
         timeout_ms=timeout_ms,
+        variables=variables,
+        variables_file=variables_file,
     )
     frame_paths = _snapshot_pngs(project, before)
     return HyperframesSnapshotResult(

--- a/mcp_video/hyperframes_engine.py
+++ b/mcp_video/hyperframes_engine.py
@@ -24,7 +24,7 @@ from .errors import (
     HyperframesRenderError,
     MCPVideoError,
 )
-from .ffmpeg_helpers import _validate_output_path
+from .ffmpeg_helpers import _validate_input_path, _validate_output_path
 from .hyperframes_models import (
     CompositionInfo,
     CompositionsResult,
@@ -396,6 +396,13 @@ def _format_cli_value(value: Any) -> str:
     return str(value)
 
 
+def _validate_variables_file(path: str | os.PathLike[str] | None) -> str | None:
+    """Validate optional runtime-data files before forwarding them to Hyperframes."""
+    if path is None:
+        return None
+    return _validate_input_path(str(path))
+
+
 def _post_process_ops() -> dict[str, Callable]:
     """Return the post-processing operation registry for render_and_post."""
     from . import engine as _video_engine
@@ -559,6 +566,7 @@ def render(
         output_path = _default_render_output(project_path, format)
 
     effective_resolution = _resolve_render_resolution(width, height, resolution)
+    variables_file = _validate_variables_file(variables_file)
 
     start_time = time.time()
     _result, _project = _hyperframes_op(
@@ -747,6 +755,7 @@ def snapshot(
     snapshot_dir = project / "snapshots"
     before = set(snapshot_dir.glob("*.png")) if snapshot_dir.is_dir() else set()
     at_csv = _csv(at)
+    variables_file = _validate_variables_file(variables_file)
     _hyperframes_op(
         "snapshot",
         project_path=project_path,

--- a/mcp_video/server_tools_hyperframes.py
+++ b/mcp_video/server_tools_hyperframes.py
@@ -31,7 +31,7 @@ def hyperframes_render(
     workers: str | int | None = None,
     crf: int | None = None,
     video_bitrate: str | None = None,
-    variables: str | None = None,
+    variables: Any | None = None,
     variables_file: str | None = None,
     docker: bool = False,
     hdr: bool = False,
@@ -59,6 +59,8 @@ def hyperframes_render(
         composition: Specific composition file to render instead of index.html.
         workers: Parallel render workers (number or 'auto'). Default auto.
         crf: Override encoder CRF (lower = better quality).
+        variables: Inline JSON object/string with runtime data for the composition.
+        variables_file: Path to a JSON file with runtime data for the composition.
     """
     if quality is not None and quality not in VALID_HYPERFRAMES_QUALITIES:
         return _validation_error(
@@ -152,6 +154,8 @@ def hyperframes_still(
     project_path: str,
     output_path: str | None = None,
     frame: int = 0,
+    variables: Any | None = None,
+    variables_file: str | None = None,
 ) -> dict[str, Any]:
     """Render a single frame as image from a Hyperframes composition.
 
@@ -159,11 +163,15 @@ def hyperframes_still(
         project_path: Absolute path to the Hyperframes project directory.
         output_path: Where to save the image. Auto-generated if omitted.
         frame: Frame number to render (default 0).
+        variables: Inline JSON object/string with runtime data for the composition.
+        variables_file: Path to a JSON file with runtime data for the composition.
     """
     project_path = _validate_project_path(project_path)
     from .hyperframes_engine import still
 
-    return _result(still(project_path, output_path=output_path, frame=frame))
+    return _result(
+        still(project_path, output_path=output_path, frame=frame, variables=variables, variables_file=variables_file)
+    )
 
 
 @mcp.tool()
@@ -173,6 +181,8 @@ def hyperframes_snapshot(
     frames: int = 5,
     at: list[float] | None = None,
     timeout_ms: int | None = None,
+    variables: Any | None = None,
+    variables_file: str | None = None,
 ) -> dict[str, Any]:
     """Capture key frames as PNG screenshots for visual verification."""
     if frames < 1:
@@ -180,7 +190,16 @@ def hyperframes_snapshot(
     project_path = _validate_project_path(project_path)
     from .hyperframes_engine import snapshot
 
-    return _result(snapshot(project_path, frames=frames, at=at, timeout_ms=timeout_ms))
+    return _result(
+        snapshot(
+            project_path,
+            frames=frames,
+            at=at,
+            timeout_ms=timeout_ms,
+            variables=variables,
+            variables_file=variables_file,
+        )
+    )
 
 
 @mcp.tool()

--- a/tests/test_cli_handlers.py
+++ b/tests/test_cli_handlers.py
@@ -342,6 +342,100 @@ class TestHandlersHyperframes:
         assert captured["project_path"] == "/tmp/project"
         assert captured["kwargs"]["format"] == "webm"
 
+    def test_render_json_forwards_runtime_variables(self, monkeypatch, capsys):
+        from mcp_video.cli.handlers_hyperframes import handle_hyperframes_commands
+
+        captured = {}
+
+        def fake_render(project_path, **kwargs):
+            captured["project_path"] = project_path
+            captured["kwargs"] = kwargs
+            return {"success": True, "output_path": "/tmp/render.mp4"}
+
+        monkeypatch.setattr("mcp_video.hyperframes_engine.render", fake_render)
+        monkeypatch.setattr(
+            "mcp_video.cli.handlers_hyperframes._with_spinner",
+            lambda _label, fn, *args, **kwargs: fn(*args, **kwargs),
+        )
+        args = _make_args(
+            command="hyperframes-render",
+            project_path="/tmp/project",
+            variables='{"title":"Launch"}',
+            variables_file="/tmp/render-vars.json",
+            output_format="mp4",
+        )
+
+        result = handle_hyperframes_commands(args, use_json=True)
+        data = json.loads(capsys.readouterr().out)
+
+        assert result is True
+        assert data["success"] is True
+        assert captured["kwargs"]["variables"] == {"title": "Launch"}
+        assert captured["kwargs"]["variables_file"] == "/tmp/render-vars.json"
+
+    def test_still_json_forwards_runtime_variables(self, monkeypatch, capsys):
+        from mcp_video.cli.handlers_hyperframes import handle_hyperframes_commands
+
+        captured = {}
+
+        def fake_still(project_path, **kwargs):
+            captured["project_path"] = project_path
+            captured["kwargs"] = kwargs
+            return {"success": True, "output_path": "/tmp/still.png"}
+
+        monkeypatch.setattr("mcp_video.hyperframes_engine.still", fake_still)
+        monkeypatch.setattr(
+            "mcp_video.cli.handlers_hyperframes._with_spinner",
+            lambda _label, fn, *args, **kwargs: fn(*args, **kwargs),
+        )
+        args = _make_args(
+            command="hyperframes-still",
+            project_path="/tmp/project",
+            frame=10,
+            variables='{"title":"Still"}',
+            variables_file="/tmp/still-vars.json",
+        )
+
+        result = handle_hyperframes_commands(args, use_json=True)
+        data = json.loads(capsys.readouterr().out)
+
+        assert result is True
+        assert data["success"] is True
+        assert captured["kwargs"]["variables"] == {"title": "Still"}
+        assert captured["kwargs"]["variables_file"] == "/tmp/still-vars.json"
+
+    def test_snapshot_json_forwards_runtime_variables(self, monkeypatch, capsys):
+        from mcp_video.cli.handlers_hyperframes import handle_hyperframes_commands
+
+        captured = {}
+
+        def fake_snapshot(project_path, **kwargs):
+            captured["project_path"] = project_path
+            captured["kwargs"] = kwargs
+            return {"frame_paths": ["/tmp/snap.png"]}
+
+        monkeypatch.setattr("mcp_video.hyperframes_engine.snapshot", fake_snapshot)
+        monkeypatch.setattr(
+            "mcp_video.cli.handlers_hyperframes._with_spinner",
+            lambda _label, fn, *args, **kwargs: fn(*args, **kwargs),
+        )
+        args = _make_args(
+            command="hyperframes-snapshot",
+            project_path="/tmp/project",
+            frames=1,
+            at=None,
+            variables='{"title":"Snapshot"}',
+            variables_file="/tmp/snapshot-vars.json",
+        )
+
+        result = handle_hyperframes_commands(args, use_json=True)
+        data = json.loads(capsys.readouterr().out)
+
+        assert result is True
+        assert data["frame_paths"] == ["/tmp/snap.png"]
+        assert captured["kwargs"]["variables"] == {"title": "Snapshot"}
+        assert captured["kwargs"]["variables_file"] == "/tmp/snapshot-vars.json"
+
 
 class TestHandlersImage:
     def test_all_commands_register(self, monkeypatch):

--- a/tests/test_cli_parsers.py
+++ b/tests/test_cli_parsers.py
@@ -209,6 +209,47 @@ class TestParserHyperframes:
         assert args.resolution == "portrait"
         assert args.output_format == "png-sequence"
 
+    def test_render_still_and_snapshot_accept_runtime_data_flags(self):
+        from mcp_video.cli.parser import build_parser
+
+        render_args = build_parser().parse_args(
+            [
+                "hyperframes-render",
+                "project",
+                "--variables",
+                '{"title":"Launch"}',
+                "--variables-file",
+                "/tmp/render-vars.json",
+            ]
+        )
+        still_args = build_parser().parse_args(
+            [
+                "hyperframes-still",
+                "project",
+                "--variables",
+                '{"title":"Still"}',
+                "--variables-file",
+                "/tmp/still-vars.json",
+            ]
+        )
+        snapshot_args = build_parser().parse_args(
+            [
+                "hyperframes-snapshot",
+                "project",
+                "--variables",
+                '{"title":"Snapshot"}',
+                "--variables-file",
+                "/tmp/snapshot-vars.json",
+            ]
+        )
+
+        assert render_args.variables == '{"title":"Launch"}'
+        assert render_args.variables_file == "/tmp/render-vars.json"
+        assert still_args.variables == '{"title":"Still"}'
+        assert still_args.variables_file == "/tmp/still-vars.json"
+        assert snapshot_args.variables == '{"title":"Snapshot"}'
+        assert snapshot_args.variables_file == "/tmp/snapshot-vars.json"
+
     def test_init_add_and_benchmark_accept_current_hyperframes_flags(self):
         from mcp_video.cli.parser import build_parser
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -564,6 +564,15 @@ class TestClientAgentApiConsistency:
         assert "images" in info["parameters"]
         assert info["return_type"] == "EditResult"
 
+    def test_hyperframes_runtime_data_is_in_client_signatures(self, editor):
+        render = editor.inspect("hyperframes_render")
+        still = editor.inspect("hyperframes_still")
+        snapshot = editor.inspect("hyperframes_snapshot")
+
+        for info in (render, still, snapshot):
+            assert "variables" in info["parameters"]
+            assert "variables_file" in info["parameters"]
+
     def test_pipeline_chains_edit_results(self, editor, monkeypatch):
         calls = []
 

--- a/tests/test_hyperframes_engine.py
+++ b/tests/test_hyperframes_engine.py
@@ -278,6 +278,38 @@ class TestRender:
             assert "--width" not in cmd
             assert "--height" not in cmd
 
+    def test_render_serializes_inline_variables(self, sample_hyperframes_project):
+        """render() should pass inline runtime data as JSON to Hyperframes."""
+        project = str(sample_hyperframes_project)
+        fake_cp = _make_completed_process(stdout="done")
+
+        with (
+            _mock_deps_ok(),
+            patch("mcp_video.hyperframes_engine.subprocess.run", return_value=fake_cp) as mock_run,
+            patch("os.path.isfile", return_value=True),
+            patch("os.path.getsize", return_value=2 * 1024 * 1024),
+        ):
+            render(project, output_path="/tmp/out.mp4", variables={"title": "Launch", "count": 3})
+
+        cmd = mock_run.call_args[0][0]
+        assert cmd[cmd.index("--variables") + 1] == '{"count":3,"title":"Launch"}'
+
+    def test_render_accepts_variables_file(self, sample_hyperframes_project):
+        """render() should pass variables_file to Hyperframes."""
+        project = str(sample_hyperframes_project)
+        fake_cp = _make_completed_process(stdout="done")
+
+        with (
+            _mock_deps_ok(),
+            patch("mcp_video.hyperframes_engine.subprocess.run", return_value=fake_cp) as mock_run,
+            patch("os.path.isfile", return_value=True),
+            patch("os.path.getsize", return_value=2 * 1024 * 1024),
+        ):
+            render(project, output_path="/tmp/out.mp4", variables_file="/tmp/variables.json")
+
+        cmd = mock_run.call_args[0][0]
+        assert cmd[cmd.index("--variables-file") + 1] == "/tmp/variables.json"
+
     def test_raises_on_nonzero_exit(self, sample_hyperframes_project):
         """render() should raise HyperframesRenderError on non-zero exit."""
         project = str(sample_hyperframes_project)
@@ -651,6 +683,18 @@ class TestStill:
             idx = cmd.index("--at")
             assert cmd[idx + 1] == "1.4"
 
+    def test_forwards_runtime_variables_to_snapshot(self, sample_hyperframes_project):
+        """still() should pass runtime data through to the snapshot CLI."""
+        project = Path(sample_hyperframes_project)
+        fake_cp = _make_completed_process(stdout="Rendered frame.")
+
+        with _mock_deps_ok(), patch("mcp_video.hyperframes_engine.subprocess.run", return_value=fake_cp) as mock_run:
+            still(str(project), frame=42, variables={"headline": "Runtime"}, variables_file="/tmp/runtime.json")
+
+        cmd = mock_run.call_args[0][0]
+        assert cmd[cmd.index("--variables") + 1] == '{"headline":"Runtime"}'
+        assert cmd[cmd.index("--variables-file") + 1] == "/tmp/runtime.json"
+
 
 class TestSnapshot:
     """Tests for Hyperframes 0.5 snapshot path handling."""
@@ -684,6 +728,18 @@ class TestSnapshot:
         assert "snapshot" in cmd
         assert "--at" in cmd
         assert cmd[cmd.index("--at") + 1] == "0.5,1.25"
+
+    def test_builds_runtime_data_args(self, sample_hyperframes_project):
+        project = str(sample_hyperframes_project)
+        fake_cp = _make_completed_process(stdout="captured")
+
+        with _mock_deps_ok(), patch("mcp_video.hyperframes_engine.subprocess.run", return_value=fake_cp) as mock_run:
+            snapshot(project, frames=1, variables={"quote": "Hello"}, variables_file="/tmp/vars.json")
+
+        cmd = mock_run.call_args[0][0]
+        assert "snapshot" in cmd
+        assert cmd[cmd.index("--variables") + 1] == '{"quote":"Hello"}'
+        assert cmd[cmd.index("--variables-file") + 1] == "/tmp/vars.json"
 
     def test_still_returns_actual_snapshot_path_not_requested_path(self, sample_hyperframes_project):
         project = Path(sample_hyperframes_project)

--- a/tests/test_hyperframes_engine.py
+++ b/tests/test_hyperframes_engine.py
@@ -33,6 +33,7 @@ from mcp_video.errors import (
     HyperframesNotFoundError,
     HyperframesProjectError,
     HyperframesRenderError,
+    InputFileError,
     MCPVideoError,
 )
 
@@ -294,9 +295,11 @@ class TestRender:
         cmd = mock_run.call_args[0][0]
         assert cmd[cmd.index("--variables") + 1] == '{"count":3,"title":"Launch"}'
 
-    def test_render_accepts_variables_file(self, sample_hyperframes_project):
+    def test_render_accepts_variables_file(self, sample_hyperframes_project, tmp_path):
         """render() should pass variables_file to Hyperframes."""
         project = str(sample_hyperframes_project)
+        variables_file = tmp_path / "variables.json"
+        variables_file.write_text('{"title":"Launch"}')
         fake_cp = _make_completed_process(stdout="done")
 
         with (
@@ -305,10 +308,23 @@ class TestRender:
             patch("os.path.isfile", return_value=True),
             patch("os.path.getsize", return_value=2 * 1024 * 1024),
         ):
-            render(project, output_path="/tmp/out.mp4", variables_file="/tmp/variables.json")
+            render(project, output_path="/tmp/out.mp4", variables_file=str(variables_file))
 
         cmd = mock_run.call_args[0][0]
-        assert cmd[cmd.index("--variables-file") + 1] == "/tmp/variables.json"
+        assert cmd[cmd.index("--variables-file") + 1] == str(variables_file)
+
+    def test_render_validates_variables_file(self, sample_hyperframes_project):
+        """render() should reject missing variables_file before subprocess execution."""
+        project = str(sample_hyperframes_project)
+
+        with (
+            _mock_deps_ok(),
+            patch("mcp_video.hyperframes_engine.subprocess.run") as mock_run,
+            pytest.raises(InputFileError),
+        ):
+            render(project, output_path="/tmp/out.mp4", variables_file="/tmp/missing-variables.json")
+
+        mock_run.assert_not_called()
 
     def test_raises_on_nonzero_exit(self, sample_hyperframes_project):
         """render() should raise HyperframesRenderError on non-zero exit."""
@@ -683,17 +699,19 @@ class TestStill:
             idx = cmd.index("--at")
             assert cmd[idx + 1] == "1.4"
 
-    def test_forwards_runtime_variables_to_snapshot(self, sample_hyperframes_project):
+    def test_forwards_runtime_variables_to_snapshot(self, sample_hyperframes_project, tmp_path):
         """still() should pass runtime data through to the snapshot CLI."""
         project = Path(sample_hyperframes_project)
+        variables_file = tmp_path / "runtime.json"
+        variables_file.write_text('{"headline":"Runtime"}')
         fake_cp = _make_completed_process(stdout="Rendered frame.")
 
         with _mock_deps_ok(), patch("mcp_video.hyperframes_engine.subprocess.run", return_value=fake_cp) as mock_run:
-            still(str(project), frame=42, variables={"headline": "Runtime"}, variables_file="/tmp/runtime.json")
+            still(str(project), frame=42, variables={"headline": "Runtime"}, variables_file=str(variables_file))
 
         cmd = mock_run.call_args[0][0]
         assert cmd[cmd.index("--variables") + 1] == '{"headline":"Runtime"}'
-        assert cmd[cmd.index("--variables-file") + 1] == "/tmp/runtime.json"
+        assert cmd[cmd.index("--variables-file") + 1] == str(variables_file)
 
 
 class TestSnapshot:
@@ -729,17 +747,31 @@ class TestSnapshot:
         assert "--at" in cmd
         assert cmd[cmd.index("--at") + 1] == "0.5,1.25"
 
-    def test_builds_runtime_data_args(self, sample_hyperframes_project):
+    def test_builds_runtime_data_args(self, sample_hyperframes_project, tmp_path):
         project = str(sample_hyperframes_project)
+        variables_file = tmp_path / "vars.json"
+        variables_file.write_text('{"quote":"Hello"}')
         fake_cp = _make_completed_process(stdout="captured")
 
         with _mock_deps_ok(), patch("mcp_video.hyperframes_engine.subprocess.run", return_value=fake_cp) as mock_run:
-            snapshot(project, frames=1, variables={"quote": "Hello"}, variables_file="/tmp/vars.json")
+            snapshot(project, frames=1, variables={"quote": "Hello"}, variables_file=str(variables_file))
 
         cmd = mock_run.call_args[0][0]
         assert "snapshot" in cmd
         assert cmd[cmd.index("--variables") + 1] == '{"quote":"Hello"}'
-        assert cmd[cmd.index("--variables-file") + 1] == "/tmp/vars.json"
+        assert cmd[cmd.index("--variables-file") + 1] == str(variables_file)
+
+    def test_validates_variables_file(self, sample_hyperframes_project):
+        project = str(sample_hyperframes_project)
+
+        with (
+            _mock_deps_ok(),
+            patch("mcp_video.hyperframes_engine.subprocess.run") as mock_run,
+            pytest.raises(InputFileError),
+        ):
+            snapshot(project, frames=1, variables_file="/tmp/missing-snapshot-vars.json")
+
+        mock_run.assert_not_called()
 
     def test_still_returns_actual_snapshot_path_not_requested_path(self, sample_hyperframes_project):
         project = Path(sample_hyperframes_project)

--- a/tests/test_public_surface.py
+++ b/tests/test_public_surface.py
@@ -379,3 +379,20 @@ def test_module_reexports():
         "video_batch",
     ]:
         assert hasattr(engine, name), f"engine missing {name}"
+
+
+def test_hyperframes_runtime_data_public_signatures():
+    """Hyperframes runtime-data controls stay visible on public tool surfaces."""
+    import inspect
+
+    from mcp_video import server_tools_hyperframes as tools
+    from mcp_video.client import Client
+
+    server_methods = [tools.hyperframes_render, tools.hyperframes_still, tools.hyperframes_snapshot]
+    client = Client()
+    client_methods = [client.hyperframes_render, client.hyperframes_still, client.hyperframes_snapshot]
+
+    for method in [*server_methods, *client_methods]:
+        params = inspect.signature(method).parameters
+        assert "variables" in params
+        assert "variables_file" in params


### PR DESCRIPTION
## Summary
- add runtime-data support to Hyperframes still/snapshot paths via optional variables and variables_file parameters
- expose variables / variables_file consistently through MCP server tools, Python client, and CLI parser/handlers
- document the new runtime-data surface and lock it with engine, CLI, client, and public-signature tests

Closes #306.

## Verification
- python3 -m pytest tests/test_hyperframes_engine.py tests/test_cli_parsers.py tests/test_cli_handlers.py tests/test_client.py tests/test_public_surface.py
- python3 -m pytest
- python3 -m pytest tests/ -x -q --tb=short
- python3 -m ruff check mcp_video tests
- python3 -m ruff format --check mcp_video tests
- git diff --check
- python3 -c 'import mcp_video'

## Notes
- Uses the existing Hyperframes naming, variables / variables_file, rather than introducing Remotion-specific props as the canonical public name.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/mcp-video/pr/313"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781937820&installation_id=130430723&pr_number=313&repository=KyaniteLabs%2Fmcp-video&return_to=https%3A%2F%2Fgithub.com%2FKyaniteLabs%2Fmcp-video%2Fpull%2F313&signature=44579ad21ccba348144c2423f47d344752dc8b0c2f30d11087555ff91ce5b7c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for passing runtime template variables to Hyperframes operations via --variables (inline JSON) and --variables-file (path), exposed in CLI commands and client methods.

* **Documentation**
  * CLI reference, Python client docs, and tool docs updated to document the new runtime variables parameters.

* **Tests**
  * Added tests covering CLI parsing/handlers, client signatures, engine behavior, and validation for runtime variables.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KyaniteLabs/mcp-video/pull/313?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->