### PR TITLE
fix(hyperframes): prevent init from hanging under MCP (no TTY)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ This project follows a simple release-note style:
 - Approved AI-video dispositions now require active exact human decisions with requirement-level evidence; analyzer output alone cannot create approval.
 - Body-swap and salvage resolve verified stored source identities and reject stale, ambiguous, aliased, or protected inputs rather than trusting ambient paths.
 
+### Fixed
+
+- `hyperframes_init` no longer hangs when Kinocut runs as an MCP server. Project scaffolding now always invokes the Hyperframes CLI non-interactively and with `HYPERFRAMES_SKIP_SKILLS=1` (the CLI ignores the `--skip-skills` flag and otherwise runs a blocking network AI-skills check on `init`), and every Hyperframes subprocess is run with a closed stdin so a missing TTY can never block on an interactive prompt.
+
 ### Release status
 
 - These changes are under draft review. No version bump, tag, package upload, directory submission, deployment, release, or announcement is authorized.

--- a/kinocut/hyperframes_engine.py
+++ b/kinocut/hyperframes_engine.py
@@ -191,6 +191,12 @@ def _run_hyperframes(
             capture_output=True,
             text=True,
             timeout=timeout,
+            # Never inherit the caller's stdin: when invoked from an MCP server
+            # there is no TTY, so a stray interactive prompt would block forever.
+            stdin=subprocess.DEVNULL,
+            # `init` runs a network AI-skills check that the --skip-skills flag
+            # does not currently disable; this env var is the supported opt-out.
+            env={**os.environ, "HYPERFRAMES_SKIP_SKILLS": "1"},
         )
     except subprocess.TimeoutExpired:
         raise HyperframesRenderError(" ".join(cmd), -1, "Render timed out") from None
@@ -387,10 +393,12 @@ _SCHEMA: dict[str, dict[str, Any]] = {
             "resolution": "resolution",
         },
         "switches": {
-            "skip-transcribe": "skip_transcribe",
             "tailwind": "tailwind",
         },
-        "fixed": ["--non-interactive", "--skip-skills"],
+        # `init` prompts interactively by default and can implicitly launch
+        # Whisper; always pass --non-interactive and --skip-transcribe so the
+        # MCP subprocess scaffolds a project without ever blocking on input.
+        "fixed": ["--non-interactive", "--skip-skills", "--skip-transcribe"],
         "cwd_key": "output_dir",
         "timeout": 120,
     },

--- a/tests/test_hyperframes_engine.py
+++ b/tests/test_hyperframes_engine.py
@@ -1214,6 +1214,67 @@ class TestCreateProject:
 
 
 # ---------------------------------------------------------------------------
+# Test: init non-interactive / MCP no-hang regression
+# ---------------------------------------------------------------------------
+
+
+class TestInitNonInteractiveHang:
+    """Regression: ``init`` must never block on a prompt when run under MCP.
+
+    An MCP server has no TTY, so an interactive prompt -- or the network
+    AI-skills check that ``--skip-skills`` does not actually disable -- would
+    hang the tool call indefinitely. ``init`` must always run non-interactively
+    and skip transcription, and every Hyperframes subprocess must run with a
+    closed stdin and ``HYPERFRAMES_SKIP_SKILLS=1``.
+    """
+
+    def test_init_forces_non_interactive_and_skip_transcribe(self, tmp_path):
+        """init passes --non-interactive and --skip-transcribe even when not requested."""
+        with _mock_deps_ok(), patch("mcp_video.hyperframes_engine.subprocess.run") as mock_run:
+            mock_run.return_value = _make_completed_process(stdout="initialized")
+
+            # skip_transcribe defaults to False, yet both flags must still be forced.
+            create_project("regression-project", output_dir=str(tmp_path), template="blank")
+
+            cmd = mock_run.call_args[0][0]
+            assert _hyperframes_subcommand(cmd) == "init"
+            assert "--non-interactive" in cmd
+            assert "--skip-transcribe" in cmd
+            # Forced exactly once -- the removed switch must not double it up.
+            assert cmd.count("--skip-transcribe") == 1
+
+    def test_subprocess_closes_stdin_and_skips_skills(self, tmp_path):
+        """Every Hyperframes subprocess runs with DEVNULL stdin and the skills opt-out."""
+        with _mock_deps_ok(), patch("mcp_video.hyperframes_engine.subprocess.run") as mock_run:
+            mock_run.return_value = _make_completed_process(stdout="initialized")
+
+            create_project("regression-project", output_dir=str(tmp_path), template="blank")
+
+            kwargs = mock_run.call_args.kwargs
+            assert kwargs["stdin"] is subprocess.DEVNULL
+            assert kwargs["env"]["HYPERFRAMES_SKIP_SKILLS"] == "1"
+            # The parent environment is preserved, not replaced.
+            assert "PATH" in kwargs["env"]
+
+    def test_unrelated_commands_do_not_receive_init_flags(self, sample_hyperframes_project):
+        """render() (and other commands) must not inherit init-only flags."""
+        fake_cp = _make_completed_process(stdout="Rendered.")
+        with (
+            _mock_deps_ok(),
+            patch("mcp_video.hyperframes_engine.subprocess.run", return_value=fake_cp) as mock_run,
+            patch("os.path.isfile", return_value=True),
+            patch("os.path.getsize", return_value=1024 * 1024),
+        ):
+            render(str(sample_hyperframes_project), output_path="/tmp/out.mp4", format="mp4")
+
+            cmd = mock_run.call_args[0][0]
+            assert "--skip-transcribe" not in cmd
+            assert "--non-interactive" not in cmd
+            # The shared runner still applies the safe non-interactive default.
+            assert mock_run.call_args.kwargs["stdin"] is subprocess.DEVNULL
+
+
+# ---------------------------------------------------------------------------
 # Test: validate
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
### Summary
Fixes an indefinite hang in `hyperframes_init` (and any Hyperframes call) when Kinocut runs as an MCP server.

### Root cause
The MCP `hyperframes_init` tool shells out to the Hyperframes CLI via `_run_hyperframes`. Two properties of `hyperframes init` make it block when there is no controlling terminal (exactly the case under an MCP stdio server):
1. `init` is **interactive by default** — it prompts for confirmation unless `--non-interactive` is passed.
2. `init` runs a **network "AI-skills" check** on every invocation; the `--skip-skills` flag is currently a no-op (the CLI documents `HYPERFRAMES_SKIP_SKILLS=1` as the real opt-out).

Because `_run_hyperframes` invoked `subprocess.run(...)` without overriding `stdin`, the child inherited the server's non-TTY stdio pipe and blocked waiting on a prompt that could never be answered, so the MCP tool call never returned.

### The fix
- `_SCHEMA["init"]`: move `--skip-transcribe` into the always-on `fixed` args and keep `--non-interactive`, so scaffolding is fully non-interactive and never launches Whisper implicitly.
- `_run_hyperframes`: pass `stdin=subprocess.DEVNULL` and `env={**os.environ, "HYPERFRAMES_SKIP_SKILLS": "1"}`.

### Why it prevents the hang
- `stdin=DEVNULL` guarantees any stray prompt receives EOF immediately instead of blocking on the MCP pipe.
- `HYPERFRAMES_SKIP_SKILLS=1` disables the blocking network skills check that `--skip-skills` does not.
- `--non-interactive` (retained) removes the confirmation prompt at the source.

### Safety / scope
- The parent environment is **merged, not replaced** (`{**os.environ, ...}`), so PATH and Node resolution are preserved.
- Only `init` reads `HYPERFRAMES_SKIP_SKILLS`; `--non-interactive`/`--skip-transcribe` are `init`-only schema entries — **other commands (`render`, `info`, …) are unaffected**, covered by a dedicated test.
- `stdin=DEVNULL` is safe for all subcommands (all are agent-invoked and non-interactive).

### Before / after
- **Before:** calling `hyperframes_init` from an MCP client hangs until timeout.
- **After:** `hyperframes_init` returns in ~2–3 s; `info` and `render` unchanged.

### Testing
- `ruff format` (no changes) and `ruff check` (clean).
- `pytest tests/test_hyperframes_engine.py` → 89 passed, 2 skipped; new `TestInitNonInteractiveHang` (3 tests) covers forced flags, the non-interactive subprocess env, and non-leakage to other commands.
- Manually verified end-to-end through a fresh MCP server: `hyperframes_init` → `hyperframes_info` → `hyperframes_render` all succeed with no hang.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/kinocut/pr/361"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786560133&installation_id=130430723&pr_number=361&repository=KyaniteLabs%2Fkinocut&return_to=https%3A%2F%2Fgithub.com%2FKyaniteLabs%2Fkinocut%2Fpull%2F361&signature=09cdd8f57929baa5ebc8a6507eee96b9271b43fc94d12ee54c3bd567a6a06b19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed project creation hanging when running without an interactive terminal.
  * Project initialization now runs non-interactively and skips unnecessary transcription setup.
  * Improved reliability when Kinocut runs as an MCP server.

* **Tests**
  * Added regression coverage to ensure safe subprocess behavior during project creation and normal subsequent commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->