### PR TITLE
feat: establish long-form transcription boundaries

### DIFF
--- a/kinocut/ai_engine/_longform_models.py
+++ b/kinocut/ai_engine/_longform_models.py
@@ -1,0 +1,115 @@
+"""Strict pydantic models for the long-form transcription path (PR1).
+
+Subclass :class:`kinocut.contracts._common.ValueObject` so each model
+inherits ``extra="forbid"``, ``frozen=True``, and ``allow_inf_nan=False``.
+Field-level bounds come from pydantic ``Field``; cross-field invariants
+come from ``model_validator(mode="after")``.
+"""
+
+from __future__ import annotations
+
+from pydantic import Field, model_validator
+
+from ..contracts._common import ValueObject
+
+
+class LongformChunk(ValueObject):
+    """One planned chunk. ``duration`` may exceed ``end - start`` (overlap tail)."""
+
+    index: int = Field(ge=0)
+    start: float = Field(ge=0.0)
+    end: float = Field(ge=0.0)
+    duration: float = Field(gt=0.0)
+    anchor: str = "fixed"  # one of: "fixed", "scene"
+
+    @model_validator(mode="after")
+    def _chunk_invariants(self) -> LongformChunk:
+        if self.end <= self.start:
+            raise ValueError(f"LongformChunk end ({self.end}) must be greater than start ({self.start})")
+        covered = self.end - self.start
+        if self.duration + 1e-9 < covered:
+            raise ValueError(f"LongformChunk duration ({self.duration}) must cover end - start ({covered})")
+        return self
+
+
+class LongformWord(ValueObject):
+    """One word with globally remapped timestamps (seconds, source-time)."""
+
+    word: str = Field(min_length=1)
+    start: float = Field(ge=0.0)
+    end: float = Field(ge=0.0)
+    chunk_index: int = Field(ge=0)
+    probability: float | None = Field(default=None, ge=0.0, le=1.0)
+
+    @model_validator(mode="after")
+    def _word_has_positive_width(self) -> LongformWord:
+        if self.end <= self.start:
+            raise ValueError(f"LongformWord end ({self.end}) must be greater than start ({self.start})")
+        return self
+
+
+class LongformSegment(ValueObject):
+    """One transcript segment, globally remapped and dedup-overlapped."""
+
+    start: float = Field(ge=0.0)
+    end: float = Field(ge=0.0)
+    text: str = Field(min_length=1)
+    chunk_index: int = Field(ge=0)
+    avg_logprob: float | None = Field(default=None, le=0.0)
+    no_speech_prob: float | None = Field(default=None, ge=0.0, le=1.0)
+
+    @model_validator(mode="after")
+    def _segment_has_positive_width(self) -> LongformSegment:
+        if self.end <= self.start:
+            raise ValueError(f"LongformSegment end ({self.end}) must be greater than start ({self.start})")
+        return self
+
+
+class LongformTranscribePlan(ValueObject):
+    """Deterministic plan returned by the planner."""
+
+    video_path: str = Field(min_length=1)
+    duration: float = Field(ge=0.0)
+    chunk_seconds: int = Field(gt=0)
+    overlap_seconds: int = Field(ge=0)
+    chunks: list[LongformChunk]
+
+    @model_validator(mode="after")
+    def _overlap_strictly_smaller_than_chunk(self) -> LongformTranscribePlan:
+        if self.overlap_seconds >= self.chunk_seconds:
+            raise ValueError(
+                f"overlap_seconds ({self.overlap_seconds}) must be strictly smaller "
+                f"than chunk_seconds ({self.chunk_seconds})"
+            )
+        return self
+
+
+class LongformTranscribeResult(ValueObject):
+    """Strict-model result of a long-form transcription run."""
+
+    video_path: str = Field(min_length=1)
+    duration: float = Field(ge=0.0)
+    language: str = Field(min_length=1)
+    transcript: str
+    segments: list[LongformSegment]
+    words: list[LongformWord]
+    chunk_count: int = Field(ge=0)
+    model: str = Field(min_length=1)
+    plan: LongformTranscribePlan
+
+    @model_validator(mode="after")
+    def _chunk_count_and_duration_match_plan(self) -> LongformTranscribeResult:
+        if self.chunk_count != len(self.plan.chunks):
+            raise ValueError(f"chunk_count ({self.chunk_count}) must equal len(plan.chunks) ({len(self.plan.chunks)})")
+        if self.duration != self.plan.duration:
+            raise ValueError(f"duration ({self.duration}) must equal plan.duration ({self.plan.duration})")
+        return self
+
+
+__all__ = [
+    "LongformChunk",
+    "LongformSegment",
+    "LongformTranscribePlan",
+    "LongformTranscribeResult",
+    "LongformWord",
+]

--- a/kinocut/ai_engine/_longform_models.py
+++ b/kinocut/ai_engine/_longform_models.py
@@ -7,6 +7,7 @@ come from ``model_validator(mode="after")``.
 """
 
 from __future__ import annotations
+from typing import Literal
 
 from pydantic import Field, model_validator
 
@@ -14,21 +15,21 @@ from ..contracts._common import ValueObject
 
 
 class LongformChunk(ValueObject):
-    """One planned chunk. ``duration`` may exceed ``end - start`` (overlap tail)."""
+    """One fixed or scene-anchored source-time chunk."""
 
     index: int = Field(ge=0)
     start: float = Field(ge=0.0)
     end: float = Field(ge=0.0)
     duration: float = Field(gt=0.0)
-    anchor: str = "fixed"  # one of: "fixed", "scene"
+    anchor: Literal["fixed", "scene"] = "fixed"
 
     @model_validator(mode="after")
     def _chunk_invariants(self) -> LongformChunk:
         if self.end <= self.start:
             raise ValueError(f"LongformChunk end ({self.end}) must be greater than start ({self.start})")
         covered = self.end - self.start
-        if self.duration + 1e-9 < covered:
-            raise ValueError(f"LongformChunk duration ({self.duration}) must cover end - start ({covered})")
+        if abs(self.duration - covered) > 1e-9:
+            raise ValueError(f"LongformChunk duration ({self.duration}) must equal end - start ({covered})")
         return self
 
 
@@ -69,10 +70,10 @@ class LongformTranscribePlan(ValueObject):
     """Deterministic plan returned by the planner."""
 
     video_path: str = Field(min_length=1)
-    duration: float = Field(ge=0.0)
+    duration: float = Field(gt=0.0)
     chunk_seconds: int = Field(gt=0)
     overlap_seconds: int = Field(ge=0)
-    chunks: list[LongformChunk]
+    chunks: tuple[LongformChunk, ...]
 
     @model_validator(mode="after")
     def _overlap_strictly_smaller_than_chunk(self) -> LongformTranscribePlan:
@@ -88,11 +89,11 @@ class LongformTranscribeResult(ValueObject):
     """Strict-model result of a long-form transcription run."""
 
     video_path: str = Field(min_length=1)
-    duration: float = Field(ge=0.0)
+    duration: float = Field(gt=0.0)
     language: str = Field(min_length=1)
     transcript: str
-    segments: list[LongformSegment]
-    words: list[LongformWord]
+    segments: tuple[LongformSegment, ...]
+    words: tuple[LongformWord, ...]
     chunk_count: int = Field(ge=0)
     model: str = Field(min_length=1)
     plan: LongformTranscribePlan

--- a/kinocut/ai_engine/_longform_validation.py
+++ b/kinocut/ai_engine/_longform_validation.py
@@ -1,0 +1,94 @@
+"""Path and parameter validation for the long-form transcription path.
+
+The long-form path is the ONLY way to transcribe media up to
+``MAX_VIDEO_DURATION``; ordinary ``ai_transcribe`` keeps its 3600s ceiling.
+"""
+
+from __future__ import annotations
+
+from ..errors import InputFileError, MCPVideoError
+from ..ffmpeg_helpers import _get_video_duration, _validate_input_path
+from ..limits import (
+    LONGFORM_TRANSCRIBE_OVERLAP_SECONDS,
+    MAX_LONGFORM_TRANSCRIBE_CHUNK_SECONDS,
+    MAX_LONGFORM_TRANSCRIBE_CHUNKS,
+    MAX_VIDEO_DURATION,
+    MIN_LONGFORM_TRANSCRIBE_CHUNK_SECONDS,
+)
+
+
+def _validate_longform_path(video: str) -> str:
+    """Validate long-form path. Raises InputFileError on null bytes /
+    unreadable input, MCPVideoError ``invalid_input`` for non-positive
+    duration, and MCPVideoError ``duration_too_long`` for >MAX_VIDEO_DURATION."""
+    if "\x00" in video:
+        raise InputFileError(video, "Invalid path: contains null bytes")
+    _validate_input_path(video)
+    duration = _get_video_duration(video)
+    if duration <= 0:
+        raise MCPVideoError(
+            f"Could not determine positive duration for {video!r}",
+            error_type="validation_error",
+            code="invalid_input",
+        )
+    if duration > MAX_VIDEO_DURATION:
+        raise MCPVideoError(
+            f"Video duration ({duration:.0f}s) exceeds long-form cap of {MAX_VIDEO_DURATION}s",
+            error_type="validation_error",
+            code="duration_too_long",
+        )
+    return video
+
+
+def _validate_chunk_seconds(chunk_seconds: int) -> int:
+    """Validate chunk-window size. Codes: ``invalid_parameter``,
+    ``chunk_too_large``, ``chunk_too_small`` (in that order)."""
+    if not isinstance(chunk_seconds, int) or isinstance(chunk_seconds, bool) or chunk_seconds <= 0:
+        raise MCPVideoError(
+            f"chunk_seconds must be a positive int, got {chunk_seconds!r}",
+            error_type="validation_error",
+            code="invalid_parameter",
+        )
+    if chunk_seconds > MAX_LONGFORM_TRANSCRIBE_CHUNK_SECONDS:
+        raise MCPVideoError(
+            f"chunk_seconds ({chunk_seconds}) exceeds cap of {MAX_LONGFORM_TRANSCRIBE_CHUNK_SECONDS}",
+            error_type="validation_error",
+            code="chunk_too_large",
+        )
+    if chunk_seconds < MIN_LONGFORM_TRANSCRIBE_CHUNK_SECONDS:
+        raise MCPVideoError(
+            f"chunk_seconds ({chunk_seconds}) below minimum of {MIN_LONGFORM_TRANSCRIBE_CHUNK_SECONDS}",
+            error_type="validation_error",
+            code="chunk_too_small",
+        )
+    return chunk_seconds
+
+
+def _validate_overlap_seconds(overlap_seconds: int, chunk_seconds: int) -> int:
+    """Validate overlap-window size. Codes: ``invalid_parameter``,
+    ``invalid_overlap`` (in that order)."""
+    if not isinstance(overlap_seconds, int) or isinstance(overlap_seconds, bool) or overlap_seconds < 0:
+        raise MCPVideoError(
+            f"overlap_seconds must be a non-negative int, got {overlap_seconds!r}",
+            error_type="validation_error",
+            code="invalid_parameter",
+        )
+    if overlap_seconds >= chunk_seconds:
+        raise MCPVideoError(
+            f"overlap_seconds ({overlap_seconds}) must be smaller than chunk_seconds ({chunk_seconds})",
+            error_type="validation_error",
+            code="invalid_overlap",
+        )
+    return overlap_seconds
+
+
+__all__ = [
+    "LONGFORM_TRANSCRIBE_OVERLAP_SECONDS",
+    "MAX_LONGFORM_TRANSCRIBE_CHUNKS",
+    "MAX_LONGFORM_TRANSCRIBE_CHUNK_SECONDS",
+    "MAX_VIDEO_DURATION",
+    "MIN_LONGFORM_TRANSCRIBE_CHUNK_SECONDS",
+    "_validate_chunk_seconds",
+    "_validate_longform_path",
+    "_validate_overlap_seconds",
+]

--- a/kinocut/limits.py
+++ b/kinocut/limits.py
@@ -27,6 +27,15 @@ MAX_WAVE3_VERDICT_IDS = 64
 MAX_WAVE3_AUTH_DECISION_IDS = 64
 MAX_ACCEPTANCE_EVIDENCE_FILES = 64
 
+# Long-form transcription chunking (per-chunk cap and overlap for the
+# reusable long-form stream-to-shorts workflow). These are independent of
+# MAX_AI_TRANSCRIBE_DURATION: ordinary ai_transcribe still rejects >3600s,
+# while transcribe_longform permits media up to MAX_VIDEO_DURATION.
+MAX_LONGFORM_TRANSCRIBE_CHUNK_SECONDS = 1500  # 25 minutes per chunk
+LONGFORM_TRANSCRIBE_OVERLAP_SECONDS = 15  # tail-overlap for word dedup
+MIN_LONGFORM_TRANSCRIBE_CHUNK_SECONDS = 30  # refuse sub-30s windows
+MAX_LONGFORM_TRANSCRIBE_CHUNKS = 64  # upper bound on plan size
+
 # Audio limits
 MAX_AUDIO_DURATION = 3600  # 1 hour
 MAX_AI_TRANSCRIBE_DURATION = MAX_AUDIO_DURATION

--- a/tests/test_longform_foundation.py
+++ b/tests/test_longform_foundation.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from kinocut.ai_engine import _longform_validation as validation
+from kinocut.ai_engine._longform_models import (
+    LongformChunk,
+    LongformSegment,
+    LongformTranscribePlan,
+    LongformTranscribeResult,
+    LongformWord,
+)
+from kinocut.ai_engine._longform_validation import (
+    _validate_chunk_seconds,
+    _validate_longform_path,
+    _validate_overlap_seconds,
+)
+from kinocut.errors import InputFileError, MCPVideoError
+from kinocut.limits import (
+    LONGFORM_TRANSCRIBE_OVERLAP_SECONDS,
+    MAX_LONGFORM_TRANSCRIBE_CHUNK_SECONDS,
+    MAX_LONGFORM_TRANSCRIBE_CHUNKS,
+    MAX_VIDEO_DURATION,
+    MIN_LONGFORM_TRANSCRIBE_CHUNK_SECONDS,
+)
+
+
+def _chunk() -> LongformChunk:
+    return LongformChunk(index=0, start=0, end=60, duration=60)
+
+
+def _plan() -> LongformTranscribePlan:
+    return LongformTranscribePlan(
+        video_path="source.mp4",
+        duration=60,
+        chunk_seconds=60,
+        overlap_seconds=5,
+        chunks=[_chunk()],
+    )
+
+
+def _result() -> LongformTranscribeResult:
+    return LongformTranscribeResult(
+        video_path="source.mp4",
+        duration=60,
+        language="en",
+        transcript="hello",
+        segments=[LongformSegment(start=0, end=1, text="hello", chunk_index=0)],
+        words=[LongformWord(word="hello", start=0, end=1, chunk_index=0, probability=0.8)],
+        chunk_count=1,
+        model="base",
+        plan=_plan(),
+    )
+
+
+def test_longform_policy_constants_are_bounded() -> None:
+    assert MAX_VIDEO_DURATION == 14_400
+    assert MIN_LONGFORM_TRANSCRIBE_CHUNK_SECONDS == 30
+    assert MAX_LONGFORM_TRANSCRIBE_CHUNK_SECONDS == 1_500
+    assert LONGFORM_TRANSCRIBE_OVERLAP_SECONDS == 15
+    assert MAX_LONGFORM_TRANSCRIBE_CHUNKS == 64
+
+
+@pytest.mark.parametrize("factory", [_chunk, _plan, _result])
+def test_models_are_strict_frozen_and_json_stable(factory) -> None:
+    value = factory()
+    assert type(value).model_validate_json(value.model_dump_json()) == value
+    with pytest.raises(ValidationError):
+        value.model_copy(update={"unknown": True}).model_validate({**value.model_dump(), "unknown": True})
+    with pytest.raises(ValidationError):
+        setattr(value, next(iter(type(value).model_fields)), "changed")
+
+
+@pytest.mark.parametrize(
+    "constructor,kwargs",
+    [
+        (LongformChunk, {"index": 0, "start": 1, "end": 1, "duration": 1}),
+        (LongformChunk, {"index": 0, "start": 0, "end": 2, "duration": 1}),
+        (LongformWord, {"word": "x", "start": 1, "end": 1, "chunk_index": 0}),
+        (LongformSegment, {"start": 2, "end": 1, "text": "x", "chunk_index": 0}),
+        (
+            LongformTranscribePlan,
+            {
+                "video_path": "x",
+                "duration": 1,
+                "chunk_seconds": 30,
+                "overlap_seconds": 30,
+                "chunks": [],
+            },
+        ),
+    ],
+)
+def test_models_reject_invalid_ranges(constructor, kwargs) -> None:
+    with pytest.raises(ValidationError):
+        constructor(**kwargs)
+
+
+def test_result_must_match_plan_lineage() -> None:
+    payload = _result().model_dump()
+    payload["chunk_count"] = 0
+    with pytest.raises(ValidationError, match="chunk_count"):
+        LongformTranscribeResult.model_validate(payload)
+    payload = _result().model_dump()
+    payload["duration"] = 59
+    with pytest.raises(ValidationError, match=r"plan\.duration"):
+        LongformTranscribeResult.model_validate(payload)
+
+
+@pytest.mark.parametrize(
+    "value,code",
+    [
+        (0, "invalid_parameter"),
+        (True, "invalid_parameter"),
+        (MIN_LONGFORM_TRANSCRIBE_CHUNK_SECONDS - 1, "chunk_too_small"),
+        (MAX_LONGFORM_TRANSCRIBE_CHUNK_SECONDS + 1, "chunk_too_large"),
+    ],
+)
+def test_chunk_validation_rejects_invalid_values(value, code) -> None:
+    with pytest.raises(MCPVideoError) as exc:
+        _validate_chunk_seconds(value)
+    assert exc.value.code == code
+
+
+@pytest.mark.parametrize(
+    "overlap,chunk,code", [(-1, 60, "invalid_parameter"), (True, 60, "invalid_parameter"), (60, 60, "invalid_overlap")]
+)
+def test_overlap_validation_rejects_invalid_values(overlap, chunk, code) -> None:
+    with pytest.raises(MCPVideoError) as exc:
+        _validate_overlap_seconds(overlap, chunk)
+    assert exc.value.code == code
+
+
+def test_parameter_validation_accepts_policy_edges() -> None:
+    assert _validate_chunk_seconds(MIN_LONGFORM_TRANSCRIBE_CHUNK_SECONDS) == 30
+    assert _validate_overlap_seconds(0, 30) == 0
+
+
+def test_longform_path_rejects_null_byte() -> None:
+    with pytest.raises(InputFileError):
+        _validate_longform_path("bad\x00path.mp4")
+
+
+@pytest.mark.parametrize("duration,code", [(0, "invalid_input"), (MAX_VIDEO_DURATION + 1, "duration_too_long")])
+def test_longform_path_rejects_invalid_duration(monkeypatch, duration, code) -> None:
+    monkeypatch.setattr(validation, "_validate_input_path", lambda path: path)
+    monkeypatch.setattr(validation, "_get_video_duration", lambda path: duration)
+    with pytest.raises(MCPVideoError) as exc:
+        _validate_longform_path("source.mp4")
+    assert exc.value.code == code
+
+
+def test_longform_path_accepts_over_legacy_ceiling(monkeypatch) -> None:
+    monkeypatch.setattr(validation, "_validate_input_path", lambda path: path)
+    monkeypatch.setattr(validation, "_get_video_duration", lambda path: 3_601)
+    assert _validate_longform_path("source.mp4") == "source.mp4"

--- a/tests/test_longform_foundation.py
+++ b/tests/test_longform_foundation.py
@@ -66,6 +66,9 @@ def test_longform_policy_constants_are_bounded() -> None:
 def test_models_are_strict_frozen_and_json_stable(factory) -> None:
     value = factory()
     assert type(value).model_validate_json(value.model_dump_json()) == value
+    for field in ("chunks", "segments", "words"):
+        if hasattr(value, field):
+            assert isinstance(getattr(value, field), tuple)
     with pytest.raises(ValidationError):
         value.model_copy(update={"unknown": True}).model_validate({**value.model_dump(), "unknown": True})
     with pytest.raises(ValidationError):


### PR DESCRIPTION
Progresses #402.

Adds the first dependency-safe chunked-transcription slice:
- bounded long-form chunk/overlap policy constants without changing the legacy 3600s transcription ceiling
- strict immutable plan/result/chunk/segment/word contracts
- actionable long-form path and parameter validation through the 4-hour media cap
- focused model, policy, and unhappy-path tests

Stacked on #410 (`feat/401-shorts-config`). Final diff: 374 additions across four files. Focused dependency verification: 69 passed; Ruff and diff checks pass.

Draft pending GLM 5.2 ULTRACODE adversarial review and exact-head hosted CI. Umbrella #400 remains review-only and must not merge.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/kinocut/pr/411"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787364581&installation_model_id=20207&pr_number=411&repository=KyaniteLabs%2Fkinocut&return_to=https%3A%2F%2Fgithub.com%2FKyaniteLabs%2Fkinocut%2Fpull%2F411&signature=4d10ce6cc5148dfa93ae35915376ffbaff2ff5e03fdf7c39e29715357005a429"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->