### PR TITLE
Unblock Hyperframes NucBox dogfood

### DIFF
--- a/mcp_video/doctor.py
+++ b/mcp_video/doctor.py
@@ -11,6 +11,7 @@ import sys
 from collections.abc import Callable
 from typing import Any
 
+from .hyperframes_engine import HYPERFRAMES_COMMAND_PREFIX
 from .limits import DOCTOR_COMMAND_TIMEOUT
 
 WhichFn = Callable[[str], str | None]
@@ -52,6 +53,13 @@ COMMAND_CHECKS = (
         "required": False,
         "command": ["npx", "--version"],
         "install_hint": "Install npx/npm for Hyperframes CLI execution.",
+    },
+    {
+        "name": "npm",
+        "category": "hyperframes",
+        "required": False,
+        "command": ["npm", "--version"],
+        "install_hint": "Install npm for Hyperframes package diagnostics.",
     },
 )
 
@@ -111,6 +119,7 @@ def _check_command(definition: dict[str, Any], which: WhichFn, version_runner: V
         "ok": ok,
         "path": path,
         "version": version,
+        "command": definition["command"],
         "install_hint": None if ok else definition["install_hint"],
     }
 
@@ -140,6 +149,61 @@ def _check_package(
     }
 
 
+def _check_mcp_video(find_spec: FindSpecFn, package_version: PackageVersionFn) -> dict[str, Any]:
+    spec = find_spec("mcp_video")
+    path = getattr(spec, "origin", None) if spec is not None else None
+    found = spec is not None
+    return {
+        "name": "mcp-video",
+        "category": "core",
+        "required": True,
+        "ok": found,
+        "path": path,
+        "version": package_version("mcp-video") if found else None,
+        "install_hint": None if found else "Install the local package: pip install mcp-video",
+    }
+
+
+def _check_hyperframes_cli(which: WhichFn, version_runner: VersionRunner) -> dict[str, Any]:
+    command = [*HYPERFRAMES_COMMAND_PREFIX, "--version"]
+    path = which("npx")
+    version = version_runner(command) if path else None
+    ok = path is not None and version is not None
+    return {
+        "name": "hyperframes",
+        "category": "hyperframes",
+        "required": False,
+        "ok": ok,
+        "path": path,
+        "version": version,
+        "command": command,
+        "install_hint": None
+        if ok
+        else "Install Hyperframes or make it resolvable with: npx --yes hyperframes --version",
+    }
+
+
+def _check_hyperframes_core(which: WhichFn, version_runner: VersionRunner) -> dict[str, Any]:
+    command = [
+        "node",
+        "-e",
+        "try { console.log(require('@hyperframes/core/package.json').version) } catch (err) { process.exit(1) }",
+    ]
+    path = which("node")
+    version = version_runner(command) if path else None
+    ok = path is not None and version is not None
+    return {
+        "name": "@hyperframes/core",
+        "category": "hyperframes",
+        "required": False,
+        "ok": ok,
+        "path": path,
+        "version": version,
+        "command": command,
+        "install_hint": None if ok else "Install @hyperframes/core in the active Node package layout.",
+    }
+
+
 def _summary(checks: list[dict[str, Any]]) -> dict[str, Any]:
     required = [check for check in checks if check["required"]]
     optional = [check for check in checks if not check["required"]]
@@ -163,7 +227,14 @@ def run_diagnostics(
     package_version: PackageVersionFn = _package_version,
 ) -> dict[str, Any]:
     """Return a structured report for core and optional integration dependencies."""
-    checks = [_check_command(definition, which, version_runner) for definition in COMMAND_CHECKS]
+    checks = [_check_mcp_video(find_spec, package_version)]
+    checks.extend(_check_command(definition, which, version_runner) for definition in COMMAND_CHECKS)
+    checks.extend(
+        [
+            _check_hyperframes_cli(which, version_runner),
+            _check_hyperframes_core(which, version_runner),
+        ]
+    )
     checks.extend(
         _check_package(*definition, find_spec=find_spec, package_version=package_version)
         for definition in PACKAGE_CHECKS

--- a/mcp_video/hyperframes_engine.py
+++ b/mcp_video/hyperframes_engine.py
@@ -14,6 +14,7 @@ import re
 import shutil
 import subprocess
 import time
+import contextlib
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any
@@ -38,6 +39,8 @@ from .hyperframes_models import (
     HyperframesStillResult,
     HyperframesValidationResult,
 )
+
+HYPERFRAMES_COMMAND_PREFIX = ["npx", "--yes", "hyperframes"]
 
 
 # ---------------------------------------------------------------------------
@@ -93,7 +96,7 @@ def _run_hyperframes(
     timeout: int = 600,
 ) -> subprocess.CompletedProcess[str]:
     """Run an npx hyperframes command and return the CompletedProcess."""
-    cmd = ["npx", "--yes", "--no-install", "hyperframes", *args]
+    cmd = [*HYPERFRAMES_COMMAND_PREFIX, *args]
     try:
         return subprocess.run(
             cmd,
@@ -658,6 +661,26 @@ def _parse_compositions_output(stdout: str) -> list[dict[str, Any]]:
     return comps
 
 
+def _coerce_float(value: Any) -> float | None:
+    with contextlib.suppress(TypeError, ValueError):
+        return float(value)
+    return None
+
+
+def _composition_duration_frames(data: dict[str, Any]) -> int:
+    fps = _coerce_float(data.get("fps")) or 30.0
+    frame_value = data.get("durationInFrames", data.get("duration_in_frames"))
+    frames = _coerce_float(frame_value)
+    if frames and frames > 0:
+        return round(frames)
+
+    seconds = _coerce_float(data.get("durationInSeconds", data.get("duration")))
+    if seconds and seconds > 0:
+        return round(seconds * fps)
+
+    return 0
+
+
 def compositions(
     project_path: str,
 ) -> CompositionsResult:
@@ -674,7 +697,7 @@ def compositions(
                 width=c.get("width", 1920),
                 height=c.get("height", 1080),
                 fps=c.get("fps", 30),
-                duration_in_frames=c.get("durationInFrames", c.get("duration", 0)),
+                duration_in_frames=_composition_duration_frames(c),
                 default_props=c.get("defaultProps", {}),
             )
         )
@@ -696,7 +719,7 @@ def preview(
     _require_hyperframes_deps()
     project, _entry_point = _validate_project(project_path)
 
-    cmd = ["npx", "--yes", "--no-install", "hyperframes", "preview", str(project), "--port", str(port)]
+    cmd = [*HYPERFRAMES_COMMAND_PREFIX, "preview", str(project), "--port", str(port)]
     proc = subprocess.Popen(
         cmd,
         cwd=str(project),

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -4,36 +4,56 @@ import json
 import subprocess
 import sys
 from importlib.machinery import ModuleSpec
+from pathlib import Path
 
 
 def test_run_diagnostics_marks_required_tools_ok_when_present():
     from mcp_video.doctor import run_diagnostics
 
     def fake_which(name: str) -> str | None:
-        return f"/usr/bin/{name}" if name in {"ffmpeg", "ffprobe"} else None
+        return f"/usr/bin/{name}" if name in {"ffmpeg", "ffprobe", "node", "npm", "npx"} else None
 
     def fake_version(command: list[str]) -> str | None:
+        if command[:3] == ["npx", "--yes", "hyperframes"]:
+            return "0.6.31"
+        if command[:2] == ["node", "-e"]:
+            return "0.6.31"
         return f"{command[0]} version test"
 
-    present_packages = {"mcp", "pydantic", "rich"}
+    present_packages = {"mcp", "pydantic", "rich", "mcp_video"}
 
     def fake_find_spec(name: str) -> ModuleSpec | None:
-        return ModuleSpec(name, loader=None) if name in present_packages else None
+        if name not in present_packages:
+            return None
+        spec = ModuleSpec(name, loader=None)
+        if name == "mcp_video":
+            spec.origin = "/env/site-packages/mcp_video/__init__.py"
+        return spec
 
     report = run_diagnostics(
         which=fake_which,
         version_runner=fake_version,
         find_spec=fake_find_spec,
-        package_version=lambda name: "1.0.0" if name in present_packages else None,
+        package_version=lambda name: (
+            "1.4.0" if name == "mcp-video" else ("1.0.0" if name in present_packages else None)
+        ),
     )
 
     checks = {check["name"]: check for check in report["checks"]}
     assert report["success"] is True
     assert report["summary"]["required_ok"] is True
+    assert checks["mcp-video"]["ok"] is True
+    assert checks["mcp-video"]["version"] == "1.4.0"
+    assert checks["mcp-video"]["path"] == "/env/site-packages/mcp_video/__init__.py"
     assert checks["ffmpeg"]["ok"] is True
     assert checks["ffprobe"]["ok"] is True
     assert checks["node"]["required"] is False
-    assert checks["node"]["ok"] is False
+    assert checks["node"]["ok"] is True
+    assert checks["npm"]["ok"] is True
+    assert checks["npx"]["ok"] is True
+    assert checks["hyperframes"]["ok"] is True
+    assert checks["hyperframes"]["command"] == ["npx", "--yes", "hyperframes", "--version"]
+    assert checks["@hyperframes/core"]["ok"] is True
 
 
 def test_run_diagnostics_marks_required_tools_missing():
@@ -117,7 +137,7 @@ def test_run_diagnostics_explains_python313_basicsr_guard(monkeypatch):
 def test_run_diagnostics_requires_matching_distribution_for_package_checks():
     from mcp_video.doctor import run_diagnostics
 
-    present = {"mcp", "pydantic", "rich", "cv2"}
+    present = {"mcp", "pydantic", "rich", "cv2", "mcp_video"}
 
     def fake_find_spec(name: str) -> ModuleSpec | None:
         return ModuleSpec(name, loader=None) if name in present else None
@@ -138,6 +158,29 @@ def test_run_diagnostics_requires_matching_distribution_for_package_checks():
     assert checks["opencv-contrib-python"]["version"] is None
 
 
+def test_run_diagnostics_reports_mcp_video_import_path_when_distribution_metadata_missing():
+    from mcp_video.doctor import run_diagnostics
+
+    def fake_find_spec(name: str) -> ModuleSpec | None:
+        if name != "mcp_video":
+            return ModuleSpec(name, loader=None) if name in {"mcp", "pydantic", "rich"} else None
+        spec = ModuleSpec(name, loader=None)
+        spec.origin = str(Path("/repo/mcp_video/__init__.py"))
+        return spec
+
+    report = run_diagnostics(
+        which=lambda name: f"/usr/bin/{name}" if name in {"ffmpeg", "ffprobe"} else None,
+        version_runner=lambda command: f"{command[0]} version test",
+        find_spec=fake_find_spec,
+        package_version=lambda name: None,
+    )
+
+    checks = {check["name"]: check for check in report["checks"]}
+    assert checks["mcp-video"]["ok"] is True
+    assert checks["mcp-video"]["path"] == "/repo/mcp_video/__init__.py"
+    assert checks["mcp-video"]["version"] is None
+
+
 def test_cli_doctor_json_outputs_structured_report():
     result = subprocess.run(
         [sys.executable, "-m", "mcp_video", "doctor", "--json"],
@@ -151,6 +194,7 @@ def test_cli_doctor_json_outputs_structured_report():
     assert data["success"] is True
     assert "summary" in data
     assert isinstance(data["checks"], list)
+    assert any(check["name"] == "mcp-video" for check in data["checks"])
     assert any(check["name"] == "ffmpeg" for check in data["checks"])
 
 
@@ -165,4 +209,5 @@ def test_cli_doctor_text_outputs_summary():
     assert result.returncode == 0
     assert "mcp-video doctor" in result.stdout
     assert "ffmpeg" in result.stdout
+    assert "hyperframes" in result.stdout
     assert "openai-whisper" in result.stdout

--- a/tests/test_hyperframes_engine.py
+++ b/tests/test_hyperframes_engine.py
@@ -73,10 +73,10 @@ def _mock_deps_ok():
 
 
 def _has_real_hyperframes_cli() -> bool:
-    """Return True only when the no-install Hyperframes CLI path works."""
+    """Return True only when the same package-resolving Hyperframes CLI path works."""
     try:
         result = subprocess.run(
-            ["npx", "--yes", "--no-install", "hyperframes", "--version"],
+            ["npx", "--yes", "hyperframes", "--version"],
             capture_output=True,
             text=True,
             timeout=15,
@@ -201,7 +201,8 @@ class TestRender:
             call_args = mock_run.call_args
             cmd = call_args[0][0]
             assert cmd[0] == "npx"
-            assert cmd[1:4] == ["--yes", "--no-install", "hyperframes"]
+            assert cmd[1:3] == ["--yes", "hyperframes"]
+            assert "--no-install" not in cmd
             assert "render" in cmd
             assert "/tmp/out.mp4" in cmd
             assert "--fps" in cmd
@@ -560,6 +561,44 @@ class TestCompositions:
             assert len(result.compositions) == 1
             assert result.compositions[0].id == "A"
 
+    def test_computes_frames_from_duration_seconds(self, sample_hyperframes_project):
+        """Seconds-based Hyperframes output should report frames, not raw seconds."""
+        project = str(sample_hyperframes_project)
+        comp_json = json.dumps(
+            {
+                "id": "main",
+                "width": 1080,
+                "height": 1920,
+                "fps": 30,
+                "duration": 5,
+            }
+        )
+        fake_cp = _make_completed_process(stdout=comp_json)
+
+        with _mock_deps_ok(), patch("mcp_video.hyperframes_engine.subprocess.run", return_value=fake_cp):
+            result = compositions(project)
+
+        assert result.compositions[0].duration_in_frames == 150
+
+    def test_computes_frames_from_duration_in_seconds_alias(self, sample_hyperframes_project):
+        """Alternate upstream duration key should still produce frame counts."""
+        project = str(sample_hyperframes_project)
+        comp_json = json.dumps(
+            {
+                "id": "main",
+                "width": 1080,
+                "height": 1920,
+                "fps": 29.97,
+                "durationInSeconds": 4,
+            }
+        )
+        fake_cp = _make_completed_process(stdout=comp_json)
+
+        with _mock_deps_ok(), patch("mcp_video.hyperframes_engine.subprocess.run", return_value=fake_cp):
+            result = compositions(project)
+
+        assert result.compositions[0].duration_in_frames == 120
+
     def test_handles_invalid_json(self, sample_hyperframes_project):
         """compositions() should return empty list when JSON is invalid."""
         project = str(sample_hyperframes_project)
@@ -641,7 +680,8 @@ class TestPreview:
             call_args = mock_popen.call_args
             cmd = call_args[0][0]
             assert cmd[0] == "npx"
-            assert cmd[1:4] == ["--yes", "--no-install", "hyperframes"]
+            assert cmd[1:3] == ["--yes", "hyperframes"]
+            assert "--no-install" not in cmd
             assert "preview" in cmd
             assert "--port" in cmd
             idx = cmd.index("--port")
@@ -968,7 +1008,8 @@ class TestCreateProject:
             call_args = mock_run.call_args
             cmd = call_args[0][0]
             assert cmd[0] == "npx"
-            assert cmd[1:4] == ["--yes", "--no-install", "hyperframes"]
+            assert cmd[1:3] == ["--yes", "hyperframes"]
+            assert "--no-install" not in cmd
             assert "init" in cmd
             assert "test-project" in cmd
             assert "--example" in cmd
@@ -1355,7 +1396,7 @@ class TestErrorHandling:
 @pytest.mark.hyperframes
 @pytest.mark.skipif(
     not _has_real_hyperframes_cli(),
-    reason="requires a locally installed Hyperframes CLI available via npx --no-install",
+    reason="requires a Hyperframes CLI available via npx --yes hyperframes",
 )
 class TestHyperframesIntegration:
     """Integration tests that require a real Node.js/Hyperframes installation."""

--- a/tests/test_hyperframes_engine.py
+++ b/tests/test_hyperframes_engine.py
@@ -1,6 +1,7 @@
 """Tests for the Hyperframes engine."""
 
 import json
+import os
 import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -73,7 +74,9 @@ def _mock_deps_ok():
 
 
 def _has_real_hyperframes_cli() -> bool:
-    """Return True only when the same package-resolving Hyperframes CLI path works."""
+    """Return True only when explicit integration runs should probe Hyperframes."""
+    if os.environ.get("MCP_VIDEO_RUN_HYPERFRAMES_INTEGRATION") != "1":
+        return False
     try:
         result = subprocess.run(
             ["npx", "--yes", "hyperframes", "--version"],

--- a/tests/test_launch_remediation.py
+++ b/tests/test_launch_remediation.py
@@ -50,7 +50,7 @@ def test_mograph_frame_count_is_capped(monkeypatch):
     assert result["error"]["code"] == "mograph_too_large"
 
 
-def test_hyperframes_command_uses_no_install_npx(monkeypatch, tmp_path):
+def test_hyperframes_command_uses_package_resolving_npx(monkeypatch, tmp_path):
     from mcp_video import hyperframes_engine
 
     project = tmp_path / "project"
@@ -73,7 +73,8 @@ def test_hyperframes_command_uses_no_install_npx(monkeypatch, tmp_path):
 
     hyperframes_engine.compositions(str(project))
 
-    assert captured["cmd"][:4] == ["npx", "--yes", "--no-install", "hyperframes"]
+    assert captured["cmd"][:3] == ["npx", "--yes", "hyperframes"]
+    assert "--no-install" not in captured["cmd"]
 
 
 def test_ytdlp_rejects_resolved_private_media_url(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- remove the `npx --no-install` Hyperframes command path so the CLI can resolve the installed/pinned package layout used on the NucBox
- compute `hyperframes-compositions` frame counts from seconds-based upstream duration fields when `durationInFrames` is absent or zero
- expand `mcp-video doctor` with mcp-video import/version, npm, Hyperframes CLI, and `@hyperframes/core` checks for offline preflight diagnostics
- keep live Hyperframes integration tests opt-in with `MCP_VIDEO_RUN_HYPERFRAMES_INTEGRATION=1` so normal CI does not fetch npm packages during collection

## Issues
Closes #314
Closes #315
Closes #316

## Verification
- `python3 -m pytest tests/ -x -q --tb=short` -> 1182 passed, 29 skipped
- `python3 -c "import mcp_video; print(mcp_video.__name__)"`
- `uvx ruff check mcp_video/hyperframes_engine.py mcp_video/doctor.py tests/test_hyperframes_engine.py tests/test_doctor.py tests/test_launch_remediation.py`
- `uvx ruff format --check mcp_video/hyperframes_engine.py mcp_video/doctor.py tests/test_hyperframes_engine.py tests/test_doctor.py tests/test_launch_remediation.py`
- `python3 -m mcp_video doctor --json` smoke verified the new preflight fields


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Diagnostics now detect and report mcp_video and Hyperframes presence, including reported path, version and probe command.

* **Improvements**
  * Standardized Hyperframes command invocation for more reliable CLI resolution.
  * Composition parsing enhanced to compute frame durations from multiple duration field formats.

* **Tests**
  * Expanded tests and CLI specs to cover the new diagnostics and updated Hyperframes command behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KyaniteLabs/mcp-video/pull/317?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->