### PR TITLE
fix: ensure authored ASS subtitles have correct PlayRes for vertical burns

### DIFF
--- a/kinocut/cli/parser/media.py
+++ b/kinocut/cli/parser/media.py
@@ -64,8 +64,8 @@ def add_parsers(subparsers: argparse._SubParsersAction) -> None:
     subs_p.add_argument(
         "--style",
         help="force_style override applied to any subtitle format including authored .ass "
-        "(e.g. FontSize=24,PrimaryColour=&H00FFFFFF); omit to preserve an authored .ass "
-        "file's own styles/positions",
+        "(e.g. FontSize=24,PrimaryColour=&H00FFFFFF); omit to use the subtitle file's styles/positions; "
+        "authored .ass files will have their PlayRes values adjusted to match the video dimensions",
     )
     subs_p.add_argument("-o", "--output", help="Output file path")
 

--- a/kinocut/engine_subtitles.py
+++ b/kinocut/engine_subtitles.py
@@ -60,7 +60,7 @@ def _fill_burn_source(fd: int, subtitle_format: str, subtitle_path: str, input_p
     try:
         if subtitle_format == "ass":
             width, height = probe_display_dimensions(input_path)
-            with open(subtitle_path, "r", encoding="utf-8") as handle:
+            with open(subtitle_path, "r", encoding="utf-8", errors="replace") as handle:
                 content = handle.read()
             # Normalize PlayRes to match video dimensions
             content = _normalize_playres(content, width, height)

--- a/kinocut/engine_subtitles.py
+++ b/kinocut/engine_subtitles.py
@@ -1,7 +1,8 @@
 """Subtitle burn-in operation for the FFmpeg engine.
 
-Authored ASS is burned verbatim (its PlayRes/styles/positions are preserved and
-its source bytes are never rewritten); SRT/VTT is converted to a dimensioned ASS
+Authored ASS is read, normalized to have PlayRes matching the video
+dimensions, and written so captions render correctly across
+vertical/horizontal/square videos. SRT/VTT is converted to a dimensioned ASS
 whose single PlayResX/Y equals the probed display size so captions render
 correctly across vertical/horizontal/square. A user ``style`` is optional and is
 validated through the closed ``force_style`` parser before being applied.
@@ -35,6 +36,7 @@ from .subtitles_common import (
     parse_force_style,
     probe_display_dimensions,
     synthesize_dimensioned_ass,
+    _normalize_playres,
 )
 
 
@@ -46,20 +48,24 @@ def _synthesis_workdir(output_path: str) -> str:
 def _fill_burn_source(fd: int, subtitle_format: str, subtitle_path: str, input_path: str) -> None:
     """Write the subtitle content burned by the filter into the open temp-ASS ``fd``.
 
-    Authored ASS is copied byte-for-byte so a hostile subtitle filename never
-    reaches the filtergraph (the FFmpeg subtitles filter cannot reliably consume a
-    quote or other filter metacharacters in its path) and the source is never
-    modified; SRT/VTT is converted to a dimensioned ASS. The temp file itself is
-    owned (and cleaned up) by the caller, but this helper always closes ``fd`` on
-    every path — including when probe/synthesis fails before it is wrapped by
-    ``os.fdopen`` — and wraps any staging ``OSError`` (either format) as a private
-    ``subtitle_prepare_failed``. Custom ``MCPVideoError`` from probe/synthesis is
-    preserved unchanged.
+    Authored ASS is read, normalized to have PlayRes matching the video
+    dimensions, and written so captions render correctly across
+    vertical/horizontal/square videos. SRT/VTT is converted to a dimensioned ASS.
+    The temp file itself is owned (and cleaned up) by the caller, but this
+    helper always closes ``fd`` on every path — including when probe/synthesis
+    fails before it is wrapped by ``os.fdopen`` — and wraps any staging
+    ``OSError`` (either format) as a private ``subtitle_prepare_failed``.
+    Custom ``MCPVideoError`` from probe/synthesis is preserved unchanged.
     """
     try:
         if subtitle_format == "ass":
-            with os.fdopen(fd, "wb") as dst, open(subtitle_path, "rb") as src:
-                shutil.copyfileobj(src, dst)
+            width, height = probe_display_dimensions(input_path)
+            with open(subtitle_path, "r", encoding="utf-8") as handle:
+                content = handle.read()
+            # Normalize PlayRes to match video dimensions
+            content = _normalize_playres(content, width, height)
+            with os.fdopen(fd, "w", encoding="utf-8") as dst:
+                dst.write(content)
         else:
             width, height = probe_display_dimensions(input_path)
             content = synthesize_dimensioned_ass(subtitle_path, (width, height))


### PR DESCRIPTION
# fix: ensure authored ASS subtitles have correct PlayRes for vertical burns

## Summary

Fixed the subtitle burning functionality to properly handle authored ASS files for vertical videos. Previously, authored ASS files were copied byte-for-byte without adjusting their PlayRes values to match the video dimensions, causing incorrect subtitle positioning and scaling in videos with different aspect ratios (especially vertical videos). Now, authored ASS files are read, normalized to have PlayRes values matching the video dimensions, and written to ensure correct rendering.

This change makes authored ASS handling consistent with SRT/VTT processing, which already converts to dimensioned ASS with video-matched PlayRes values.

Fixes #374

## Changes

- Modified `_fill_burn_source` function in `engine_subtitles.py` to process authored ASS files by:
  - Reading the ASS file as UTF-8 text with error handling for invalid UTF-8 sequences (using errors="replace")
  - Normalizing PlayResX/Y values to match the input video dimensions using `_normalize_playres`
  - Writing the normalized content as UTF-8 text to the temporary file
- Updated the file docstring to reflect that authored ASS is now normalized rather than burned verbatim
- Updated the CLI help text for the `--style` option in `cli/parser/media.py` to document that authored ASS files have their PlayRes values adjusted to match video dimensions

## Testing

- Verified the changes build correctly
- Confirmed that SRT/VTT subtitle processing continues to work as before (uses `synthesize_dimensioned_ass`)
- Verified that authored ASS files now produce temporary ASS files with PlayRes matching video dimensions
- Verified that UTF-8 error handling works correctly for malformed authored ASS files (replaces invalid sequences)
- Manual inspection showed that the normalization correctly updates PlayRes values while preserving other ASS content (styles, positioning, etc.)

---
### AI assistance disclosure

This contribution was produced by an autonomous AI coding agent (Claude Code) that @Dodothereal operates and monitors. @Dodothereal is accountable for it, will address review feedback promptly, and will close this PR immediately if this kind of contribution is unwelcome in this project. Commits carry an `Assisted-by: Claude Code` trailer.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/kinocut/pr/378"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786969002&installation_id=130430723&pr_number=378&repository=KyaniteLabs%2Fkinocut&return_to=https%3A%2F%2Fgithub.com%2FKyaniteLabs%2Fkinocut%2Fpull%2F378&signature=d46cb3eb72b48fa87ac509011672ee014c1afd8988b880e92bd8160446219a96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer `--style` guidance for subtitle formatting and authored ASS files.
  * Authored ASS subtitles now automatically adjust their resolution settings to match the video dimensions during burn-in.

* **Bug Fixes**
  * Improved subtitle rendering consistency when using authored ASS subtitle files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->