### PR TITLE
Pin Hyperframes command resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ pip install mcp-video
 mcp-video doctor
 ```
 
-Hyperframes tools additionally need Node.js 22+ because they call the Hyperframes CLI through `npx`.
+Hyperframes tools additionally need Node.js 22+ and a resolvable Hyperframes CLI. Install/pin Hyperframes in the active Node package layout, add `hyperframes` to `PATH`, or set `MCP_VIDEO_HYPERFRAMES_COMMAND`.
 
 ## Quick Start
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -38,7 +38,7 @@ python -m pytest tests/test_real_all_features.py -v -m "not slow"
 
 ## Hyperframes Tests
 
-Run Hyperframes-specific tests (requires Node.js 22+ and `npx hyperframes`):
+Run Hyperframes-specific tests (requires Node.js 22+ and a resolvable local Hyperframes CLI):
 
 ```bash
 python -m pytest tests/test_hyperframes_engine.py -v

--- a/mcp_video/doctor.py
+++ b/mcp_video/doctor.py
@@ -11,7 +11,8 @@ import sys
 from collections.abc import Callable
 from typing import Any
 
-from .hyperframes_engine import HYPERFRAMES_COMMAND_PREFIX
+from .errors import HyperframesNotFoundError
+from .hyperframes_engine import HYPERFRAMES_COMMAND_ENV, _hyperframes_command_prefix
 from .limits import DOCTOR_COMMAND_TIMEOUT
 
 WhichFn = Callable[[str], str | None]
@@ -52,7 +53,7 @@ COMMAND_CHECKS = (
         "category": "hyperframes",
         "required": False,
         "command": ["npx", "--version"],
-        "install_hint": "Install npx/npm for Hyperframes CLI execution.",
+        "install_hint": "Install npx/npm only if your chosen Hyperframes package layout uses it.",
     },
     {
         "name": "npm",
@@ -165,8 +166,12 @@ def _check_mcp_video(find_spec: FindSpecFn, package_version: PackageVersionFn) -
 
 
 def _check_hyperframes_cli(which: WhichFn, version_runner: VersionRunner) -> dict[str, Any]:
-    command = [*HYPERFRAMES_COMMAND_PREFIX, "--version"]
-    path = which("npx")
+    try:
+        prefix = _hyperframes_command_prefix(which=which)
+    except HyperframesNotFoundError:
+        prefix = ["hyperframes"]
+    command = [*prefix, "--version"]
+    path = prefix[0] if prefix != ["hyperframes"] else which("hyperframes")
     version = version_runner(command) if path else None
     ok = path is not None and version is not None
     return {
@@ -179,7 +184,7 @@ def _check_hyperframes_cli(which: WhichFn, version_runner: VersionRunner) -> dic
         "command": command,
         "install_hint": None
         if ok
-        else "Install Hyperframes or make it resolvable with: npx --yes hyperframes --version",
+        else (f"Install a pinned Hyperframes package, add hyperframes to PATH, or set {HYPERFRAMES_COMMAND_ENV}."),
     }
 
 

--- a/mcp_video/errors.py
+++ b/mcp_video/errors.py
@@ -112,7 +112,7 @@ class HyperframesNotFoundError(MCPVideoError):
     """Hyperframes CLI or Node.js not found on PATH."""
 
     def __init__(self, detail: str = "") -> None:
-        msg = "Hyperframes requires Node.js 22+ and npx. Install Node.js from https://nodejs.org"
+        msg = "Hyperframes requires Node.js 22+ and a resolvable Hyperframes CLI."
         if detail:
             msg += f" — {detail}"
         super().__init__(
@@ -121,7 +121,10 @@ class HyperframesNotFoundError(MCPVideoError):
             code="hyperframes_not_found",
             suggested_action={
                 "auto_fix": False,
-                "description": "Install Node.js (v22+) and ensure npx is on PATH, then run: npx hyperframes --version",
+                "description": (
+                    "Install Node.js (v22+) and a pinned Hyperframes package, add hyperframes to PATH, "
+                    "or set MCP_VIDEO_HYPERFRAMES_COMMAND."
+                ),
             },
         )
 

--- a/mcp_video/hyperframes_engine.py
+++ b/mcp_video/hyperframes_engine.py
@@ -1,4 +1,4 @@
-"""Hyperframes engine — subprocess wrappers calling npx hyperframes CLI.
+"""Hyperframes engine — subprocess wrappers calling the Hyperframes CLI.
 
 No pip packages needed — Hyperframes is external (Node.js).
 
@@ -11,11 +11,12 @@ from __future__ import annotations
 import json
 import os
 import re
+import shlex
 import shutil
 import subprocess
 import time
 import contextlib
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from pathlib import Path
 from typing import Any
 
@@ -40,7 +41,9 @@ from .hyperframes_models import (
     HyperframesValidationResult,
 )
 
-HYPERFRAMES_COMMAND_PREFIX = ["npx", "--yes", "hyperframes"]
+HYPERFRAMES_COMMAND_ENV = "MCP_VIDEO_HYPERFRAMES_COMMAND"
+HYPERFRAMES_COMMAND_PREFIX = ["hyperframes"]
+_HYPERFRAMES_BINARY_NAMES = ("hyperframes", "hyperframes.cmd")
 
 
 # ---------------------------------------------------------------------------
@@ -58,12 +61,62 @@ def _validate_project_name(name: str) -> str:
     return name
 
 
-def _require_hyperframes_deps() -> None:
-    """Raise a helpful error if Node.js/npx are not available."""
+def _find_local_hyperframes_binary(cwd: str | Path | None) -> Path | None:
+    start = Path(cwd) if cwd is not None else Path.cwd()
+    try:
+        start = start.resolve()
+    except OSError:
+        start = start.absolute()
+    if start.is_file():
+        start = start.parent
+
+    for base in (start, *start.parents):
+        for name in _HYPERFRAMES_BINARY_NAMES:
+            candidate = base / "node_modules" / ".bin" / name
+            if candidate.is_file() and (name.endswith(".cmd") or os.access(candidate, os.X_OK)):
+                return candidate
+    return None
+
+
+def _hyperframes_command_prefix(
+    cwd: str | Path | None = None,
+    *,
+    env: Mapping[str, str] | None = None,
+    which: Callable[[str], str | None] | None = None,
+) -> list[str]:
+    env_map = os.environ if env is None else env
+    which_fn = shutil.which if which is None else which
+    configured = env_map.get(HYPERFRAMES_COMMAND_ENV)
+    if configured is not None:
+        command = shlex.split(configured)
+        if command:
+            return command
+        raise HyperframesNotFoundError(f"{HYPERFRAMES_COMMAND_ENV} is set but empty")
+
+    local_binary = _find_local_hyperframes_binary(cwd)
+    if local_binary is not None:
+        return [str(local_binary)]
+
+    path_binary = which_fn("hyperframes")
+    if path_binary:
+        return [path_binary]
+
+    raise HyperframesNotFoundError(
+        "Hyperframes CLI not found. Install a pinned Hyperframes package with "
+        "node_modules/.bin/hyperframes, add hyperframes to PATH, or set "
+        f"{HYPERFRAMES_COMMAND_ENV}."
+    )
+
+
+def _require_node() -> None:
     if shutil.which("node") is None:
         raise HyperframesNotFoundError("node not found on PATH")
-    if shutil.which("npx") is None:
-        raise HyperframesNotFoundError("npx not found on PATH")
+
+
+def _require_hyperframes_deps(cwd: str | Path | None = None) -> None:
+    """Raise a helpful error if Node.js/Hyperframes are not available."""
+    _require_node()
+    _hyperframes_command_prefix(cwd=cwd)
 
 
 def _find_entry_point(project: Path) -> Path:
@@ -95,8 +148,8 @@ def _run_hyperframes(
     cwd: str | Path,
     timeout: int = 600,
 ) -> subprocess.CompletedProcess[str]:
-    """Run an npx hyperframes command and return the CompletedProcess."""
-    cmd = [*HYPERFRAMES_COMMAND_PREFIX, *args]
+    """Run a Hyperframes command and return the CompletedProcess."""
+    cmd = [*_hyperframes_command_prefix(cwd=cwd), *args]
     try:
         return subprocess.run(
             cmd,
@@ -108,7 +161,7 @@ def _run_hyperframes(
     except subprocess.TimeoutExpired:
         raise HyperframesRenderError(" ".join(cmd), -1, "Render timed out") from None
     except FileNotFoundError:
-        raise HyperframesNotFoundError("npx command not found") from None
+        raise HyperframesNotFoundError(f"{cmd[0]} command not found") from None
 
 
 # ---------------------------------------------------------------------------
@@ -332,7 +385,7 @@ def _hyperframes_op(
             code="invalid_parameter",
         )
 
-    _require_hyperframes_deps()
+    _require_node()
 
     cwd_key = spec.get("cwd_key", "project_path")
     if cwd_key is None:
@@ -350,6 +403,8 @@ def _hyperframes_op(
             cwd, _entry_point = _validate_project(cwd_val)
         else:
             cwd = Path(cwd_val).resolve()
+
+    _require_hyperframes_deps(cwd=cwd)
 
     args: list[str] = [spec["subcommand"]]
 
@@ -716,10 +771,11 @@ def preview(
     """Launch Hyperframes preview studio (non-blocking)."""
     if port < 1024 or port > 65535:
         raise HyperframesProjectError(str(project_path), "Preview port must be between 1024 and 65535")
-    _require_hyperframes_deps()
+    _require_node()
     project, _entry_point = _validate_project(project_path)
+    _require_hyperframes_deps(cwd=project)
 
-    cmd = [*HYPERFRAMES_COMMAND_PREFIX, "preview", str(project), "--port", str(port)]
+    cmd = [*_hyperframes_command_prefix(cwd=project), "preview", str(project), "--port", str(port)]
     proc = subprocess.Popen(
         cmd,
         cwd=str(project),
@@ -773,7 +829,7 @@ def snapshot(
     variables_file: str | None = None,
 ) -> HyperframesSnapshotResult:
     """Capture key frames as PNG screenshots for visual verification."""
-    _require_hyperframes_deps()
+    _require_node()
     project, _entry_point = _validate_project(project_path)
     snapshot_dir = project / "snapshots"
     before = set(snapshot_dir.glob("*.png")) if snapshot_dir.is_dir() else set()
@@ -963,7 +1019,7 @@ def create_project(
     project_dir = Path(output_dir) / name
     _validate_output_path(str(project_dir))
 
-    _require_hyperframes_deps()
+    _require_hyperframes_deps(cwd=output_dir)
 
     if project_dir.exists() and any(project_dir.iterdir()):
         print(f"Warning: Project directory already exists and is not empty — files will be overwritten: {project_dir}")
@@ -1021,14 +1077,16 @@ def validate(
     except HyperframesProjectError:
         issues.append("No HTML entry point found (expected index.html)")
 
-    # Check Node.js/npx
+    # Check Node.js/Hyperframes
     if shutil.which("node") is None:
         issues.append("Node.js not found on PATH")
-    if shutil.which("npx") is None:
-        issues.append("npx not found on PATH")
+    try:
+        _hyperframes_command_prefix(cwd=p)
+    except HyperframesNotFoundError as e:
+        issues.append(f"Hyperframes CLI not found: {e}")
 
     # Run hyperframes lint if deps are available
-    if shutil.which("npx") is not None:
+    if shutil.which("node") is not None and not any("Hyperframes CLI not found" in issue for issue in issues):
         try:
             result = _run_hyperframes(["lint", str(p), "--json"], cwd=p, timeout=60)
             if result.returncode != 0:

--- a/mcp_video/hyperframes_engine.py
+++ b/mcp_video/hyperframes_engine.py
@@ -44,6 +44,7 @@ from .hyperframes_models import (
 HYPERFRAMES_COMMAND_ENV = "MCP_VIDEO_HYPERFRAMES_COMMAND"
 HYPERFRAMES_COMMAND_PREFIX = ["hyperframes"]
 _HYPERFRAMES_BINARY_NAMES = ("hyperframes", "hyperframes.cmd")
+_WINDOWS_COMMAND_PATH_RE = re.compile(r"^([A-Za-z]:\\.*?\.(?:bat|cmd|exe|ps1))(?=\s|$)", re.IGNORECASE)
 
 
 # ---------------------------------------------------------------------------
@@ -78,6 +79,26 @@ def _find_local_hyperframes_binary(cwd: str | Path | None) -> Path | None:
     return None
 
 
+def _split_configured_hyperframes_command(value: str) -> list[str]:
+    configured = value.strip()
+    if not configured:
+        return []
+
+    candidate = Path(configured).expanduser()
+    if candidate.is_file():
+        return [str(candidate)]
+
+    windows_match = _WINDOWS_COMMAND_PATH_RE.match(configured)
+    if windows_match:
+        command = windows_match.group(1)
+        rest = configured[windows_match.end() :].strip()
+        if not rest:
+            return [command]
+        return [command, *[part.strip('"') for part in shlex.split(rest, posix=False)]]
+
+    return [part.strip('"') for part in shlex.split(configured, posix=os.name != "nt")]
+
+
 def _hyperframes_command_prefix(
     cwd: str | Path | None = None,
     *,
@@ -88,7 +109,7 @@ def _hyperframes_command_prefix(
     which_fn = shutil.which if which is None else which
     configured = env_map.get(HYPERFRAMES_COMMAND_ENV)
     if configured is not None:
-        command = shlex.split(configured)
+        command = _split_configured_hyperframes_command(configured)
         if command:
             return command
         raise HyperframesNotFoundError(f"{HYPERFRAMES_COMMAND_ENV} is set but empty")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
 client = ["pillow>=10.0"]
 image = ["pillow>=10.0", "scikit-learn>=1.3", "webcolors>=1.13"]
 image-ai = ["pillow>=10.0", "scikit-learn>=1.3", "webcolors>=1.13", "anthropic>=0.96.0"]
-hyperframes = []  # External: Node.js + Hyperframes CLI (npx hyperframes)
+hyperframes = []  # External: Node.js + resolvable Hyperframes CLI
 transcribe = ["openai-whisper>=20231117"]
 ai-scene = ["imagehash>=4.3", "Pillow>=10.0"]
 stems = ["demucs>=4.0", "torch>=2.0", "torchaudio>=2.0", "torchcodec>=0.8"]

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -11,10 +11,10 @@ def test_run_diagnostics_marks_required_tools_ok_when_present():
     from mcp_video.doctor import run_diagnostics
 
     def fake_which(name: str) -> str | None:
-        return f"/usr/bin/{name}" if name in {"ffmpeg", "ffprobe", "node", "npm", "npx"} else None
+        return f"/usr/bin/{name}" if name in {"ffmpeg", "ffprobe", "node", "npm", "npx", "hyperframes"} else None
 
     def fake_version(command: list[str]) -> str | None:
-        if command[:3] == ["npx", "--yes", "hyperframes"]:
+        if command[:1] == ["/usr/bin/hyperframes"]:
             return "0.6.31"
         if command[:2] == ["node", "-e"]:
             return "0.6.31"
@@ -52,7 +52,7 @@ def test_run_diagnostics_marks_required_tools_ok_when_present():
     assert checks["npm"]["ok"] is True
     assert checks["npx"]["ok"] is True
     assert checks["hyperframes"]["ok"] is True
-    assert checks["hyperframes"]["command"] == ["npx", "--yes", "hyperframes", "--version"]
+    assert checks["hyperframes"]["command"] == ["/usr/bin/hyperframes", "--version"]
     assert checks["@hyperframes/core"]["ok"] is True
 
 

--- a/tests/test_hyperframes_engine.py
+++ b/tests/test_hyperframes_engine.py
@@ -9,6 +9,8 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from mcp_video.hyperframes_engine import (
+    HYPERFRAMES_COMMAND_ENV,
+    _hyperframes_command_prefix,
     _require_hyperframes_deps,
     _validate_project,
     add_block,
@@ -51,7 +53,7 @@ def _make_completed_process(
 ) -> subprocess.CompletedProcess[str]:
     """Create a fake subprocess.CompletedProcess for mocking."""
     return subprocess.CompletedProcess(
-        args=["npx", "hyperframes"],
+        args=["hyperframes"],
         returncode=returncode,
         stdout=stdout,
         stderr=stderr,
@@ -59,14 +61,17 @@ def _make_completed_process(
 
 
 def _hyperframes_subcommand(cmd: list[str]) -> str:
-    return cmd[cmd.index("hyperframes") + 1]
+    for index, value in enumerate(cmd):
+        if Path(value).name in {"hyperframes", "hyperframes.cmd"}:
+            return cmd[index + 1]
+    raise AssertionError(f"hyperframes command not found in {cmd!r}")
 
 
 def _mock_deps_ok():
-    """Return a patcher that makes shutil.which find node and npx."""
+    """Return a patcher that makes shutil.which find Node and Hyperframes."""
 
     def _which(name: str):
-        if name in ("node", "npx"):
+        if name in ("node", "npm", "npx", "hyperframes"):
             return f"/usr/bin/{name}"
         return None
 
@@ -78,15 +83,24 @@ def _has_real_hyperframes_cli() -> bool:
     if os.environ.get("MCP_VIDEO_RUN_HYPERFRAMES_INTEGRATION") != "1":
         return False
     try:
+        command = [*_hyperframes_command_prefix(), "--version"]
         result = subprocess.run(
-            ["npx", "--yes", "hyperframes", "--version"],
+            command,
             capture_output=True,
             text=True,
             timeout=15,
         )
-    except (FileNotFoundError, subprocess.TimeoutExpired):
+    except (FileNotFoundError, HyperframesNotFoundError, subprocess.TimeoutExpired):
         return False
     return result.returncode == 0
+
+
+def _write_local_hyperframes_bin(project: Path) -> Path:
+    bin_path = project / "node_modules" / ".bin" / "hyperframes"
+    bin_path.parent.mkdir(parents=True)
+    bin_path.write_text("#!/bin/sh\n", encoding="utf-8")
+    bin_path.chmod(0o755)
+    return bin_path
 
 
 # ---------------------------------------------------------------------------
@@ -105,22 +119,24 @@ class TestRequireHyperframesDeps:
         mock_which.assert_called_with("node")
 
     @patch("mcp_video.hyperframes_engine.shutil.which")
-    def test_raises_when_npx_missing(self, mock_which):
-        """Should raise HyperframesNotFoundError when npx is not on PATH."""
+    def test_raises_when_hyperframes_missing(self, mock_which):
+        """Should raise HyperframesNotFoundError when the Hyperframes CLI is unavailable."""
 
         def _which(name: str):
             if name == "node":
                 return "/usr/bin/node"
+            if name == "npx":
+                return "/usr/bin/npx"
             return None
 
         mock_which.side_effect = _which
 
-        with pytest.raises(HyperframesNotFoundError, match="npx not found"):
+        with pytest.raises(HyperframesNotFoundError, match="Hyperframes CLI not found"):
             _require_hyperframes_deps()
 
     @patch("mcp_video.hyperframes_engine.shutil.which")
     def test_passes_when_both_found(self, mock_which):
-        """Should not raise when both node and npx are available."""
+        """Should not raise when Node and Hyperframes are available."""
 
         def _which(name: str):
             return f"/usr/bin/{name}"
@@ -128,6 +144,33 @@ class TestRequireHyperframesDeps:
         mock_which.side_effect = _which
 
         _require_hyperframes_deps()  # should not raise
+
+    def test_prefers_configured_hyperframes_command(self, monkeypatch):
+        monkeypatch.setenv(HYPERFRAMES_COMMAND_ENV, "/opt/hyperframes/bin/hyperframes --project-root /srv/app")
+
+        assert _hyperframes_command_prefix() == ["/opt/hyperframes/bin/hyperframes", "--project-root", "/srv/app"]
+
+    def test_prefers_local_node_modules_binary(self, tmp_path, monkeypatch):
+        monkeypatch.delenv(HYPERFRAMES_COMMAND_ENV, raising=False)
+        expected = _write_local_hyperframes_bin(tmp_path)
+        monkeypatch.setattr(
+            "mcp_video.hyperframes_engine.shutil.which", lambda name: "/usr/bin/node" if name == "node" else None
+        )
+
+        assert _hyperframes_command_prefix(cwd=tmp_path) == [str(expected)]
+
+    def test_does_not_fall_back_to_package_resolving_npx(self, monkeypatch):
+        monkeypatch.delenv(HYPERFRAMES_COMMAND_ENV, raising=False)
+
+        def _which(name: str):
+            if name in {"node", "npx"}:
+                return f"/usr/bin/{name}"
+            return None
+
+        monkeypatch.setattr("mcp_video.hyperframes_engine.shutil.which", _which)
+
+        with pytest.raises(HyperframesNotFoundError, match="set MCP_VIDEO_HYPERFRAMES_COMMAND"):
+            _hyperframes_command_prefix()
 
     def test_raises_with_correct_error_type(self):
         """HyperframesNotFoundError should have error_type='dependency_error'."""
@@ -183,7 +226,7 @@ class TestRender:
     """Tests for render()."""
 
     def test_builds_correct_cli_args(self, sample_hyperframes_project):
-        """render() should invoke npx hyperframes with the right arguments."""
+        """render() should invoke Hyperframes with the right arguments."""
         project = str(sample_hyperframes_project)
         fake_cp = _make_completed_process(stdout="Rendered.")
 
@@ -203,8 +246,8 @@ class TestRender:
 
             call_args = mock_run.call_args
             cmd = call_args[0][0]
-            assert cmd[0] == "npx"
-            assert cmd[1:3] == ["--yes", "hyperframes"]
+            assert Path(cmd[0]).name in {"hyperframes", "hyperframes.cmd"}
+            assert "npx" not in cmd[:3]
             assert "--no-install" not in cmd
             assert "render" in cmd
             assert "/tmp/out.mp4" in cmd
@@ -669,7 +712,7 @@ class TestPreview:
             assert result.port == 8080
 
     def test_launches_popen_with_correct_command(self, sample_hyperframes_project):
-        """preview() should launch npx hyperframes preview with --port."""
+        """preview() should launch Hyperframes preview with --port."""
         project = str(sample_hyperframes_project)
         mock_proc = MagicMock()
         mock_proc.poll.return_value = None
@@ -682,8 +725,8 @@ class TestPreview:
 
             call_args = mock_popen.call_args
             cmd = call_args[0][0]
-            assert cmd[0] == "npx"
-            assert cmd[1:3] == ["--yes", "hyperframes"]
+            assert Path(cmd[0]).name in {"hyperframes", "hyperframes.cmd"}
+            assert "npx" not in cmd[:3]
             assert "--no-install" not in cmd
             assert "preview" in cmd
             assert "--port" in cmd
@@ -847,7 +890,7 @@ class TestHyperframes05Tools:
 
         assert result.items[0]["name"] == "tiktok-follow"
         cmd = mock_run.call_args[0][0]
-        assert cmd[0] == "npx"
+        assert cmd[0] == "/usr/bin/hyperframes"
         assert _hyperframes_subcommand(cmd) == "catalog"
         assert "--json" in cmd
         assert "--tag" in cmd
@@ -878,7 +921,7 @@ class TestHyperframes05Tools:
 
         assert result.data["projectPath"].endswith("captured")
         cmd = mock_run.call_args[0][0]
-        assert cmd[0] == "npx"
+        assert cmd[0] == "/usr/bin/hyperframes"
         assert _hyperframes_subcommand(cmd) == "capture"
         assert "https://example.com" in cmd
         assert "--json" in cmd
@@ -991,7 +1034,7 @@ class TestCreateProject:
             create_project("safe-name", output_dir="bad\x00dir")
 
     def test_runs_hyperframes_init(self, tmp_path):
-        """create_project() should run npx hyperframes init with correct args."""
+        """create_project() should run Hyperframes init with correct args."""
         with _mock_deps_ok(), patch("mcp_video.hyperframes_engine.subprocess.run") as mock_run:
             mock_run.return_value = _make_completed_process(stdout="initialized")
 
@@ -1010,8 +1053,8 @@ class TestCreateProject:
 
             call_args = mock_run.call_args
             cmd = call_args[0][0]
-            assert cmd[0] == "npx"
-            assert cmd[1:3] == ["--yes", "hyperframes"]
+            assert Path(cmd[0]).name in {"hyperframes", "hyperframes.cmd"}
+            assert "npx" not in cmd[:3]
             assert "--no-install" not in cmd
             assert "init" in cmd
             assert "test-project" in cmd
@@ -1069,7 +1112,7 @@ class TestValidate:
 
         assert result.valid is False
         assert any("Node.js" in i for i in result.issues)
-        assert any("npx" in i for i in result.issues)
+        assert any("Hyperframes CLI" in i for i in result.issues)
 
     def test_valid_project(self, tmp_path):
         """validate() should return valid=True for a well-formed project."""
@@ -1115,7 +1158,7 @@ class TestAddBlock:
     """Tests for add_block()."""
 
     def test_adds_block_with_correct_args(self, sample_hyperframes_project):
-        """add_block() should invoke npx hyperframes add with the block name."""
+        """add_block() should invoke Hyperframes add with the block name."""
         project = str(sample_hyperframes_project)
         fake_cp = _make_completed_process(stdout='{"files": ["blocks/test.tsx"]}')
 
@@ -1157,7 +1200,7 @@ class TestRenderAndPost:
         """render_and_post() should render then apply resize."""
 
         def _which(name: str):
-            if name in ("node", "npx"):
+            if name in ("node", "npx", "hyperframes"):
                 return f"/usr/bin/{name}"
             if name in ("ffmpeg", "ffprobe"):
                 return f"/usr/bin/{name}"
@@ -1194,7 +1237,7 @@ class TestRenderAndPost:
         """render_and_post() should chain multiple post-processing ops."""
 
         def _which(name: str):
-            if name in ("node", "npx", "ffmpeg", "ffprobe"):
+            if name in ("node", "npx", "hyperframes", "ffmpeg", "ffprobe"):
                 return f"/usr/bin/{name}"
             return None
 
@@ -1228,7 +1271,7 @@ class TestRenderAndPost:
         """render_and_post() should not report success when Hyperframes produced no artifact."""
 
         def _which(name: str):
-            if name in ("node", "npx"):
+            if name in ("node", "npx", "hyperframes"):
                 return f"/usr/bin/{name}"
             return None
 
@@ -1249,7 +1292,7 @@ class TestRenderAndPost:
         """render_and_post() should raise MCPVideoError for unknown operations."""
 
         def _which(name: str):
-            if name in ("node", "npx"):
+            if name in ("node", "npx", "hyperframes"):
                 return f"/usr/bin/{name}"
             return None
 
@@ -1276,7 +1319,7 @@ class TestRenderAndPost:
         """render_and_post() should accept 'type' key as alias for 'op'."""
 
         def _which(name: str):
-            if name in ("node", "npx", "ffmpeg", "ffprobe"):
+            if name in ("node", "npx", "hyperframes", "ffmpeg", "ffprobe"):
                 return f"/usr/bin/{name}"
             return None
 
@@ -1317,19 +1360,19 @@ class TestErrorHandling:
         project = str(sample_hyperframes_project)
 
         with _mock_deps_ok(), patch("mcp_video.hyperframes_engine.subprocess.run") as mock_run:
-            mock_run.side_effect = subprocess.TimeoutExpired(cmd="npx", timeout=600)
+            mock_run.side_effect = subprocess.TimeoutExpired(cmd="hyperframes", timeout=600)
 
             with pytest.raises(HyperframesRenderError, match="timed out"):
                 render(project, output_path="/tmp/out.mp4")
 
-    def test_render_npx_not_found(self, sample_hyperframes_project):
-        """render() should raise HyperframesNotFoundError when npx binary is missing."""
+    def test_render_hyperframes_not_found(self, sample_hyperframes_project):
+        """render() should raise HyperframesNotFoundError when the CLI binary is missing."""
         project = str(sample_hyperframes_project)
 
         with _mock_deps_ok(), patch("mcp_video.hyperframes_engine.subprocess.run") as mock_run:
-            mock_run.side_effect = FileNotFoundError("npx not found")
+            mock_run.side_effect = FileNotFoundError("hyperframes not found")
 
-            with pytest.raises(HyperframesNotFoundError, match="npx command not found"):
+            with pytest.raises(HyperframesNotFoundError, match="hyperframes command not found"):
                 render(project, output_path="/tmp/out.mp4")
 
     def test_render_error_has_command_and_returncode(self, sample_hyperframes_project):
@@ -1399,7 +1442,7 @@ class TestErrorHandling:
 @pytest.mark.hyperframes
 @pytest.mark.skipif(
     not _has_real_hyperframes_cli(),
-    reason="requires a Hyperframes CLI available via npx --yes hyperframes",
+    reason="requires a local Hyperframes CLI",
 )
 class TestHyperframesIntegration:
     """Integration tests that require a real Node.js/Hyperframes installation."""

--- a/tests/test_hyperframes_engine.py
+++ b/tests/test_hyperframes_engine.py
@@ -150,6 +150,20 @@ class TestRequireHyperframesDeps:
 
         assert _hyperframes_command_prefix() == ["/opt/hyperframes/bin/hyperframes", "--project-root", "/srv/app"]
 
+    def test_preserves_unquoted_windows_hyperframes_command_path(self, monkeypatch):
+        monkeypatch.setenv(HYPERFRAMES_COMMAND_ENV, r"C:\Program Files\Hyperframes\hyperframes.cmd")
+
+        assert _hyperframes_command_prefix() == [r"C:\Program Files\Hyperframes\hyperframes.cmd"]
+
+    def test_preserves_unquoted_windows_hyperframes_command_path_with_args(self, monkeypatch):
+        monkeypatch.setenv(HYPERFRAMES_COMMAND_ENV, r"C:\Program Files\Hyperframes\hyperframes.cmd --profile prod")
+
+        assert _hyperframes_command_prefix() == [
+            r"C:\Program Files\Hyperframes\hyperframes.cmd",
+            "--profile",
+            "prod",
+        ]
+
     def test_prefers_local_node_modules_binary(self, tmp_path, monkeypatch):
         monkeypatch.delenv(HYPERFRAMES_COMMAND_ENV, raising=False)
         expected = _write_local_hyperframes_bin(tmp_path)

--- a/tests/test_launch_remediation.py
+++ b/tests/test_launch_remediation.py
@@ -50,12 +50,16 @@ def test_mograph_frame_count_is_capped(monkeypatch):
     assert result["error"]["code"] == "mograph_too_large"
 
 
-def test_hyperframes_command_uses_package_resolving_npx(monkeypatch, tmp_path):
+def test_hyperframes_command_uses_local_pinned_binary(monkeypatch, tmp_path):
     from mcp_video import hyperframes_engine
 
     project = tmp_path / "project"
     project.mkdir()
     (project / "index.html").write_text("<html></html>")
+    local_bin = project / "node_modules" / ".bin" / "hyperframes"
+    local_bin.parent.mkdir(parents=True)
+    local_bin.write_text("#!/bin/sh\n", encoding="utf-8")
+    local_bin.chmod(0o755)
     captured = {}
 
     def fake_run(cmd, **kwargs):
@@ -68,12 +72,13 @@ def test_hyperframes_command_uses_package_resolving_npx(monkeypatch, tmp_path):
 
         return Result()
 
-    monkeypatch.setattr(hyperframes_engine.shutil, "which", lambda name: f"/usr/bin/{name}")
+    monkeypatch.setattr(hyperframes_engine.shutil, "which", lambda name: "/usr/bin/node" if name == "node" else None)
     monkeypatch.setattr(hyperframes_engine.subprocess, "run", fake_run)
 
     hyperframes_engine.compositions(str(project))
 
-    assert captured["cmd"][:3] == ["npx", "--yes", "hyperframes"]
+    assert captured["cmd"][:2] == [str(local_bin), "compositions"]
+    assert "npx" not in captured["cmd"]
     assert "--no-install" not in captured["cmd"]
 
 


### PR DESCRIPTION
## Summary
- resolves Hyperframes via `MCP_VIDEO_HYPERFRAMES_COMMAND`, local `node_modules/.bin/hyperframes`, or an installed `hyperframes` binary
- removes the default runtime path that could implicitly fetch `npx --yes hyperframes`
- updates doctor, validation errors, docs, and tests around the pinned/local-first contract

## Verification
- `python3 -m pytest tests/ -x -q --tb=short` -> 1185 passed, 29 skipped
- `python3 -m pytest tests/test_hyperframes_engine.py tests/test_doctor.py tests/test_launch_remediation.py -q` -> 96 passed, 2 skipped
- `uvx ruff check mcp_video/hyperframes_engine.py mcp_video/doctor.py mcp_video/errors.py tests/test_hyperframes_engine.py tests/test_doctor.py tests/test_launch_remediation.py`
- `uvx ruff format --check mcp_video/hyperframes_engine.py mcp_video/doctor.py mcp_video/errors.py tests/test_hyperframes_engine.py tests/test_doctor.py tests/test_launch_remediation.py`
- `python3 -c "import mcp_video"`
- `python3 -m mcp_video doctor --json` smoke

Follow-up to the Codex P1 review note on PR #317.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/mcp-video/pr/318"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781985707&installation_id=130430723&pr_number=318&repository=KyaniteLabs%2Fmcp-video&return_to=https%3A%2F%2Fgithub.com%2FKyaniteLabs%2Fmcp-video%2Fpull%2F318&signature=f3f7c3836ecf46e98ba9b58179ede5980f35b86f2447897bfeccb533e017f685"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added environment variable MCP_VIDEO_HYPERFRAMES_COMMAND to override the Hyperframes CLI.

* **Improvements**
  * CLI discovery now prefers a local or PATH-resolved Hyperframes binary instead of invoking via npx, with clearer diagnostics when Node.js or the CLI are missing.
  * Project operations now validate Node.js and the resolved Hyperframes CLI before running related tasks.

* **Documentation**
  * Installation and testing docs updated to require Node.js 22+ and describe local/PATH/env options for resolving Hyperframes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KyaniteLabs/mcp-video/pull/318?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->