### PR TITLE
fix(release): exclude docs/ from sdist so 1.8.0 publish can land

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -178,13 +178,14 @@ packages = ["kinocut", "kinocut_sound"]
 "mcp_video.py" = "mcp_video.py"
 
 [tool.hatch.build.targets.sdist]
+# Do not ship /docs/ in the sdist — publish artifact check forbids that path
+# (GitHub Release 1.8.0 failed on kinocut-1.8.0.tar.gz including MCPB docs).
+# MCPB operator docs remain in-repo and under mcpb/README.md.
 only-include = [
     "/kinocut",
     "/kinocut_sound",
     "/mcp_video.py",
     "/CHANGELOG.md",
-    "/docs/MCPB.md",
-    "/docs/MCPB_SUPPLY_CHAIN.md",
     "/LICENSE",
     "/mcpb",
     "/README.md",


### PR DESCRIPTION
## Problem
GitHub Release [v1.8.0](https://github.com/KyaniteLabs/kinocut/releases/tag/v1.8.0) from `05ac601` is live, but **Publish Kinocut** failed:

```
kinocut-1.8.0.tar.gz: forbidden contents detected
- kinocut-1.8.0/docs/MCPB.md
- kinocut-1.8.0/docs/MCPB_SUPPLY_CHAIN.md
```

PyPI/npm still on 1.7.0.

## Fix
Remove `/docs/*` from hatch sdist `only-include`. MCPB docs stay in the git tree; `mcpb/README.md` remains packaged.

Local verify: `python3 -m build` + `check-built-artifacts.py` → wheel + sdist **clean**.

## After merge
1. Point `v1.8.0` at the merge commit (or re-run publish from a retagged SHA)
2. Confirm PyPI `kinocut==1.8.0` and npm
3. Flip `public_claims.published_version` + site when registries are live

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/kinocut/pr/370"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786608544&installation_id=130430723&pr_number=370&repository=KyaniteLabs%2Fkinocut&return_to=https%3A%2F%2Fgithub.com%2FKyaniteLabs%2Fkinocut%2Fpull%2F370&signature=60286701a3413bcb5f422740ce225af360893e59da808ae38b3904615b21d987"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->