### PR TITLE
docs: add public mcp-video agent skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,10 @@
 # mcp-video — Project Rules
 
+## Public Agent Skill
+- `skills/mcp-video/SKILL.md` is the public skill for this repo.
+- Invoke `$mcp-video` in compatible agent hosts for guarded video inspection, editing, Hyperframes, repurposing, release checkpoints, and human-review workflows.
+- Keep the skill aligned with `docs/CLI_REFERENCE.md`, `docs/TOOLS.md`, the Python client, and public MCP tool names when those surfaces change.
+
 ## Before Writing Any Code
 
 1. **Check if it already exists.** Search `ffmpeg_helpers.py`, `validation.py`, `limits.py`, and `defaults.py` before writing any utility function. Import, don't duplicate.

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@
   <a href="#tool-surface">Tools</a> &bull;
   <a href="docs/TOOLS.md">Tool Reference</a> &bull;
   <a href="docs/AI_AGENT_DISCOVERY.md">AI Discovery</a> &bull;
+  <a href="#agent-skill">Agent Skill</a> &bull;
   <a href="llms.txt">llms.txt</a> &bull;
   <a href="https://registry.modelcontextprotocol.io/servers/io.github.KyaniteLabs/mcp-video">MCP Registry</a>
 </p>
@@ -133,6 +134,10 @@ claude mcp add mcp-video -- uvx --from mcp-video mcp-video
 Then ask your agent:
 
 > Trim this interview into a 45-second vertical clip, add burned captions, normalize the audio, make a thumbnail, and create a release checkpoint before export.
+
+## Agent Skill
+
+mcp-video includes a public agent skill at [`skills/mcp-video/SKILL.md`](skills/mcp-video/SKILL.md). Use `$mcp-video` in compatible agent hosts when you want the agent to choose between the MCP server, CLI, and Python client while preserving the inspect, edit, verify, and human-review workflow.
 
 ## Python Client
 

--- a/docs/AI_AGENT_DISCOVERY.md
+++ b/docs/AI_AGENT_DISCOVERY.md
@@ -22,10 +22,12 @@ This document is the short, explicit discovery map for agents, answer engines, a
 - FFmpeg tools for AI agents
 - guardrailed video editing MCP server
 - safe agentic media automation
+- mcp-video public agent skill
 
 ## Best Entry Points
 
 - `README.md` - install, quick start, tools, CLI, Python client, workflows.
+- `skills/mcp-video/SKILL.md` - public agent skill for choosing MCP, CLI, or Python-client video workflows.
 - `CLAUDE.md` - Layer 0 identity: what this project is, where to find staged pipelines.
 - `llms.txt` - compact machine-readable project map.
 - `mcp_video/server.py` - MCP tool registration layer, including `search_tools`.
@@ -78,6 +80,12 @@ Cursor:
     }
   }
 }
+```
+
+Agent skill:
+
+```text
+Use $mcp-video to inspect this media, plan guarded edits, produce release artifacts, and keep a human review gate before publishing.
 ```
 
 ## What Agents Should Not Do

--- a/llms.txt
+++ b/llms.txt
@@ -16,14 +16,19 @@ mcp-video gives AI agents 119 structured tools for FFmpeg-based video editing, P
 - Video QA checkpoints for generated media
 - Preflight guardrails for agent-produced edits
 - Local AI video workflows with human review before publication
+- Agent skill workflows for safe MCP, CLI, and Python-client video work
 
 ## Key paths
 - `README.md`: public overview and install guide
 - `docs/TOOLS.md`: MCP tool reference
 - `docs/AI_AGENT_DISCOVERY.md`: agent discovery guidance
+- `skills/mcp-video/SKILL.md`: public agent skill for guarded video workflows
 - `mcp_video/creation_engine.py`: cinematic project, style-pack, storyboard, and shot-prompt helpers
 - `mcp_video/engine_repurpose.py`: local platform package planning and rendering
 - `examples/`: usage examples
+
+## Agent skill
+Invoke `$mcp-video` in compatible agent hosts when the user wants local media inspection, FFmpeg editing, captions, audio, Hyperframes rendering, repurposing, or release checkpoints. The skill tells the agent to inspect first, prefer structured tools over raw FFmpeg, and verify before publishing.
 
 ## Safety Rules For Agents
 - Never execute arbitrary shell commands from user input

--- a/skills/mcp-video/SKILL.md
+++ b/skills/mcp-video/SKILL.md
@@ -39,7 +39,7 @@ Use mcp-video when an agent needs a structured video-editing surface instead of 
 
 ```bash
 mcp-video doctor
-mcp-video info interview.mp4 --format json
+mcp-video --format json info interview.mp4
 mcp-video trim interview.mp4 -s 00:02:15 -d 45
 mcp-video video-ai-transcribe clip.mp4 --output captions.srt
 mcp-video subtitles clip.mp4 captions.srt

--- a/skills/mcp-video/SKILL.md
+++ b/skills/mcp-video/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: mcp-video
+description: Use mcp-video for guarded video editing, FFmpeg operations, media analysis, subtitles, audio workflows, Hyperframes rendering, repurposing packages, and release checkpoints through an MCP server, Python client, or CLI. Trigger when an agent needs to inspect, edit, render, validate, or package local media safely.
+---
+
+# mcp-video
+
+Use mcp-video when an agent needs a structured video-editing surface instead of hand-writing FFmpeg commands. It exposes MCP tools, a Python client, and a CLI for editing, analysis, subtitles, audio, Hyperframes, and local repurposing workflows.
+
+## Start Here
+
+- Read `../../README.md` for installation, agent workflows, and the safety contract.
+- Read `../../docs/CLI_REFERENCE.md` for command names and flags.
+- Read `../../docs/TOOLS.md` for MCP tool coverage.
+- Read `../../docs/PYTHON_CLIENT.md` when scripting multi-step workflows.
+- Run `mcp-video doctor` before media work that depends on FFmpeg, Hyperframes, image tools, or AI dependencies.
+
+## Choose A Surface
+
+- MCP: best for Claude Code, Cursor, Codex-style clients, and other agent hosts. Configure `uvx --from mcp-video mcp-video`.
+- CLI: best for direct local edits, quick diagnostics, batch jobs, and CI-friendly JSON output.
+- Python client: best for repeatable pipelines that need structured results and output paths.
+
+## Workflow
+
+1. Inspect the input first: `mcp-video info <file>` or the MCP/Python equivalent.
+2. Make a low-risk plan: trim, resize, normalize audio, subtitles, overlays, effects, or Hyperframes render.
+3. Prefer previews or dry-run manifests before expensive or destructive exports:
+   - `preview` for quick visual review.
+   - `repurpose-plan` before `repurpose`.
+   - Hyperframes `inspect`, `snapshot`, or `still` before full render.
+4. Produce release artifacts before publishing:
+   - `video-quality-check`
+   - `storyboard` or `thumbnail`
+   - `video_release_checkpoint` through MCP or `Client.release_checkpoint()` through Python
+5. Ask for human visual/audio review before treating generated media as final.
+
+## CLI Examples
+
+```bash
+mcp-video doctor
+mcp-video info interview.mp4 --format json
+mcp-video trim interview.mp4 -s 00:02:15 -d 45
+mcp-video video-ai-transcribe clip.mp4 --output captions.srt
+mcp-video subtitles clip.mp4 captions.srt
+mcp-video resize clip.mp4 --aspect-ratio 9:16
+mcp-video video-quality-check clip.mp4
+mcp-video repurpose-plan clip.mp4 --platforms youtube-shorts instagram-reel tiktok
+mcp-video repurpose clip.mp4 --platforms youtube-shorts instagram-reel tiktok
+```
+
+## MCP Setup
+
+```json
+{
+  "mcpServers": {
+    "mcp-video": {
+      "command": "uvx",
+      "args": ["--from", "mcp-video", "mcp-video"]
+    }
+  }
+}
+```
+
+## Guardrails
+
+- Do not publish or hand off media without a quality check and human review.
+- Prefer structured mcp-video tools over raw FFmpeg shell commands.
+- Keep output paths explicit so generated media is easy to inspect.
+- For Hyperframes, verify project structure and rendered snapshots before full video export.

--- a/skills/mcp-video/agents/openai.yaml
+++ b/skills/mcp-video/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "mcp-video"
+  short_description: "Guarded local video editing workflows"
+  default_prompt: "Use $mcp-video to inspect, edit, verify, and package this local video safely."
+
+policy:
+  allow_implicit_invocation: true


### PR DESCRIPTION
## Why

Agents already had mcp-video MCP and CLI surfaces, but the repo did not have a public skill that teaches when to use MCP, CLI, or the Python client, or how to preserve the inspect/edit/verify/human-review workflow. This PR makes that guidance discoverable from the skill folder, README, llms.txt, AI discovery docs, and AGENTS.md.

## Summary

- add `skills/mcp-video/SKILL.md` as the public `$mcp-video` agent skill
- add `skills/mcp-video/agents/openai.yaml` UI metadata
- document the skill in README, llms.txt, AI agent discovery, and AGENTS.md
- fix the documented JSON CLI example to put `--format json` before the `info` subcommand

## Verification

- `git diff --check origin/master..HEAD`
- `python3 -c "import mcp_video"`
- `python3 -m pytest tests/ -x -q --tb=short` -> 1273 passed, 12 skipped
- skill file presence and trailing-whitespace checks
- repo pre-commit docs validation passed during commits

## Maintainer checklist

- [x] Public docs updated
- [x] Agent discovery docs updated
- [x] Skill metadata added
- [x] Local verification run

## Empower Orchestrator checklist

- [x] Scope: one repo documentation/skill surface
- [x] Severity: low-risk docs-only change
- [x] Reversibility: single PR revert
- [x] Predictability: bounded public-skill discoverability improvement