### PR TITLE
feat: define strict stream candidate contracts

### DIFF
--- a/kinocut/product/models.py
+++ b/kinocut/product/models.py
@@ -19,10 +19,9 @@ from __future__ import annotations
 import hashlib
 import json
 import re
-from collections.abc import Mapping
-from typing import Any, Literal
+from typing import Literal
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import Field, model_validator
 
 from kinocut.contracts._common import ValueObject
 
@@ -198,20 +197,3 @@ def canonical_dedup_key(
         allow_nan=False,
     ).encode("utf-8")
     return hashlib.sha256(encoded).hexdigest()[:16]
-
-
-# --- Internal helpers exposed for tests --------------------------------------
-
-
-def to_jsonable(value: Any) -> Any:
-    """Recursively coerce strict models / nested tuples to JSON primitives."""
-
-    if isinstance(value, BaseModel):
-        return value.model_dump(mode="json")
-    if isinstance(value, tuple):
-        return [to_jsonable(item) for item in value]
-    if isinstance(value, list):
-        return [to_jsonable(item) for item in value]
-    if isinstance(value, Mapping):
-        return {str(key): to_jsonable(item) for key, item in value.items()}
-    return value

--- a/kinocut/product/models.py
+++ b/kinocut/product/models.py
@@ -1,77 +1,46 @@
 """Strict product-domain models for the long-form stream-to-shorts workflow.
 
-The models in this module are the *public contract* for moment discovery and
-downstream ShortsPlan composition. Every model is:
+Models here are the public contract for moment discovery and ShortsPlan
+composition. They are strict (no extra fields, frozen, no NaN), JSON-stable
+(round-trip via ``model_dump(mode="json")`` with ``dedup_key`` as a stable
+sha256 prefix), and decoupled from engines — value objects consumed by
+``kinocut.product.shorts``/``kinocut.workflow.executor``, never the reverse.
 
-* **Strict** — ``extra="forbid"``, ``frozen=True``, ``allow_inf_nan=False`` so a
-  caller cannot smuggle unknown fields, mutate state, or sneak a NaN into a
-  canonical JSON payload.
-* **JSON-stable** — every field round-trips through ``model_dump(mode="json")``
-  with sorted keys + compact separators; ``dedup_key`` is a stable sha256 hex
-  digest that other slices can reproduce byte-for-byte.
-* **Decoupled from engines** — these are VALUE OBJECTS, not records. The
-  downstream render-op emission (which lives in
-  ``kinocut.product.shorts``/``kinocut.workflow.executor``) consumes these
-  models but never the other way around. No engine import is performed here.
+Product-local conventions:
 
-Human review remains mandatory before any render: every :class:`CandidateMoment`
-carries a ``review_warning`` (or ``None`` when none applies) and an
-``unsuitable`` flag so reviewers can act on the proposal rather than accept it
-blind.
+* Quantisation to whole-millisecond integers when computing ``dedup_key`` so
+  deterministic re-runs collapse sub-millisecond float drift.
+* One-directional ``unsuitable`` ⇒ ``sensitivity == "unsafe"`` semantics:
+  ``unsafe`` may stand alone, but ``unsuitable`` must escalate.
 """
 
 from __future__ import annotations
-from collections.abc import Mapping
 
 import hashlib
 import json
 import re
+from collections.abc import Mapping
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, Field, model_validator
 
+from kinocut.contracts._common import ValueObject
 
-# --- Bounded string patterns -------------------------------------------------
-
-# ``segment_id`` is a caller-supplied identifier for a transcript segment. It is
-# intentionally permissive (ascii identifier characters plus ``-``/``_``/``.``)
-# because the producer (long-form transcription slice) owns the naming scheme.
+# Caller-owned segment identifier (permissive; producer owns the scheme).
 _SEGMENT_ID_PATTERN = r"^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$"
 
-# ``dedup_key`` is the canonical 16-hex-char prefix of a sha256 over the
-# stable semantic content of a candidate (start, end, sensitivity, normalised
-# excerpt). Two logically-equal candidates MUST hash to the same key.
+# 16-hex sha256 prefix over (start_ms, end_ms, excerpt, sensitivity).
 _DEDUP_KEY_PATTERN = r"^[0-9a-f]{16}$"
 
-# ``sensitivity`` is an ordinal progression callers (and the review surface) can
-# match on without re-parsing prose. ``unsafe`` is reserved for material that
-# must NOT be auto-rendered even if accepted; the orchestrator treats it as a
-# hard block.
+# Ordinal progression; ``unsafe`` is a hard render block.
 SensitivityLevel = Literal["none", "mild", "strong", "unsafe"]
-
-
-# --- Strict base -------------------------------------------------------------
-
-
-class _StrictModel(BaseModel):
-    """Frozen, unknown-field-rejecting base for every model in this module."""
-
-    model_config = ConfigDict(extra="forbid", frozen=True, allow_inf_nan=False)
 
 
 # --- Inputs ------------------------------------------------------------------
 
 
-class TranscriptSegment(_StrictModel):
-    """One timed span of transcript text.
-
-    The discovery layer treats segments as the smallest unit of analysis; they
-    may come from a long-form transcription slice that emits word-grouped
-    phrases or coarse sentence-level chunks. ``speaker`` and ``confidence`` are
-    optional because some upstream emitters only carry them when they have a
-    reliable value. ``is_silence`` lets the discovery layer honour the
-    "no leading silence" rule without re-running silence detection.
-    """
+class TranscriptSegment(ValueObject):
+    """One timed span of transcript text."""
 
     segment_id: str = Field(pattern=_SEGMENT_ID_PATTERN)
     start: float = Field(ge=0.0)
@@ -83,31 +52,13 @@ class TranscriptSegment(_StrictModel):
 
     @model_validator(mode="after")
     def _validate_time_range(self) -> TranscriptSegment:
-        """A segment's end must be strictly greater than its start.
-
-        Zero-width segments cannot anchor a moment boundary and would otherwise
-        leak into the candidate window; reject them at the input boundary so
-        the discovery layer never has to defend against them.
-        """
-
         if self.end <= self.start:
             raise ValueError("transcript segment end must be strictly greater than start")
         return self
 
 
-class TranscriptWord(_StrictModel):
-    """One timed word/token emitted by the long-form transcription slice.
-
-    Preserved through the orchestrator so caption generation can use real
-    Whisper word timings instead of evenly synthesizing them when no real
-    timings are available. ``segment_id`` ties the word back to its parent
-    :class:`TranscriptSegment` for the caption grouper, which needs the
-    segment boundary to clip each word against the candidate window.
-    ``probability`` is the per-token log-probability translated to a
-    probability in ``[0.0, 1.0]``; ``None`` when the upstream emitter did
-    not supply one. Times are source-time seconds and remain absolute —
-    caption generation offsets them to the candidate window.
-    """
+class TranscriptWord(ValueObject):
+    """One timed word/token from the long-form transcription slice."""
 
     word: str = Field(min_length=1)
     start: float = Field(ge=0.0)
@@ -123,14 +74,10 @@ class TranscriptWord(_StrictModel):
         return self
 
 
-class SourceSignal(_StrictModel):
+class SourceSignal(ValueObject):
     """One optional evidence signal attached to a candidate.
 
-    Signals are caller-supplied (long-form transcription slice, scene-detect
-    slice, audio-engine slice) and the discovery layer uses them only as a
-    tie-breaker for the *score* — the *bounds* always come from the transcript.
-    ``kind`` is a discriminated literal so a future schema addition is
-    fail-closed: any new kind has to be opted in here.
+    ``kind`` is a closed literal so future additions are fail-closed.
     """
 
     kind: Literal["scene_change", "audio_energy"]
@@ -138,32 +85,16 @@ class SourceSignal(_StrictModel):
     score: float = Field(ge=0.0, le=1.0)
     label: str | None = Field(default=None, min_length=1)
 
-    @model_validator(mode="after")
-    def _validate_score_window(self) -> SourceSignal:
-        if not self.score >= 0.0:  # tautology kept explicit for readability
-            raise ValueError("source signal score must be >= 0.0")
-        return self
-
 
 # --- Output ------------------------------------------------------------------
 
 
-class CandidateMoment(_StrictModel):
+class CandidateMoment(ValueObject):
     """One proposed clip derived from the transcript.
 
-    A candidate is a *suggestion*, not an executable plan. ``start``/``end``
-    are the discovery layer's best estimate of where to cut, given the
-    complete-thought / no-leading-silence / bounds / duration / payoff rules.
-    ``transcript_excerpt`` is the verbatim slice the rule engine chose; the
-    surrounding ``context_before`` / ``context_after`` strings (each ``None``
-    when not applicable) let a reviewer see what was trimmed off.
-
-    ``dedup_key`` is the stable hash that downstream stages use to collapse
-    near-duplicate proposals. ``unsuitable`` is a hard flag for material that
-    must never be auto-rendered (e.g. unfinished thoughts, dead air,
-    self-harm content). ``sensitivity`` is a soft ordinal: ``none`` is safe to
-    publish as-is; ``mild`` may need a content warning; ``strong`` should be
-    reviewed before render; ``unsafe`` blocks rendering entirely.
+    A candidate is a *suggestion*, not an executable plan. ``dedup_key`` MUST
+    equal ``canonical_dedup_key(start, end, transcript_excerpt, sensitivity)``
+    — the validator re-derives it so callers cannot smuggle a stale key.
     """
 
     candidate_id: str = Field(pattern=_SEGMENT_ID_PATTERN)
@@ -184,55 +115,40 @@ class CandidateMoment(_StrictModel):
 
     @model_validator(mode="after")
     def _validate_invariants(self) -> CandidateMoment:
-        """Enforce the cheap structural invariants of a candidate.
-
-        Numeric bounds, duration, and the "end strictly greater than start"
-        rule live here so callers cannot construct an invalid candidate even
-        by hand. The semantic rules (complete-thought boundary, no leading
-        silence, payoff) are enforced in :func:`discover_highlights` — they
-        require transcript context and do not belong on the model.
-        """
-
         if self.end <= self.start:
             raise ValueError("candidate end must be strictly greater than start")
         if self.unsuitable and self.sensitivity != "unsafe":
-            # An unsuitable candidate must also declare the unsafe sensitivity
-            # so the review surface can match on a single field.
             raise ValueError("unsuitable candidates must declare sensitivity='unsafe'")
+        if self.dedup_key != canonical_dedup_key(
+            start=self.start,
+            end=self.end,
+            excerpt=self.transcript_excerpt,
+            sensitivity=self.sensitivity,
+        ):
+            raise ValueError("dedup_key does not match canonical_dedup_key(start, end, excerpt, sensitivity)")
         return self
 
 
-class HighlightDiscoveryConfig(_StrictModel):
+class HighlightDiscoveryConfig(ValueObject):
     """Tunable knobs for :func:`discover_highlights`.
 
-    Defaults target YouTube Shorts (180 s cap) and Instagram Reels (90 s cap);
-    the discovery layer clamps every emitted candidate to the union
-    ``[min_duration, max_duration]``. ``min_clips`` is a *target*, not a
-    guarantee: degenerate inputs return fewer candidates honestly rather than
-    padding the output with weak proposals. ``max_clips`` is a hard cap.
+    ``min_clips`` is a target; ``max_clips`` is a hard cap. When the operator
+    only sets ``max_clips`` below the default ``min_clips``, ``min_clips``
+    auto-caps to ``max_clips`` to avoid surprise. An explicit
+    ``min_clips > max_clips`` is treated as an inconsistency.
     """
 
     min_duration: float = Field(default=15.0, gt=0.0)
     max_duration: float = Field(default=180.0, gt=0.0)
     min_clips: int = Field(default=3, ge=0)
     max_clips: int = Field(default=8, ge=1)
-    # Scene/audio-signal influence on score (0.0 disables, 1.0 takes over).
-    # Always clamped to [0.0, 1.0].
     signal_weight: float = Field(default=0.25, ge=0.0, le=1.0)
-    # Sliding-window stride used to enumerate candidate windows. Smaller
-    # strides produce more candidates; the discovery layer always dedups.
     window_stride: float = Field(default=8.0, gt=0.0)
 
     @model_validator(mode="after")
     def _validate_window(self) -> HighlightDiscoveryConfig:
         if self.max_duration <= self.min_duration:
             raise ValueError("max_duration must be strictly greater than min_duration")
-        # ``min_clips`` is a *target*; ``max_clips`` is a hard cap. When the
-        # operator lowers ``max_clips`` without explicitly choosing a new
-        # ``min_clips``, auto-cap ``min_clips`` so the configuration does not
-        # surprise them with a validation error. An operator who explicitly
-        # sets ``min_clips`` above ``max_clips`` is signalling an inconsistency
-        # they must resolve — that case still raises.
         if "min_clips" not in self.model_fields_set and self.min_clips > self.max_clips:
             object.__setattr__(self, "min_clips", self.max_clips)
         if self.min_clips > self.max_clips:
@@ -240,14 +156,8 @@ class HighlightDiscoveryConfig(_StrictModel):
         return self
 
 
-class HighlightDiscoveryResult(_StrictModel):
-    """The deterministic output of :func:`discover_highlights`.
-
-    The container is JSON-stable: every field is a plain value or a tuple of
-    strict models, so the orchestrator can serialise the whole object with
-    ``model_dump(mode="json")`` and feed it directly to the human-review
-    surface and the downstream ShortsPlan composer.
-    """
+class HighlightDiscoveryResult(ValueObject):
+    """The deterministic output of :func:`discover_highlights`."""
 
     candidates: tuple[CandidateMoment, ...]
     config: HighlightDiscoveryConfig
@@ -258,6 +168,9 @@ class HighlightDiscoveryResult(_StrictModel):
 # --- Canonical hashing helper ------------------------------------------------
 
 
+_WHITESPACE_RE = re.compile(r"\s+")
+
+
 def canonical_dedup_key(
     *,
     start: float,
@@ -265,20 +178,15 @@ def canonical_dedup_key(
     excerpt: str,
     sensitivity: SensitivityLevel,
 ) -> str:
-    """Compute the stable ``dedup_key`` for a candidate.
+    """Stable ``dedup_key`` over (start_ms, end_ms, excerpt, sensitivity).
 
-    Two candidates whose (start, end, excerpt, sensitivity) are equal MUST
-    hash to the same key so downstream dedup is a set-membership test, not a
-    fuzzy comparison. Float ``start``/``end`` are quantised to milliseconds
-    so that deterministic re-runs with subtly different float arithmetic
-    (e.g. ``30.0`` vs ``30.00000001``) collapse to one key.
+    Floats are quantised to whole milliseconds so deterministic re-runs with
+    sub-millisecond float drift collapse to one key.
     """
 
     payload = {
         "start_ms": round(start * 1000.0),
         "end_ms": round(end * 1000.0),
-        # Normalise whitespace so a transcript rendered with different
-        # line-ending / spacing choices collapses to the same key.
         "excerpt": _WHITESPACE_RE.sub(" ", excerpt).strip().lower(),
         "sensitivity": sensitivity,
     }
@@ -292,20 +200,11 @@ def canonical_dedup_key(
     return hashlib.sha256(encoded).hexdigest()[:16]
 
 
-_WHITESPACE_RE = re.compile(r"\s+")
-
-
 # --- Internal helpers exposed for tests --------------------------------------
 
 
 def to_jsonable(value: Any) -> Any:
-    """Recursively coerce a strict model (or tuple of them) to JSON primitives.
-
-    The orchestrator wants plain JSON; Pydantic's ``model_dump(mode="json")``
-    already handles ``datetime``/``Enum`` but it does not deep-coerce nested
-    tuples. This helper is the bridge between strict models and the
-    ``shorts_plan`` JSON contract.
-    """
+    """Recursively coerce strict models / nested tuples to JSON primitives."""
 
     if isinstance(value, BaseModel):
         return value.model_dump(mode="json")

--- a/kinocut/product/models.py
+++ b/kinocut/product/models.py
@@ -1,0 +1,318 @@
+"""Strict product-domain models for the long-form stream-to-shorts workflow.
+
+The models in this module are the *public contract* for moment discovery and
+downstream ShortsPlan composition. Every model is:
+
+* **Strict** — ``extra="forbid"``, ``frozen=True``, ``allow_inf_nan=False`` so a
+  caller cannot smuggle unknown fields, mutate state, or sneak a NaN into a
+  canonical JSON payload.
+* **JSON-stable** — every field round-trips through ``model_dump(mode="json")``
+  with sorted keys + compact separators; ``dedup_key`` is a stable sha256 hex
+  digest that other slices can reproduce byte-for-byte.
+* **Decoupled from engines** — these are VALUE OBJECTS, not records. The
+  downstream render-op emission (which lives in
+  ``kinocut.product.shorts``/``kinocut.workflow.executor``) consumes these
+  models but never the other way around. No engine import is performed here.
+
+Human review remains mandatory before any render: every :class:`CandidateMoment`
+carries a ``review_warning`` (or ``None`` when none applies) and an
+``unsuitable`` flag so reviewers can act on the proposal rather than accept it
+blind.
+"""
+
+from __future__ import annotations
+from collections.abc import Mapping
+
+import hashlib
+import json
+import re
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+# --- Bounded string patterns -------------------------------------------------
+
+# ``segment_id`` is a caller-supplied identifier for a transcript segment. It is
+# intentionally permissive (ascii identifier characters plus ``-``/``_``/``.``)
+# because the producer (long-form transcription slice) owns the naming scheme.
+_SEGMENT_ID_PATTERN = r"^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$"
+
+# ``dedup_key`` is the canonical 16-hex-char prefix of a sha256 over the
+# stable semantic content of a candidate (start, end, sensitivity, normalised
+# excerpt). Two logically-equal candidates MUST hash to the same key.
+_DEDUP_KEY_PATTERN = r"^[0-9a-f]{16}$"
+
+# ``sensitivity`` is an ordinal progression callers (and the review surface) can
+# match on without re-parsing prose. ``unsafe`` is reserved for material that
+# must NOT be auto-rendered even if accepted; the orchestrator treats it as a
+# hard block.
+SensitivityLevel = Literal["none", "mild", "strong", "unsafe"]
+
+
+# --- Strict base -------------------------------------------------------------
+
+
+class _StrictModel(BaseModel):
+    """Frozen, unknown-field-rejecting base for every model in this module."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True, allow_inf_nan=False)
+
+
+# --- Inputs ------------------------------------------------------------------
+
+
+class TranscriptSegment(_StrictModel):
+    """One timed span of transcript text.
+
+    The discovery layer treats segments as the smallest unit of analysis; they
+    may come from a long-form transcription slice that emits word-grouped
+    phrases or coarse sentence-level chunks. ``speaker`` and ``confidence`` are
+    optional because some upstream emitters only carry them when they have a
+    reliable value. ``is_silence`` lets the discovery layer honour the
+    "no leading silence" rule without re-running silence detection.
+    """
+
+    segment_id: str = Field(pattern=_SEGMENT_ID_PATTERN)
+    start: float = Field(ge=0.0)
+    end: float = Field(gt=0.0)
+    text: str = Field(min_length=1)
+    speaker: str | None = Field(default=None, min_length=1)
+    confidence: float | None = Field(default=None, ge=0.0, le=1.0)
+    is_silence: bool = False
+
+    @model_validator(mode="after")
+    def _validate_time_range(self) -> TranscriptSegment:
+        """A segment's end must be strictly greater than its start.
+
+        Zero-width segments cannot anchor a moment boundary and would otherwise
+        leak into the candidate window; reject them at the input boundary so
+        the discovery layer never has to defend against them.
+        """
+
+        if self.end <= self.start:
+            raise ValueError("transcript segment end must be strictly greater than start")
+        return self
+
+
+class TranscriptWord(_StrictModel):
+    """One timed word/token emitted by the long-form transcription slice.
+
+    Preserved through the orchestrator so caption generation can use real
+    Whisper word timings instead of evenly synthesizing them when no real
+    timings are available. ``segment_id`` ties the word back to its parent
+    :class:`TranscriptSegment` for the caption grouper, which needs the
+    segment boundary to clip each word against the candidate window.
+    ``probability`` is the per-token log-probability translated to a
+    probability in ``[0.0, 1.0]``; ``None`` when the upstream emitter did
+    not supply one. Times are source-time seconds and remain absolute —
+    caption generation offsets them to the candidate window.
+    """
+
+    word: str = Field(min_length=1)
+    start: float = Field(ge=0.0)
+    end: float = Field(gt=0.0)
+    segment_id: str = Field(pattern=_SEGMENT_ID_PATTERN)
+    probability: float | None = Field(default=None, ge=0.0, le=1.0)
+    chunk_index: int | None = Field(default=None, ge=0)
+
+    @model_validator(mode="after")
+    def _validate_time_range(self) -> TranscriptWord:
+        if self.end <= self.start:
+            raise ValueError("transcript word end must be strictly greater than start")
+        return self
+
+
+class SourceSignal(_StrictModel):
+    """One optional evidence signal attached to a candidate.
+
+    Signals are caller-supplied (long-form transcription slice, scene-detect
+    slice, audio-engine slice) and the discovery layer uses them only as a
+    tie-breaker for the *score* — the *bounds* always come from the transcript.
+    ``kind`` is a discriminated literal so a future schema addition is
+    fail-closed: any new kind has to be opted in here.
+    """
+
+    kind: Literal["scene_change", "audio_energy"]
+    timestamp: float = Field(ge=0.0)
+    score: float = Field(ge=0.0, le=1.0)
+    label: str | None = Field(default=None, min_length=1)
+
+    @model_validator(mode="after")
+    def _validate_score_window(self) -> SourceSignal:
+        if not self.score >= 0.0:  # tautology kept explicit for readability
+            raise ValueError("source signal score must be >= 0.0")
+        return self
+
+
+# --- Output ------------------------------------------------------------------
+
+
+class CandidateMoment(_StrictModel):
+    """One proposed clip derived from the transcript.
+
+    A candidate is a *suggestion*, not an executable plan. ``start``/``end``
+    are the discovery layer's best estimate of where to cut, given the
+    complete-thought / no-leading-silence / bounds / duration / payoff rules.
+    ``transcript_excerpt`` is the verbatim slice the rule engine chose; the
+    surrounding ``context_before`` / ``context_after`` strings (each ``None``
+    when not applicable) let a reviewer see what was trimmed off.
+
+    ``dedup_key`` is the stable hash that downstream stages use to collapse
+    near-duplicate proposals. ``unsuitable`` is a hard flag for material that
+    must never be auto-rendered (e.g. unfinished thoughts, dead air,
+    self-harm content). ``sensitivity`` is a soft ordinal: ``none`` is safe to
+    publish as-is; ``mild`` may need a content warning; ``strong`` should be
+    reviewed before render; ``unsafe`` blocks rendering entirely.
+    """
+
+    candidate_id: str = Field(pattern=_SEGMENT_ID_PATTERN)
+    start: float = Field(ge=0.0)
+    end: float = Field(gt=0.0)
+    transcript_excerpt: str = Field(min_length=1)
+    suggested_title: str = Field(min_length=1)
+    suggested_hook: str = Field(min_length=1)
+    rationale: str = Field(min_length=1)
+    confidence: float = Field(ge=0.0, le=1.0)
+    review_warning: str | None = None
+    context_before: str | None = None
+    context_after: str | None = None
+    dedup_key: str = Field(pattern=_DEDUP_KEY_PATTERN)
+    sensitivity: SensitivityLevel = "none"
+    unsuitable: bool = False
+    source_signals: tuple[SourceSignal, ...] = ()
+
+    @model_validator(mode="after")
+    def _validate_invariants(self) -> CandidateMoment:
+        """Enforce the cheap structural invariants of a candidate.
+
+        Numeric bounds, duration, and the "end strictly greater than start"
+        rule live here so callers cannot construct an invalid candidate even
+        by hand. The semantic rules (complete-thought boundary, no leading
+        silence, payoff) are enforced in :func:`discover_highlights` — they
+        require transcript context and do not belong on the model.
+        """
+
+        if self.end <= self.start:
+            raise ValueError("candidate end must be strictly greater than start")
+        if self.unsuitable and self.sensitivity != "unsafe":
+            # An unsuitable candidate must also declare the unsafe sensitivity
+            # so the review surface can match on a single field.
+            raise ValueError("unsuitable candidates must declare sensitivity='unsafe'")
+        return self
+
+
+class HighlightDiscoveryConfig(_StrictModel):
+    """Tunable knobs for :func:`discover_highlights`.
+
+    Defaults target YouTube Shorts (180 s cap) and Instagram Reels (90 s cap);
+    the discovery layer clamps every emitted candidate to the union
+    ``[min_duration, max_duration]``. ``min_clips`` is a *target*, not a
+    guarantee: degenerate inputs return fewer candidates honestly rather than
+    padding the output with weak proposals. ``max_clips`` is a hard cap.
+    """
+
+    min_duration: float = Field(default=15.0, gt=0.0)
+    max_duration: float = Field(default=180.0, gt=0.0)
+    min_clips: int = Field(default=3, ge=0)
+    max_clips: int = Field(default=8, ge=1)
+    # Scene/audio-signal influence on score (0.0 disables, 1.0 takes over).
+    # Always clamped to [0.0, 1.0].
+    signal_weight: float = Field(default=0.25, ge=0.0, le=1.0)
+    # Sliding-window stride used to enumerate candidate windows. Smaller
+    # strides produce more candidates; the discovery layer always dedups.
+    window_stride: float = Field(default=8.0, gt=0.0)
+
+    @model_validator(mode="after")
+    def _validate_window(self) -> HighlightDiscoveryConfig:
+        if self.max_duration <= self.min_duration:
+            raise ValueError("max_duration must be strictly greater than min_duration")
+        # ``min_clips`` is a *target*; ``max_clips`` is a hard cap. When the
+        # operator lowers ``max_clips`` without explicitly choosing a new
+        # ``min_clips``, auto-cap ``min_clips`` so the configuration does not
+        # surprise them with a validation error. An operator who explicitly
+        # sets ``min_clips`` above ``max_clips`` is signalling an inconsistency
+        # they must resolve — that case still raises.
+        if "min_clips" not in self.model_fields_set and self.min_clips > self.max_clips:
+            object.__setattr__(self, "min_clips", self.max_clips)
+        if self.min_clips > self.max_clips:
+            raise ValueError("min_clips must be <= max_clips")
+        return self
+
+
+class HighlightDiscoveryResult(_StrictModel):
+    """The deterministic output of :func:`discover_highlights`.
+
+    The container is JSON-stable: every field is a plain value or a tuple of
+    strict models, so the orchestrator can serialise the whole object with
+    ``model_dump(mode="json")`` and feed it directly to the human-review
+    surface and the downstream ShortsPlan composer.
+    """
+
+    candidates: tuple[CandidateMoment, ...]
+    config: HighlightDiscoveryConfig
+    source_segment_count: int = Field(ge=0)
+    discovered_at_offsets: tuple[float, ...] = ()
+
+
+# --- Canonical hashing helper ------------------------------------------------
+
+
+def canonical_dedup_key(
+    *,
+    start: float,
+    end: float,
+    excerpt: str,
+    sensitivity: SensitivityLevel,
+) -> str:
+    """Compute the stable ``dedup_key`` for a candidate.
+
+    Two candidates whose (start, end, excerpt, sensitivity) are equal MUST
+    hash to the same key so downstream dedup is a set-membership test, not a
+    fuzzy comparison. Float ``start``/``end`` are quantised to milliseconds
+    so that deterministic re-runs with subtly different float arithmetic
+    (e.g. ``30.0`` vs ``30.00000001``) collapse to one key.
+    """
+
+    payload = {
+        "start_ms": round(start * 1000.0),
+        "end_ms": round(end * 1000.0),
+        # Normalise whitespace so a transcript rendered with different
+        # line-ending / spacing choices collapses to the same key.
+        "excerpt": _WHITESPACE_RE.sub(" ", excerpt).strip().lower(),
+        "sensitivity": sensitivity,
+    }
+    encoded = json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()[:16]
+
+
+_WHITESPACE_RE = re.compile(r"\s+")
+
+
+# --- Internal helpers exposed for tests --------------------------------------
+
+
+def to_jsonable(value: Any) -> Any:
+    """Recursively coerce a strict model (or tuple of them) to JSON primitives.
+
+    The orchestrator wants plain JSON; Pydantic's ``model_dump(mode="json")``
+    already handles ``datetime``/``Enum`` but it does not deep-coerce nested
+    tuples. This helper is the bridge between strict models and the
+    ``shorts_plan`` JSON contract.
+    """
+
+    if isinstance(value, BaseModel):
+        return value.model_dump(mode="json")
+    if isinstance(value, tuple):
+        return [to_jsonable(item) for item in value]
+    if isinstance(value, list):
+        return [to_jsonable(item) for item in value]
+    if isinstance(value, Mapping):
+        return {str(key): to_jsonable(item) for key, item in value.items()}
+    return value

--- a/tests/test_product_models.py
+++ b/tests/test_product_models.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from kinocut.product.models import (
+    CandidateMoment,
+    HighlightDiscoveryConfig,
+    SourceSignal,
+    TranscriptSegment,
+    TranscriptWord,
+    canonical_dedup_key,
+)
+
+
+def test_transcript_ranges_are_strict() -> None:
+    with pytest.raises(ValidationError):
+        TranscriptSegment(segment_id="s", start=1, end=1, text="x")
+    with pytest.raises(ValidationError):
+        TranscriptWord(word="x", start=2, end=1, segment_id="s")
+
+
+def test_probabilities_and_unknown_fields_fail_closed() -> None:
+    with pytest.raises(ValidationError):
+        TranscriptWord(word="x", start=0, end=1, segment_id="s", probability=1.1)
+    with pytest.raises(ValidationError):
+        SourceSignal(kind="scene_change", timestamp=0, score=0.5, unknown=True)
+
+
+def _candidate(**updates: object) -> CandidateMoment:
+    data: dict[str, object] = {
+        "candidate_id": "candidate",
+        "start": 1.0,
+        "end": 2.0,
+        "transcript_excerpt": "A complete thought.",
+        "suggested_title": "Title",
+        "suggested_hook": "Hook",
+        "rationale": "Complete thought",
+        "confidence": 0.8,
+        "dedup_key": "0123456789abcdef",
+    }
+    data.update(updates)
+    return CandidateMoment.model_validate(data)
+
+
+def test_candidate_requires_safe_unsuitable_state() -> None:
+    with pytest.raises(ValidationError):
+        _candidate(unsuitable=True, sensitivity="strong")
+    assert _candidate(unsuitable=True, sensitivity="unsafe").unsuitable is True
+
+
+def test_candidate_is_frozen_and_json_stable() -> None:
+    candidate = _candidate(source_signals=(SourceSignal(kind="audio_energy", timestamp=1, score=0.7),))
+    with pytest.raises(ValidationError):
+        candidate.end = 3  # type: ignore[misc]
+    assert CandidateMoment.model_validate_json(candidate.model_dump_json()) == candidate
+
+
+def test_discovery_config_bounds_are_coherent() -> None:
+    assert HighlightDiscoveryConfig(max_clips=2).min_clips == 2
+    with pytest.raises(ValidationError):
+        HighlightDiscoveryConfig(min_clips=3, max_clips=2)
+
+
+def test_dedup_key_is_semantic_and_stable() -> None:
+    first = canonical_dedup_key(start=1, end=2, excerpt="  Hello   world ", sensitivity="none")
+    second = canonical_dedup_key(start=1, end=2, excerpt="hello world", sensitivity="none")
+    assert first == second
+    assert len(first) == 16

--- a/tests/test_product_models.py
+++ b/tests/test_product_models.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import math
+
 import pytest
 from pydantic import ValidationError
 
@@ -13,40 +15,77 @@ from kinocut.product.models import (
 )
 
 
-def test_transcript_ranges_are_strict() -> None:
-    with pytest.raises(ValidationError):
-        TranscriptSegment(segment_id="s", start=1, end=1, text="x")
-    with pytest.raises(ValidationError):
-        TranscriptWord(word="x", start=2, end=1, segment_id="s")
-
-
-def test_probabilities_and_unknown_fields_fail_closed() -> None:
-    with pytest.raises(ValidationError):
-        TranscriptWord(word="x", start=0, end=1, segment_id="s", probability=1.1)
-    with pytest.raises(ValidationError):
-        SourceSignal(kind="scene_change", timestamp=0, score=0.5, unknown=True)
-
-
 def _candidate(**updates: object) -> CandidateMoment:
+    excerpt = "A complete thought."
+    start, end, sensitivity = 1.0, 2.0, "none"
+    if "transcript_excerpt" in updates:
+        excerpt = updates["transcript_excerpt"]  # type: ignore[assignment]
+    if "start" in updates:
+        start = updates["start"]  # type: ignore[assignment]
+    if "end" in updates:
+        end = updates["end"]  # type: ignore[assignment]
+    if "sensitivity" in updates:
+        sensitivity = updates["sensitivity"]  # type: ignore[assignment]
     data: dict[str, object] = {
         "candidate_id": "candidate",
-        "start": 1.0,
-        "end": 2.0,
-        "transcript_excerpt": "A complete thought.",
+        "start": start,
+        "end": end,
+        "transcript_excerpt": excerpt,
         "suggested_title": "Title",
         "suggested_hook": "Hook",
         "rationale": "Complete thought",
         "confidence": 0.8,
-        "dedup_key": "0123456789abcdef",
+        "dedup_key": canonical_dedup_key(
+            start=start,
+            end=end,
+            excerpt=excerpt,
+            sensitivity=sensitivity,  # type: ignore[arg-type]
+        ),
     }
     data.update(updates)
     return CandidateMoment.model_validate(data)
 
 
-def test_candidate_requires_safe_unsuitable_state() -> None:
+# --- Existing six behaviours ------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "build",
+    [
+        lambda: TranscriptSegment(segment_id="s", start=1, end=1, text="x"),
+        lambda: TranscriptWord(word="x", start=2, end=1, segment_id="s"),
+    ],
+)
+def test_transcript_ranges_are_strict(build) -> None:
     with pytest.raises(ValidationError):
-        _candidate(unsuitable=True, sensitivity="strong")
-    assert _candidate(unsuitable=True, sensitivity="unsafe").unsuitable is True
+        build()
+
+
+@pytest.mark.parametrize(
+    "build",
+    [
+        lambda: TranscriptWord(word="x", start=0, end=1, segment_id="s", probability=1.1),
+        lambda: SourceSignal(kind="scene_change", timestamp=0, score=0.5, unknown=True),
+    ],
+)
+def test_probabilities_and_unknown_fields_fail_closed(build) -> None:
+    with pytest.raises(ValidationError):
+        build()
+
+
+@pytest.mark.parametrize(
+    "kwargs,expect_ok",
+    [
+        ({"unsuitable": True, "sensitivity": "strong"}, False),
+        ({"unsuitable": True, "sensitivity": "unsafe"}, True),
+    ],
+)
+def test_candidate_requires_safe_unsuitable_state(kwargs, expect_ok) -> None:
+    if expect_ok:
+        assert _candidate(**kwargs).unsuitable is True
+    else:
+        with pytest.raises(ValidationError):
+            _candidate(**kwargs)
 
 
 def test_candidate_is_frozen_and_json_stable() -> None:
@@ -56,10 +95,19 @@ def test_candidate_is_frozen_and_json_stable() -> None:
     assert CandidateMoment.model_validate_json(candidate.model_dump_json()) == candidate
 
 
-def test_discovery_config_bounds_are_coherent() -> None:
-    assert HighlightDiscoveryConfig(max_clips=2).min_clips == 2
-    with pytest.raises(ValidationError):
-        HighlightDiscoveryConfig(min_clips=3, max_clips=2)
+@pytest.mark.parametrize(
+    "kwargs,expect_ok",
+    [
+        ({"max_clips": 2}, True),
+        ({"min_clips": 3, "max_clips": 2}, False),
+    ],
+)
+def test_discovery_config_bounds_are_coherent(kwargs, expect_ok) -> None:
+    if expect_ok:
+        assert HighlightDiscoveryConfig(**kwargs).min_clips == kwargs.get("max_clips", 3)
+    else:
+        with pytest.raises(ValidationError):
+            HighlightDiscoveryConfig(**kwargs)
 
 
 def test_dedup_key_is_semantic_and_stable() -> None:
@@ -67,3 +115,32 @@ def test_dedup_key_is_semantic_and_stable() -> None:
     second = canonical_dedup_key(start=1, end=2, excerpt="hello world", sensitivity="none")
     assert first == second
     assert len(first) == 16
+
+
+# --- New findings ------------------------------------------------------------
+
+
+def test_candidate_rejects_mismatched_dedup_key() -> None:
+    with pytest.raises(ValidationError, match="dedup_key does not match"):
+        _candidate(dedup_key="0123456789abcdef")
+
+
+def test_candidate_accepts_pinned_known_digest() -> None:
+    excerpt = "A complete thought."
+    digest = canonical_dedup_key(start=1.0, end=2.0, excerpt=excerpt, sensitivity="none")
+    assert _candidate(transcript_excerpt=excerpt, dedup_key=digest).dedup_key == digest
+
+
+@pytest.mark.parametrize("value", [math.inf, -math.inf, math.nan])
+def test_candidate_rejects_non_finite_numeric(value: float) -> None:
+    with pytest.raises(ValidationError):
+        _candidate(confidence=value)
+
+
+@pytest.mark.parametrize(
+    "min_dur,max_dur",
+    [(10.0, 10.0), (20.0, 10.0)],
+)
+def test_discovery_config_rejects_max_le_min(min_dur: float, max_dur: float) -> None:
+    with pytest.raises(ValidationError, match="max_duration"):
+        HighlightDiscoveryConfig(min_duration=min_dur, max_duration=max_dur)


### PR DESCRIPTION
Part of #401 and stacked on #408. Extracted from review umbrella #400.

## Scope

- strict transcript segment and word models
- optional scene/audio evidence signals
- immutable candidate moments with sensitivity/unsuitable invariants
- bounded discovery configuration/result envelope
- stable semantic duplicate keys

No discovery heuristics, transcription runtime, rendering, packaging, posting, or authentication.

## Verification

- focused: 6 passed
- full repository: 4349 passed, 172 skipped
- Ruff check/format: passed
- import smoke test: passed
- `git diff --check`: passed

Changed lines against stacked base: 387, within policy.

Draft pending GLM 5.2 adversarial review before merge.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/kinocut/pr/409"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787351362&installation_model_id=20207&pr_number=409&repository=KyaniteLabs%2Fkinocut&return_to=https%3A%2F%2Fgithub.com%2FKyaniteLabs%2Fkinocut%2Fpull%2F409&signature=348841c974437bd26290aaa8e9fb54ce0dee2c9f7d6e112df820b03287a70e5b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->