### PR TITLE
cli: add QA namespace aliases

### DIFF
--- a/kinocut/cli/namespaces.py
+++ b/kinocut/cli/namespaces.py
@@ -32,6 +32,11 @@ NAMESPACED_ALIASES: dict[tuple[str, str], str] = {
     ("audio", "add-generated"): "video-add-generated-audio",
     ("audio", "spatial"): "video-audio-spatial",
     ("audio", "bed"): "audio-bed",
+    ("qa", "auto-chapters"): "video-auto-chapters",
+    ("qa", "info-detailed"): "video-info-detailed",
+    ("qa", "check"): "video-quality-check",
+    ("qa", "design-check"): "video-design-quality-check",
+    ("qa", "fix-design"): "video-fix-design-issues",
 }
 
 

--- a/tests/test_namespace_routing.py
+++ b/tests/test_namespace_routing.py
@@ -1,10 +1,11 @@
-"""Behavior tests for the namespaced CLI argv router (#388, T7a; #390, T7b).
+"""Behavior tests for the namespaced CLI argv router (#388, T7a; #390, T7b; #391, T7c).
 
 These tests exercise the ``kino <group> <action> ...`` -> ``kino <flat> ...`` rewrite
 that ``kinocut.__main__._rewrite_namespaced_argv`` performs before
 ``build_parser().parse_args()`` runs. They do NOT depend on a new argparse subparser
 being added; the flat 130-command surface stays authoritative. T7a added the seven
-``aivideo`` aliases; T7b adds the nine ``audio`` aliases on top of the merged router.
+``aivideo`` aliases; T7b adds the nine ``audio`` aliases; T7c adds the five ``qa``
+aliases on top of the merged router.
 """
 
 from __future__ import annotations
@@ -49,15 +50,16 @@ def test_no_dangling_aliases_every_target_is_a_registered_flat_command():
 def test_every_namespaced_alias_rewrites_to_its_flat_target(group: str, action: str, flat: str):
     """Every (group, action) alias rewrites to its flat command, preserving trailing argv.
 
-    Covers all 16 aliases: the seven ``aivideo`` paths (T7a) and the nine ``audio``
-    paths (T7b). Group/action-specific counts are pinned by the dedicated tests below.
+    Covers all 21 aliases: the seven ``aivideo`` paths (T7a), the nine ``audio``
+    paths (T7b), and the five ``qa`` paths (T7c). Group/action-specific counts are
+    pinned by the dedicated tests below.
     """
 
     rewritten = _rewrite_namespaced_argv([group, action, "PROJECT", "--extra", "value"])
     assert rewritten == [flat, "PROJECT", "--extra", "value"]
 
 
-# Explicit per-group coverage so a future addition to either group is caught.
+# Explicit per-group coverage so a future addition to any group is caught.
 
 AIVIDEO_ALIASES: dict[tuple[str, str], str] = {
     ("aivideo", "verdict"): "video-verdict",
@@ -81,6 +83,14 @@ AUDIO_ALIASES: dict[tuple[str, str], str] = {
     ("audio", "bed"): "audio-bed",
 }
 
+QA_ALIASES: dict[tuple[str, str], str] = {
+    ("qa", "auto-chapters"): "video-auto-chapters",
+    ("qa", "info-detailed"): "video-info-detailed",
+    ("qa", "check"): "video-quality-check",
+    ("qa", "design-check"): "video-design-quality-check",
+    ("qa", "fix-design"): "video-fix-design-issues",
+}
+
 
 def test_aivideo_group_keeps_exactly_seven_aliases():
     """The T7a aivideo group is unchanged: exactly its seven known aliases."""
@@ -102,6 +112,28 @@ def test_every_audio_alias_rewrites_to_its_flat_target(action: str, flat: str):
     assert rewritten == [flat, "PROJECT", "--extra", "value"]
     # The flat target is still directly parseable as a registered subcommand.
     assert flat in EXPECTED_CLI_COMMANDS
+
+
+@pytest.mark.parametrize(
+    ("action", "flat"),
+    [(action, flat) for (_, action), flat in sorted(QA_ALIASES.items())],
+    ids=[f"qa-{action}" for _, action in sorted(QA_ALIASES)],
+)
+def test_every_qa_alias_rewrites_to_its_flat_target(action: str, flat: str):
+    """All five T7c qa aliases route to the matching flat command, preserving trailing argv."""
+
+    rewritten = _rewrite_namespaced_argv(["qa", action, "PROJECT", "--extra", "value"])
+    assert rewritten == [flat, "PROJECT", "--extra", "value"]
+    # The flat target is still directly parseable as a registered subcommand.
+    assert flat in EXPECTED_CLI_COMMANDS
+
+
+def test_qa_group_keeps_exactly_five_aliases():
+    """The T7c qa group is exactly its five known aliases (auto-chapters, info-detailed, check, design-check, fix-design)."""
+
+    qa = {k: v for k, v in NAMESPACED_ALIASES.items() if k[0] == "qa"}
+    assert qa == QA_ALIASES
+    assert len(qa) == 5
 
 
 def test_format_json_before_group_is_preserved():
@@ -181,14 +213,14 @@ def test_flat_command_set_remains_130():
     """The flat subcommand set is the same 130-command surface; no new parser was added.
 
     Namespace aliases are pure argv rewrites to existing flat commands, never new
-    subcommands: 7 aivideo aliases (T7a) + 9 audio aliases (T7b) = 16 grouped paths
-    over the unchanged 130-command parser.
+    subcommands: 7 aivideo aliases (T7a) + 9 audio aliases (T7b) + 5 qa aliases
+    (T7c) = 21 grouped paths over the unchanged 130-command parser.
     """
 
     assert len(EXPECTED_CLI_COMMANDS) == 130
-    assert len(NAMESPACED_ALIASES) == 16
+    assert len(NAMESPACED_ALIASES) == 21
     groups = namespaced_groups()
-    assert set(groups) == {"aivideo", "audio"}
+    assert set(groups) == {"aivideo", "audio", "qa"}
     assert groups["aivideo"] == (
         "acceptance",
         "body-swap",
@@ -209,10 +241,17 @@ def test_flat_command_set_remains_130():
         "spatial",
         "synthesize",
     )
+    assert groups["qa"] == (
+        "auto-chapters",
+        "check",
+        "design-check",
+        "fix-design",
+        "info-detailed",
+    )
 
 
 def test_parser_does_not_register_a_namespace_group_subparser():
-    """Grouped routing reuses flat subparsers; no `aivideo` or `audio` subparser is created."""
+    """Grouped routing reuses flat subparsers; no `aivideo`, `audio`, or `qa` subparser is created."""
 
     import argparse as _argparse
 
@@ -221,6 +260,7 @@ def test_parser_does_not_register_a_namespace_group_subparser():
     choices = set(subparsers_action.choices)
     assert "aivideo" not in choices
     assert "audio" not in choices
+    assert "qa" not in choices
     assert choices == EXPECTED_CLI_COMMANDS
 
 
@@ -244,8 +284,18 @@ def test_grouped_audio_bed_route_exposes_flat_audio_bed_help():
     assert "--loop-crossfade" in result.stdout
 
 
+def test_grouped_qa_check_route_exposes_flat_video_quality_check_help():
+    """`kino qa check --help` rewrites so argparse prints the flat video-quality-check command's help."""
+
+    result = _cli("qa", "check", "--help")
+    assert result.returncode == 0, result.stderr
+    # The flat video-quality-check command's help is shown — its prog line and a distinctive option appear verbatim.
+    assert "video-quality-check" in result.stdout
+    assert "--fail-on-warning" in result.stdout
+
+
 def test_group_help_does_not_add_namespace_groups_to_top_level_command_list():
-    """`kino --help` still lists exactly the flat 130 commands — no aivideo or audio entry."""
+    """`kino --help` still lists exactly the flat 130 commands — no aivideo, audio, or qa entry."""
 
     result = _cli("--help")
     assert result.returncode == 0, result.stderr
@@ -255,3 +305,4 @@ def test_group_help_does_not_add_namespace_groups_to_top_level_command_list():
     assert help_commands == EXPECTED_CLI_COMMANDS
     assert "aivideo" not in help_commands
     assert "audio" not in help_commands
+    assert "qa" not in help_commands


### PR DESCRIPTION
Closes #391. Child of #375.

Adds the five approved `qa` grouped paths as pure rewrites to existing flat commands. Every flat target remains directly available, no argparse namespace subparser is added, and the public count stays exactly 130.

Focused verification: 84 passed; Ruff clean; grouped `kino qa check --help` and flat `video-quality-check --help` replayed identically. T7b merged-master CI 29697560874 passed all jobs.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/kinocut/pr/394"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787075687&installation_id=130430723&pr_number=394&repository=KyaniteLabs%2Fkinocut&return_to=https%3A%2F%2Fgithub.com%2FKyaniteLabs%2Fkinocut%2Fpull%2F394&signature=0e235befebc955256c7d902fbf66f375b25a22d136de75514b193f33a3f1fe9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->