### PR TITLE
ci: restore Node and FFmpeg matrix compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -263,6 +263,10 @@ jobs:
           python-version: '3.13'
           cache: 'pip'
           cache-dependency-path: 'pyproject.toml'
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        if: needs.changes.outputs.code == 'true'
+        with:
+          node-version: '22'
       - name: Create venv
         if: needs.changes.outputs.code == 'true'
         run: python -m venv .venv
@@ -309,11 +313,11 @@ jobs:
             # assertion regression (ffmpeg_filter.c) that aborts on the glitch
             # engine's scale2ref+displace graphs; fixed by 7.1.5. Pin the fixed
             # frozen build, not the buggy early release.
-            ffmpeg_tag: autobuild-2026-06-25-13-48
+            ffmpeg_tag: autobuild-2026-06-30-13-34
             ffmpeg_asset: ffmpeg-n7.1.5-1-g7d0e842004-linux64-gpl-7.1.tar.xz
           - major: "8"
-            ffmpeg_tag: autobuild-2026-06-25-13-48
-            ffmpeg_asset: ffmpeg-n8.1.2-linux64-gpl-8.1.tar.xz
+            ffmpeg_tag: autobuild-2026-06-30-13-34
+            ffmpeg_asset: ffmpeg-n8.1.2-21-gce3c09c101-linux64-gpl-8.1.tar.xz
     steps:
       - name: Skip FFmpeg matrix
         if: needs.changes.outputs.code != 'true'


### PR DESCRIPTION
## Why

`master` CI is red because optional integration matrices rely on stale runner/assets: Hyperframes receives Node 20 although it requires Node >=22, and the GitHub FFmpeg 7/8 legs reference expired BtbN daily-build URLs.

Closes #383.

## What changed

- pinned the existing approved `actions/setup-node` v6 SHA with Node 22 for Hyperframes integration
- copied the verified month-end FFmpeg 7/8 tag and exact assets from the Forgejo source-of-truth matrix
- preserved all intentional structural differences between GitHub and Forgejo workflows
- kept Hyperframes informational until it proves two consecutive green runs

## Verification

- [ ] `python3 -m pytest tests/ -x -q --tb=short` — no product code changed; protected checks exercise the workflow
- [ ] `python3 -c "import kinocut, mcp_video"` — covered by protected checks
- [ ] `./scripts/git-professional-audit.sh` — not applicable to the single workflow edit
- [x] Other: HEAD requests returned HTTP 200 for both pinned FFmpeg assets
- [x] Other: workflow YAML parse/actionlint check passed
- [x] Other: `git diff --check` passed

## Maintainer checklist

- [x] Public MCP tool signatures are unchanged.
- [x] No FFmpeg filter strings or product subprocess calls changed.
- [x] No defaults or validation constants changed.
- [x] No generated artifacts were committed.
- [x] Documentation and public surface are unchanged.

## Empower Orchestrator checklist

- [x] This repairs a recurring CI runner/asset failure.
- [x] The change is the smallest durable configuration fix.
- [x] The blast radius is limited to optional CI jobs and is reversible.
- [x] Verification evidence is recorded before merge.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/kinocut/pr/384"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787013767&installation_id=130430723&pr_number=384&repository=KyaniteLabs%2Fkinocut&return_to=https%3A%2F%2Fgithub.com%2FKyaniteLabs%2Fkinocut%2Fpull%2F384&signature=d1619efc56d07d85da4e28a3ddfb0fe465bebe769e4f26fc42e4d6bd13b3082e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated integration workflows to use Node.js 22 explicitly.
  * Refreshed pinned FFmpeg 7 and 8 build artifacts used in testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->