### PR TITLE
fix(release): recover blocked 1.8.0 publication

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,17 @@ on:
   release:
     types: [published]
   workflow_dispatch:
+    inputs:
+      release_tag:
+        description: "Release tag to recover (for example, v1.8.0)"
+        required: false
+        type: string
+      recovery_scope:
+        description: "Recover only npm or the complete release publication path"
+        required: true
+        default: npm
+        type: choice
+        options: [npm, full]
 
 permissions:
   contents: read
@@ -15,7 +26,7 @@ concurrency:
 jobs:
   surface-audit:
     name: Check tracked release surface
-    if: github.event_name == 'release'
+    if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.recovery_scope == 'full')
     runs-on: blacksmith-2vcpu-ubuntu-2404
     permissions:
       contents: read
@@ -32,7 +43,7 @@ jobs:
   build:
     name: Build release artifacts
     needs: surface-audit
-    if: github.event_name == 'release'
+    if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.recovery_scope == 'full')
     runs-on: blacksmith-2vcpu-ubuntu-2404
     permissions:
       contents: read
@@ -53,8 +64,9 @@ jobs:
         run: .venv/bin/pip install build jsonschema twine
       - name: Verify release versions are publishable
         env:
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name || inputs.release_tag }}
           RELEASE_ATTEMPT: ${{ github.run_attempt }}
+          RELEASE_RECOVERY: ${{ github.event_name == 'workflow_dispatch' }}
         run: |
           .venv/bin/python - <<'PY'
           import json
@@ -78,6 +90,7 @@ jobs:
           server = json.loads(Path("server.json").read_text())
           tag = os.environ["RELEASE_TAG"]
           release_attempt = int(os.environ["RELEASE_ATTEMPT"])
+          recovery = os.environ["RELEASE_RECOVERY"].lower() == "true"
 
           failures = []
           if project["name"] != "kinocut":
@@ -105,10 +118,10 @@ jobs:
                   if exc.code != 404:
                       raise
               else:
-                  if release_attempt == 1:
+                  if not recovery and release_attempt == 1:
                       failures.append(f"{label} already exists")
                   else:
-                      print(f"Recovery attempt {release_attempt}: {label} already exists and will be skipped.")
+                      print(f"Recovery attempt: {label} already exists and will be skipped.")
 
           require_missing_on_first_attempt(
               f"https://pypi.org/pypi/kinocut/{version}/json",
@@ -196,7 +209,9 @@ jobs:
   publish:
     name: Publish to PyPI
     needs: build
-    if: github.event_name == 'release' && startsWith(github.event.release.tag_name, 'v')
+    if: >-
+      (github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.recovery_scope == 'full')) &&
+      startsWith(github.event.release.tag_name || inputs.release_tag, 'v')
     runs-on: ubuntu-latest
     environment: pypi
     permissions:
@@ -216,7 +231,9 @@ jobs:
   publish-npm:
     name: Publish to npm
     needs: publish
-    if: github.event_name == 'release' && startsWith(github.event.release.tag_name, 'v')
+    if: >-
+      (github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.recovery_scope == 'full')) &&
+      startsWith(github.event.release.tag_name || inputs.release_tag, 'v')
     runs-on: ubuntu-latest
     environment: npm
     permissions:
@@ -235,7 +252,7 @@ jobs:
         run: npm install --global npm@11.5.1
       - name: Publish to npm with provenance
         env:
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name || inputs.release_tag }}
         run: |
           version="${RELEASE_TAG#v}"
           if npm view "kinocut@$version" version >/dev/null 2>&1; then
@@ -246,7 +263,7 @@ jobs:
 
   publish-npm-recovery:
     name: Recover npm publication
-    if: github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'workflow_dispatch' && inputs.recovery_scope == 'npm'
     runs-on: ubuntu-latest
     environment: npm
     permissions:
@@ -282,13 +299,14 @@ jobs:
         always() &&
         (
           (
-            github.event_name == 'release' &&
+            (github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.recovery_scope == 'full')) &&
             needs.publish.result == 'success' &&
             needs.publish-npm.result == 'success' &&
-            startsWith(github.event.release.tag_name, 'v')
+            startsWith(github.event.release.tag_name || inputs.release_tag, 'v')
           ) ||
           (
             github.event_name == 'workflow_dispatch' &&
+            inputs.recovery_scope == 'npm' &&
             needs.publish-npm-recovery.result == 'success'
           )
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -183,8 +183,6 @@ only-include = [
     "/kinocut_sound",
     "/mcp_video.py",
     "/CHANGELOG.md",
-    "/docs/MCPB.md",
-    "/docs/MCPB_SUPPLY_CHAIN.md",
     "/LICENSE",
     "/mcpb",
     "/README.md",

--- a/tests/test_kinocut_distribution.py
+++ b/tests/test_kinocut_distribution.py
@@ -167,7 +167,9 @@ def test_mcpb_distribution_is_truthful_and_buildable(tmp_path) -> None:
     assert manifest["user_config"]["pythonExecutable"]["required"] is False
     assert "enableOptionalAi" not in manifest["user_config"]
     sdist_includes = set(project["tool"]["hatch"]["build"]["targets"]["sdist"]["only-include"])
-    assert {"/mcpb", "/docs/MCPB.md", "/scripts/build-mcpb.py"} <= sdist_includes
+    assert {"/mcpb", "/scripts/build-mcpb.py"} <= sdist_includes
+    assert "/docs/MCPB.md" not in sdist_includes
+    assert "/docs/MCPB_SUPPLY_CHAIN.md" not in sdist_includes
     assert "/kinocut_sound" in sdist_includes
     assert '["-m", "kinocut", "--mcp"]' in launcher
     assert "shell: false" in launcher
@@ -278,6 +280,10 @@ def test_release_workflow_builds_and_publishes_canonical_shim_and_npm_packages()
     assert "mcp-video==1.6.0" in workflow
     assert "pip uninstall --yes mcp-video" in workflow
     assert "RELEASE_ATTEMPT: ${{ github.run_attempt }}" in workflow
+    assert "recovery_scope:" in workflow
+    assert "inputs.recovery_scope == 'full'" in workflow
+    assert "RELEASE_TAG: ${{ github.event.release.tag_name || inputs.release_tag }}" in workflow
+    assert "RELEASE_RECOVERY: ${{ github.event_name == 'workflow_dispatch' }}" in workflow
     assert "skip-existing: true" in workflow
     assert re.search(r"publish-npm:\n(?:.*\n)*?    needs: publish\n", workflow)
     assert 'npm view "kinocut@$version" version' in workflow
@@ -285,6 +291,15 @@ def test_release_workflow_builds_and_publishes_canonical_shim_and_npm_packages()
     assert "needs.publish-npm.result == 'success'" in workflow
     assert "github.event_name == 'workflow_dispatch'" in workflow
     assert "build-mcpb.py" not in workflow
+
+
+def test_release_workflow_embedded_version_verifier_is_syntactically_valid() -> None:
+    workflow = (ROOT / ".github" / "workflows" / "publish.yml").read_text(encoding="utf-8")
+    start = workflow.index("          def require_missing_on_first_attempt")
+    end = workflow.index("          require_missing_on_first_attempt(", start)
+    source = workflow[start:end].replace("          ", "", 1)
+
+    compile(source, "<publish-version-verifier>", "exec")
 
 
 def test_npm_publish_uses_local_tarball_and_has_oidc_recovery_dispatch() -> None:


### PR DESCRIPTION
Fixes the 1.8.0 publish gate failure caused by MCPB documentation being explicitly included in the sdist while the artifact policy rejects all docs paths.\n\n- exclude the two docs paths from the Python sdist\n- retain the staged/local MCPB bundle itself\n- add an audited full-release recovery dispatch for PyPI, npm, and MCP registry when a release-triggered run fails before publication\n- cover the artifact policy and embedded verifier syntax\n\nValidation: targeted release/distribution tests (22 passed); local built wheel/sdist artifact checker clean; prior final candidate full suite 3818 passed, 170 skipped.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/kinocut/pr/372"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786608966&installation_id=130430723&pr_number=372&repository=KyaniteLabs%2Fkinocut&return_to=https%3A%2F%2Fgithub.com%2FKyaniteLabs%2Fkinocut%2Fpull%2F372&signature=4b05e7c90f6d306615da7eadbe03067c78dfdfa677a3d4fe1a505ff453a71f8f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->