### PR TITLE
fix(hyperframes): restore skip-transcribe contract

### DIFF
--- a/kinocut/hyperframes_engine.py
+++ b/kinocut/hyperframes_engine.py
@@ -394,11 +394,15 @@ _SCHEMA: dict[str, dict[str, Any]] = {
         },
         "switches": {
             "tailwind": "tailwind",
+            # Opt-in: emit the skip flag only when the caller requests it via
+            # create_project(skip_transcribe=True).
+            "skip-transcribe": "skip_transcribe",
         },
         # `init` prompts interactively by default and can implicitly launch
-        # Whisper; always pass --non-interactive and --skip-transcribe so the
-        # MCP subprocess scaffolds a project without ever blocking on input.
-        "fixed": ["--non-interactive", "--skip-skills", "--skip-transcribe"],
+        # Whisper; always pass --non-interactive so the MCP subprocess scaffolds
+        # a project without ever blocking on input. --skip-transcribe is opt-in
+        # above, so the public default (skip_transcribe=False) omits it.
+        "fixed": ["--non-interactive", "--skip-skills"],
         "cwd_key": "output_dir",
         "timeout": 120,
     },

--- a/tests/test_hyperframes_engine.py
+++ b/tests/test_hyperframes_engine.py
@@ -1223,24 +1223,44 @@ class TestInitNonInteractiveHang:
 
     An MCP server has no TTY, so an interactive prompt -- or the network
     AI-skills check that ``--skip-skills`` does not actually disable -- would
-    hang the tool call indefinitely. ``init`` must always run non-interactively
-    and skip transcription, and every Hyperframes subprocess must run with a
+    hang the tool call indefinitely. ``init`` must always run non-interactively,
+    ``--skip-transcribe`` is opt-in via ``skip_transcribe`` (false omits it, true
+    emits it exactly once), and every Hyperframes subprocess must run with a
     closed stdin and ``HYPERFRAMES_SKIP_SKILLS=1``.
     """
 
-    def test_init_forces_non_interactive_and_skip_transcribe(self, tmp_path):
-        """init passes --non-interactive and --skip-transcribe even when not requested."""
+    def test_init_default_omits_skip_transcribe(self, tmp_path):
+        """skip_transcribe=False (the public default) omits --skip-transcribe."""
         with _mock_deps_ok(), patch("mcp_video.hyperframes_engine.subprocess.run") as mock_run:
             mock_run.return_value = _make_completed_process(stdout="initialized")
 
-            # skip_transcribe defaults to False, yet both flags must still be forced.
+            # The default must not silently disable transcription.
             create_project("regression-project", output_dir=str(tmp_path), template="blank")
+
+            cmd = mock_run.call_args[0][0]
+            assert _hyperframes_subcommand(cmd) == "init"
+            # The no-TTY hang fix stays in force.
+            assert "--non-interactive" in cmd
+            assert "--skip-transcribe" not in cmd
+            assert cmd.count("--skip-transcribe") == 0
+
+    def test_init_skip_transcribe_true_emits_flag_once(self, tmp_path):
+        """skip_transcribe=True emits --skip-transcribe exactly once."""
+        with _mock_deps_ok(), patch("mcp_video.hyperframes_engine.subprocess.run") as mock_run:
+            mock_run.return_value = _make_completed_process(stdout="initialized")
+
+            create_project(
+                "regression-project",
+                output_dir=str(tmp_path),
+                template="blank",
+                skip_transcribe=True,
+            )
 
             cmd = mock_run.call_args[0][0]
             assert _hyperframes_subcommand(cmd) == "init"
             assert "--non-interactive" in cmd
             assert "--skip-transcribe" in cmd
-            # Forced exactly once -- the removed switch must not double it up.
+            # The switch must not double up with any leftover fixed entry.
             assert cmd.count("--skip-transcribe") == 1
 
     def test_subprocess_closes_stdin_and_skips_skills(self, tmp_path):


### PR DESCRIPTION
## Why

PR #361 correctly prevented Hyperframes from hanging without a TTY, but it also made `--skip-transcribe` unconditional. That silently inverted the documented `skip_transcribe=False` default across the engine, Python client, CLI, and MCP tool. This restores the public contract without reopening the hang.

Closes #379.

## What changed

- Restored `skip_transcribe` as a conditional Hyperframes `init` switch.
- Retained `--non-interactive`, closed stdin, and `HYPERFRAMES_SKIP_SKILLS=1`.
- Added regression coverage proving `False` omits the flag and `True` emits it exactly once.

## Verification

- [x] `python3 -m pytest tests/ -x -q --tb=short` — equivalent non-slow suite passed via `uv run --frozen`: 3928 passed, 167 skipped, 157 deselected.
- [x] `python3 -c "import kinocut, mcp_video"` — passed via `uv run --frozen`.
- [ ] `./scripts/git-professional-audit.sh` — code/worktree checks passed; repository integrity is blocked by a pre-existing corrupt commit-graph with missing historical objects.
- [x] Other: focused affected suites — 93 passed, 2 skipped.
- [x] Other: repository-wide Ruff check passed.
- [x] Other: focused Ruff format check passed; repository-wide format check reports pre-existing drift in 18 unchanged files.
- [x] Other: `git diff --check` passed.

## Maintainer checklist

- [x] Public MCP tool signatures are unchanged; this restores their documented behavior.
- [x] No FFmpeg filter strings changed.
- [x] No subprocess call or timeout changed; the no-TTY protections remain intact.
- [x] No defaults or validation constants were added.
- [x] No generated media, logs, caches, local research dumps, or build artifacts were committed.
- [x] Documentation remains correct because the implementation was restored to the existing documented contract.

## Empower Orchestrator checklist

- [x] I checked whether this PR reveals a repeatable task or recurring agent failure.
- [x] The regression test now covers both boolean states so the contract cannot silently invert again.
- [x] The change is small, reversible, and limited to Hyperframes `init` argument construction.
- [x] The implementation worker stayed inside its two-file scope; verification was run separately and is recorded above.