### PR TITLE
docs: make GitHub the external contribution surface

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,14 +1,14 @@
 blank_issues_enabled: false
 contact_links:
   - name: Questions and usage help
-    url: https://git.kyanitelabs.tech/KyaniteLabs/kinocut/issues/new?title=Question:%20
-    about: Ask setup questions and workflow questions in canonical Forgejo issues so bug reports stay focused and reproducible.
+    url: https://github.com/KyaniteLabs/kinocut/discussions/new?category=q-a
+    about: Ask setup and workflow questions in GitHub Discussions so bug reports stay focused and reproducible.
   - name: Ideas and early proposals
-    url: https://git.kyanitelabs.tech/KyaniteLabs/kinocut/issues/new?title=Idea:%20
+    url: https://github.com/KyaniteLabs/kinocut/discussions/new?category=ideas
     about: Float early ideas here before opening a feature request.
   - name: Security vulnerabilities
-    url: https://git.kyanitelabs.tech/KyaniteLabs/kinocut/src/branch/master/SECURITY.md
-    about: Please follow the private reporting guidance in SECURITY.md.
+    url: https://github.com/KyaniteLabs/kinocut/security/advisories/new
+    about: Report privately via GitHub private vulnerability reporting (see SECURITY.md).
   - name: Support guidance
-    url: https://git.kyanitelabs.tech/KyaniteLabs/kinocut/src/branch/master/SUPPORT.md
+    url: https://github.com/KyaniteLabs/kinocut/blob/master/SUPPORT.md
     about: Read support expectations and what details to include.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,12 +1,13 @@
 # Contributing to Kinocut
 
 Thanks for your interest in improving Kinocut. This is a focused project: every tool should work reliably, and every change should maintain that standard.
+External issues and pull requests belong on **[GitHub](https://github.com/KyaniteLabs/kinocut)** — that is the tracked public surface for bugs, features, questions, and contributions.
 
 ## Quick Start
 
 ```bash
 # Clone and install dev dependencies
-git clone https://git.kyanitelabs.tech/KyaniteLabs/kinocut.git
+git clone https://github.com/KyaniteLabs/kinocut.git
 cd kinocut
 python3 -m venv .venv
 source .venv/bin/activate
@@ -142,7 +143,7 @@ For workspace cleanup (stale worktrees/branches), run:
 ./scripts/git-workspace-cleanup.sh
 ```
 
-To monitor the GitHub mirror CI and review comments on mirrored PRs, run:
+To monitor CI and review comments on pull requests, run:
 
 ```bash
 ./scripts/github-pr-monitor.py --owner KyaniteLabs --repo kinocut
@@ -168,7 +169,7 @@ When reporting a bug, include:
 
 ## Questions?
 
-Open a Forgejo issue with the `question` label.
+Open a [GitHub Q&A discussion](https://github.com/KyaniteLabs/kinocut/discussions/new?category=q-a).
 
 <!-- EMPOWER_ORCHESTRATOR:START -->
 ## Agent-law contribution rule

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 <p align="center">
   <a href="https://pypi.org/project/kinocut/"><img src="https://img.shields.io/pypi/v/kinocut.svg" alt="PyPI"></a>
   <a href="https://kinocut.dev/"><img src="https://img.shields.io/badge/site-kinocut.dev-0A0A0A" alt="kinocut.dev"></a>
-  <a href="https://git.kyanitelabs.tech/KyaniteLabs/kinocut/actions"><img src="https://img.shields.io/badge/Forgejo%20CI-actions-blue" alt="CI"></a>
+  <a href="https://github.com/KyaniteLabs/kinocut/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/KyaniteLabs/kinocut/ci.yml?branch=master&label=CI" alt="CI"></a>
   <img src="https://img.shields.io/badge/MCP-151%20tools-orange.svg" alt="151 MCP tools on development tip">
   <img src="https://img.shields.io/badge/CLI-130%20commands-orange.svg" alt="130 CLI commands on development tip">
   <img src="https://img.shields.io/badge/python-3.11%2B-blue.svg" alt="Python 3.11+">
@@ -55,7 +55,7 @@
 | **Product site** | [kinocut.dev](https://kinocut.dev/) |
 | **PyPI** | [`kinocut`](https://pypi.org/project/kinocut/) |
 | **MCP Registry** | [`io.github.KyaniteLabs/kinocut`](https://registry.modelcontextprotocol.io/v0/servers/io.github.KyaniteLabs%2Fkinocut/versions/latest) |
-| **Source** | [GitHub](https://github.com/KyaniteLabs/kinocut) · [Forgejo (canonical)](https://git.kyanitelabs.tech/KyaniteLabs/kinocut) |
+| **Source** | [GitHub (canonical)](https://github.com/KyaniteLabs/kinocut) |
 | **License** | Apache-2.0 |
 | **Runs on** | Your machine (macOS, Linux, Windows) — FFmpeg required on `PATH` |
 | **Not** | A hosted cloud editor, credit-metered SaaS, or untyped FFmpeg shell wrapper |
@@ -639,7 +639,7 @@ Development verification lives in [docs/TESTING.md](docs/TESTING.md). Keep publi
 ## Development
 
 ```bash
-git clone https://git.kyanitelabs.tech/KyaniteLabs/kinocut.git
+git clone https://github.com/KyaniteLabs/kinocut.git
 cd kinocut
 python3 -m venv .venv
 source .venv/bin/activate
@@ -657,7 +657,7 @@ pytest tests/ -v -m "not slow and not hyperframes"
 - [Support](SUPPORT.md)
 - [Roadmap](ROADMAP.md)
 - [Changelog](CHANGELOG.md)
-- [Forgejo issues](https://git.kyanitelabs.tech/KyaniteLabs/kinocut/issues)
+- [GitHub issues](https://github.com/KyaniteLabs/kinocut/issues)
 
 ## License
 
@@ -679,6 +679,6 @@ More from [KyaniteLabs](https://kyanitelabs.tech). Related projects:
 
 ---
 
-If Kinocut is useful to you, **[star or watch it](https://git.kyanitelabs.tech/KyaniteLabs/kinocut)** — it helps other agent builders find it.
+If Kinocut is useful to you, **[star or watch it](https://github.com/KyaniteLabs/kinocut)** — it helps other agent builders find it.
 
 Built by **[Simon Gonzalez De Cruz](https://github.com/simongonzalezdc)** — available for Forward-Deployed / Applied-AI engineering and contract work via the public profile links above.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,7 +10,7 @@ Security fixes target the repository's default branch and the latest published p
 
 Please do not open a public issue for vulnerabilities.
 
-Follow the private support path in `SUPPORT.md` and include only the minimum detail needed to establish contact.
+Report privately through [GitHub private vulnerability reporting](https://github.com/KyaniteLabs/kinocut/security/advisories/new) and include only the minimum detail needed to establish contact.
 
 Helpful reports include:
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,11 +1,13 @@
 # Support
 
+All public support routes run through **[GitHub](https://github.com/KyaniteLabs/kinocut)**. Private security reports use [GitHub private vulnerability reporting](https://github.com/KyaniteLabs/kinocut/security/advisories/new) (see `SECURITY.md`).
+
 ## Where to ask for help
 
-- **Usage questions and workflow help**: Forgejo issues with the `question` label.
-- **Reproducible bugs**: Forgejo issues using the bug report template.
-- **Scoped feature requests**: Forgejo issues using the feature request template.
-- **Early ideas and proposals**: Forgejo issues with the `idea` label.
+- **Usage questions and workflow help**: [GitHub Q&A discussions](https://github.com/KyaniteLabs/kinocut/discussions/new?category=q-a).
+- **Reproducible bugs**: GitHub issues using the bug report template.
+- **Scoped feature requests**: GitHub issues using the feature request template.
+- **Early ideas and proposals**: [GitHub Ideas discussions](https://github.com/KyaniteLabs/kinocut/discussions/new?category=ideas).
 - **Security reports**: Follow the private reporting path in `SECURITY.md`.
 
 ## What to include in support requests

--- a/compat/mcp-video-shim/pyproject.toml
+++ b/compat/mcp-video-shim/pyproject.toml
@@ -35,7 +35,7 @@ dev = ["kinocut[dev]==1.9.0"]
 
 [project.urls]
 Homepage = "https://kinocut.dev/"
-Repository = "https://git.kyanitelabs.tech/KyaniteLabs/kinocut"
+Repository = "https://github.com/KyaniteLabs/kinocut"
 
 [tool.hatch.build.targets.wheel]
 bypass-selection = true

--- a/docs/ENTERPRISE.md
+++ b/docs/ENTERPRISE.md
@@ -13,7 +13,7 @@ Local-first, Apache-2.0 video execution for **AI agents and automation**, with p
 | Telemetry | No phoning home in core product path |
 | Media | Stays on your machine unless **you** send it elsewhere |
 | Cloud keys | Not required for core FFmpeg tools |
-| Support | Community via Forgejo/GitHub issues; no paid SLA claimed here |
+| Support | Community via [GitHub issues](https://github.com/KyaniteLabs/kinocut/issues); no paid SLA claimed here |
 
 ## Not claimed
 

--- a/docs/MCPB.md
+++ b/docs/MCPB.md
@@ -51,9 +51,9 @@ Do not publish this MCPB package externally until these gates are closed:
 - Add enforced MCPB runtime confinement for direct-tool absolute paths, or keep the package clearly labeled as user-configured local access.
 - Verify dependency-driven optional AI and Hyperframes behavior with dependencies absent and present.
 
-The self-contained native runtime implementation is tracked in
-[issue #125](https://git.kyanitelabs.tech/KyaniteLabs/kinocut/issues/125). Its pinned
+The self-contained native runtime implementation is tracked as an internal
+native-runtime workstream (historically referenced as issue #125). Its pinned
 runtime and licensing contract is documented in
 [MCPB_SUPPLY_CHAIN.md](MCPB_SUPPLY_CHAIN.md). The staged package on `master` remains
-non-publishable until that issue's native build, clean-machine, supply-chain, and human
+non-publishable until the native build, clean-machine, supply-chain, and human
 review gates are complete.

--- a/docs/MCPB_SUPPLY_CHAIN.md
+++ b/docs/MCPB_SUPPLY_CHAIN.md
@@ -1,6 +1,6 @@
 # MCPB Runtime Supply Chain
 
-Kinocut's native MCPB work is tracked in [issue #125](https://git.kyanitelabs.tech/KyaniteLabs/kinocut/issues/125).
+Kinocut's native MCPB work is tracked as an internal native-runtime workstream (historically referenced as issue #125).
 This document defines the evidence required before a self-contained bundle can be
 published. It does not authorize a release.
 

--- a/docs/launch-checklist.md
+++ b/docs/launch-checklist.md
@@ -91,7 +91,7 @@ Also works as a CLI: `kino trim video.mp4 -s 0:30 -d 15`
 
 pip install kinocut
 
-Source: git.kyanitelabs.tech/KyaniteLabs/kinocut
+Source: https://github.com/KyaniteLabs/kinocut
 Apache 2.0. Contributions welcome.
 
 If you build with MCP, I'd love to hear what tools you need.
@@ -137,7 +137,7 @@ Quick setup:
 
 pip install kinocut
 
-Source: https://git.kyanitelabs.tech/KyaniteLabs/kinocut
+Source: https://github.com/KyaniteLabs/kinocut
 
 ---
 
@@ -181,7 +181,7 @@ Local tools. Apache 2.0.
 
 What tools would you want to see in a video editing MCP server?
 
-Source: https://git.kyanitelabs.tech/KyaniteLabs/kinocut
+Source: https://github.com/KyaniteLabs/kinocut
 
 ---
 
@@ -218,7 +218,7 @@ Everything runs locally. No cloud, no API keys, no per-minute billing. Your vide
 
 pip install kinocut
 
-https://git.kyanitelabs.tech/KyaniteLabs/kinocut
+https://github.com/KyaniteLabs/kinocut
 
 ---
 
@@ -244,7 +244,7 @@ What's different:
 
 Apache 2.0. pip install kinocut.
 
-https://git.kyanitelabs.tech/KyaniteLabs/kinocut
+https://github.com/KyaniteLabs/kinocut
 
 ---
 
@@ -258,7 +258,7 @@ Structured tools (trim, merge, text, audio, resize, crop, rotate, fade, convert,
 
 Would love your feedback if you get a chance to try it. What video editing capabilities would be most useful in your workflows?
 
-Source: https://git.kyanitelabs.tech/KyaniteLabs/kinocut
+Source: https://github.com/KyaniteLabs/kinocut
 
 ### DM Template 2 (AI content creators)
 
@@ -276,4 +276,4 @@ The architecture is: MCP server wrapping FFmpeg, cinematic planning helpers, Hyp
 
 Curious if you've thought about adding video capabilities to [their project]? Would be happy to collaborate or share what I've learned about the MCP tool-building patterns.
 
-Source: https://git.kyanitelabs.tech/KyaniteLabs/kinocut
+Source: https://github.com/KyaniteLabs/kinocut

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,11 +140,11 @@ mcp-video = "kinocut.__main__:main"
 
 [project.urls]
 Homepage = "https://kinocut.dev/"
-Documentation = "https://git.kyanitelabs.tech/KyaniteLabs/kinocut#readme"
-Repository = "https://git.kyanitelabs.tech/KyaniteLabs/kinocut"
-"Bug Tracker" = "https://git.kyanitelabs.tech/KyaniteLabs/kinocut/issues"
-Changelog = "https://git.kyanitelabs.tech/KyaniteLabs/kinocut/src/branch/master/CHANGELOG.md"
-Discussions = "https://git.kyanitelabs.tech/KyaniteLabs/kinocut/issues"
+Documentation = "https://github.com/KyaniteLabs/kinocut#readme"
+Repository = "https://github.com/KyaniteLabs/kinocut"
+"Bug Tracker" = "https://github.com/KyaniteLabs/kinocut/issues"
+Changelog = "https://github.com/KyaniteLabs/kinocut/blob/master/CHANGELOG.md"
+Discussions = "https://github.com/KyaniteLabs/kinocut/discussions"
 
 [tool.hatch.build]
 exclude = [

--- a/tests/test_public_surface.py
+++ b/tests/test_public_surface.py
@@ -70,6 +70,20 @@ CURRENT_KINOCUT_DOC_PATHS = (
     ROOT / "workflows" / "GOLDEN_WORKFLOWS.md",
 )
 
+EXTERNAL_CONTRIBUTOR_PATHS = (
+    ROOT / ".github" / "ISSUE_TEMPLATE" / "config.yml",
+    ROOT / "README.md",
+    ROOT / "CONTRIBUTING.md",
+    ROOT / "SUPPORT.md",
+    ROOT / "SECURITY.md",
+    ROOT / "pyproject.toml",
+    ROOT / "compat" / "mcp-video-shim" / "pyproject.toml",
+    ROOT / "docs" / "ENTERPRISE.md",
+    ROOT / "docs" / "MCPB.md",
+    ROOT / "docs" / "MCPB_SUPPLY_CHAIN.md",
+    ROOT / "docs" / "launch-checklist.md",
+)
+
 
 def _public_surface_paths() -> list[Path]:
     """Return every maintained public/discovery surface covered by drift guards."""
@@ -502,14 +516,30 @@ def test_server_json_and_readme_match_registry_identity():
 
     assert server["name"] == "io.github.KyaniteLabs/kinocut"
     assert server["websiteUrl"] == "https://kinocut.dev/"
-    # The registry's semantic validator currently accepts the GitHub mirror,
-    # while Forgejo remains the canonical repository on every other surface.
+    # GitHub is the canonical public repository and contribution surface.
     assert server["repository"]["url"] == "https://github.com/KyaniteLabs/kinocut"
     assert server["repository"]["source"] == "github"
     assert server["packages"][0]["identifier"] == "kinocut"
     assert server["packages"][0]["runtimeHint"] == "uvx"
     assert server["packages"][0]["transport"]["type"] == "stdio"
     assert f"mcp-name: {server['name']}" in readme
+
+
+def test_external_contributor_surfaces_route_exclusively_to_github():
+    offenders = {
+        str(path.relative_to(ROOT)): fragment
+        for path in EXTERNAL_CONTRIBUTOR_PATHS
+        for fragment in ("git.kyanitelabs.tech", "Forgejo")
+        if fragment in path.read_text(encoding="utf-8")
+    }
+
+    assert offenders == {}
+
+    project_urls = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))["project"]["urls"]
+    assert all(
+        project_urls[key].startswith("https://github.com/KyaniteLabs/kinocut")
+        for key in ("Documentation", "Repository", "Bug Tracker", "Changelog", "Discussions")
+    )
 
 
 def test_public_tree_does_not_track_local_agent_state_artifacts():


### PR DESCRIPTION
## Summary

- route external clone, issue, support, Q&A, ideas, and pull-request guidance through GitHub
- route private vulnerability reports through enabled GitHub private vulnerability reporting
- update package metadata and public launch links so package-directory visitors are not sent to maintainer-internal Forgejo
- add a regression test covering the GitHub-only external contributor surfaces

Forgejo remains available for maintainer-internal operations and historical evidence; it is no longer advertised as an external interaction route.

## Verification

- `pytest tests/test_public_surface.py -q` — 26 passed
- `ruff check tests/test_public_surface.py`
- `ruff format --check tests/test_public_surface.py`
- `python scripts/repo-readiness-audit.py` — baseline passed (expected branch/worktree warnings only)
- TOML and issue-template YAML parsing/route assertions passed
- `git diff --check`

Closes #396

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/kinocut/pr/397"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787083137&installation_id=130430723&pr_number=397&repository=KyaniteLabs%2Fkinocut&return_to=https%3A%2F%2Fgithub.com%2FKyaniteLabs%2Fkinocut%2Fpull%2F397&signature=8ab00bb9bce1c23c8d15e13f19132ae41e070a41dd6265d4c7cba9b7a29af8cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project, contribution, support, security, and enterprise guidance to use GitHub as the primary destination.
  * Refreshed repository, issue, discussion, documentation, and changelog links throughout the project.
  * Updated release and publication guidance to reference internal workstreams where appropriate.

* **Chores**
  * Updated package metadata to use the current repository URL.

* **Tests**
  * Added coverage ensuring public contribution resources consistently point to GitHub.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->