### PR TITLE
ci: promote Hyperframes integration to required gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,12 +245,9 @@ jobs:
         run: .venv/bin/pytest tests/ -q -m "slow" --tb=short
 
   hyperframes-integration:
-    name: Hyperframes integration (informational)
+    name: Hyperframes integration
     needs: changes
     runs-on: blacksmith-2vcpu-ubuntu-2404
-    # Informational until runner compatibility is proven: failures are logged
-    # in the run, not blocking. Promote to a hard gate once stable.
-    continue-on-error: true
     steps:
       - name: Skip hyperframes integration
         if: needs.changes.outputs.code != 'true'


### PR DESCRIPTION
## Why\n\nCloses #385. Hyperframes has passed two consecutive full CI runs on pinned Node 22, so keeping the job informational would now hide real integration regressions.\n\n## What changed\n\n- removed `continue-on-error: true` from `hyperframes-integration`\n- removed the stale informational label and comments\n- preserved pinned Node 22 and all job steps\n\n## Verification\n\n- [x] Two consecutive Node-22 greens: [run 681](https://github.com/KyaniteLabs/kinocut/actions/runs/29667399839), [run 682](https://github.com/KyaniteLabs/kinocut/actions/runs/29667557712)\n- [x] Python YAML assertions confirm the job is required and Node 22 remains pinned\n- [x] `git diff --check`\n\n## Scope\n\nOne workflow file, four removed lines, no product or dependency changes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/kinocut/pr/386"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787015321&installation_id=130430723&pr_number=386&repository=KyaniteLabs%2Fkinocut&return_to=https%3A%2F%2Fgithub.com%2FKyaniteLabs%2Fkinocut%2Fpull%2F386&signature=65ad5f20d26830465a7d8b6cab7987812d2eed1d455c663000ad13bd80e7e9fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->