### PR TITLE
feat: plan complete long-form transcription coverage

### DIFF
--- a/kinocut/ai_engine/_longform_planning.py
+++ b/kinocut/ai_engine/_longform_planning.py
@@ -1,0 +1,163 @@
+"""Long-form chunk planning: scene-anchor discovery, deterministic chunk
+emission over ``[0, duration]`` with overlap, and JSON-stable replay.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from ..errors import MCPVideoError
+from ..ffmpeg_helpers import _get_video_duration
+from ..limits import (
+    LONGFORM_TRANSCRIBE_OVERLAP_SECONDS,
+    MAX_LONGFORM_TRANSCRIBE_CHUNK_SECONDS,
+    MAX_LONGFORM_TRANSCRIBE_CHUNKS,
+    MIN_LONGFORM_TRANSCRIBE_CHUNK_SECONDS,
+)
+from ._longform_models import LongformChunk, LongformTranscribePlan
+from ._longform_validation import (
+    _validate_chunk_seconds,
+    _validate_longform_path,
+    _validate_overlap_seconds,
+)
+from .scene import ai_scene_detect
+
+logger = logging.getLogger(__name__)
+
+
+def _scene_anchors(
+    video: str,
+    duration: float,
+    chunk_seconds: int,
+    overlap_seconds: int,
+) -> list[float]:
+    """Return sorted scene anchor timestamps, or ``[]`` when unavailable.
+
+    Best-effort: any failure degrades to ``[]`` so the planner falls
+    back to a fixed walk.  Anchors are clamped to the body so they
+    never create zero-width chunk boundaries.
+    """
+    try:
+        raw = ai_scene_detect(video, threshold=0.3, use_ai=False)
+    except Exception as exc:
+        logger.debug("scene detection failed for long-form plan: %s", exc)
+        return []
+    if not raw:
+        return []
+    low = float(overlap_seconds)
+    high = float(duration) - float(overlap_seconds)
+    if high <= low:
+        return []
+    anchors: set[float] = set()
+    for entry in raw:
+        try:
+            ts = float(entry.get("timestamp", 0.0) or 0.0)
+        except (TypeError, ValueError):
+            continue
+        if low < ts < high:
+            anchors.add(round(ts, 6))
+    return sorted(anchors)
+
+
+def _build_plan(
+    video: str,
+    duration: float,
+    chunk_seconds: int,
+    overlap_seconds: int,
+    *,
+    anchors: list[float] | None = None,
+) -> LongformTranscribePlan:
+    """Build an overlapping, gap-free plan over ``[0, duration]``.
+
+    A nearby scene anchor may replace a nominal chunk end, but never beyond the
+    configured size cap. The next chunk starts from that end minus overlap.
+    """
+    total = float(duration)
+    cs = float(chunk_seconds)
+    overlap = float(overlap_seconds)
+    anchor_points = sorted({round(float(a), 6) for a in (anchors or [])})
+
+    chunks: list[LongformChunk] = []
+    cursor = 0.0
+    idx = 0
+    while cursor < total:
+        nominal_end = min(total, cursor + cs)
+        end = nominal_end
+        anchor_kind = "fixed"
+        if nominal_end < total:
+            eligible = [
+                anchor
+                for anchor in anchor_points
+                if cursor + MIN_LONGFORM_TRANSCRIBE_CHUNK_SECONDS <= anchor <= nominal_end
+                and nominal_end - anchor <= cs / 2.0
+            ]
+            if eligible:
+                end = min(eligible, key=lambda anchor: (abs(nominal_end - anchor), anchor))
+                anchor_kind = "scene"
+        chunks.append(
+            LongformChunk(
+                index=idx,
+                start=float(cursor),
+                end=float(end),
+                duration=end - cursor,
+                anchor=anchor_kind,
+            )
+        )
+        idx += 1
+        if end >= total:
+            break
+        cursor = end - overlap
+
+    if len(chunks) > MAX_LONGFORM_TRANSCRIBE_CHUNKS:
+        raise MCPVideoError(
+            f"Plan has {len(chunks)} chunks, exceeds cap of {MAX_LONGFORM_TRANSCRIBE_CHUNKS}",
+            error_type="validation_error",
+            code="too_many_chunks",
+        )
+
+    return LongformTranscribePlan(
+        video_path=video,
+        duration=float(duration),
+        chunk_seconds=chunk_seconds,
+        overlap_seconds=overlap_seconds,
+        chunks=chunks,
+    )
+
+
+def plan_longform_transcription(
+    video: str,
+    *,
+    chunk_seconds: int = MAX_LONGFORM_TRANSCRIBE_CHUNK_SECONDS,
+    overlap_seconds: int = LONGFORM_TRANSCRIBE_OVERLAP_SECONDS,
+    scene_aware: bool = True,
+) -> LongformTranscribePlan:
+    """Plan a long-form transcription without invoking Whisper.
+
+    Validates path + parameters before any probe / scene work runs.
+    Scene detection is best-effort: failure or empty results yield a
+    fixed walk with ``anchor="fixed"`` on every chunk.
+    """
+    chunk_seconds = _validate_chunk_seconds(chunk_seconds)
+    overlap_seconds = _validate_overlap_seconds(overlap_seconds, chunk_seconds)
+    video = _validate_longform_path(video)
+    duration = _get_video_duration(video)
+    anchors: list[float] = []
+    if scene_aware and duration > chunk_seconds:
+        anchors = _scene_anchors(video, duration, chunk_seconds, overlap_seconds)
+    return _build_plan(
+        video,
+        duration,
+        chunk_seconds,
+        overlap_seconds,
+        anchors=anchors,
+    )
+
+
+__all__ = [
+    "LONGFORM_TRANSCRIBE_OVERLAP_SECONDS",
+    "MAX_LONGFORM_TRANSCRIBE_CHUNKS",
+    "MAX_LONGFORM_TRANSCRIBE_CHUNK_SECONDS",
+    "_build_plan",
+    "_scene_anchors",
+    "plan_longform_transcription",
+]

--- a/kinocut/ai_engine/_longform_planning.py
+++ b/kinocut/ai_engine/_longform_planning.py
@@ -94,6 +94,13 @@ def _build_plan(
             if eligible:
                 end = min(eligible, key=lambda anchor: (abs(nominal_end - anchor), anchor))
                 anchor_kind = "scene"
+        if end < total and end - overlap <= cursor:
+            raise MCPVideoError(
+                "overlap_seconds is too large for the selected scene boundary; "
+                "reduce overlap_seconds or disable scene-aware planning",
+                error_type="validation_error",
+                code="invalid_overlap",
+            )
         chunks.append(
             LongformChunk(
                 index=idx,

--- a/tests/test_longform_planning.py
+++ b/tests/test_longform_planning.py
@@ -1,0 +1,204 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from kinocut.ai_engine._longform_models import LongformTranscribePlan
+from kinocut.ai_engine._longform_planning import (
+    _build_plan,
+    _scene_anchors,
+    plan_longform_transcription,
+)
+from kinocut.errors import MCPVideoError
+from kinocut.limits import (
+    LONGFORM_TRANSCRIBE_OVERLAP_SECONDS,
+    MAX_LONGFORM_TRANSCRIBE_CHUNK_SECONDS,
+    MAX_LONGFORM_TRANSCRIBE_CHUNKS,
+    MAX_VIDEO_DURATION,
+    MIN_LONGFORM_TRANSCRIBE_CHUNK_SECONDS,
+)
+
+_PLANNING = "kinocut.ai_engine._longform_planning"
+
+
+def _stub_probe(monkeypatch, duration: float) -> None:
+    monkeypatch.setattr(f"{_PLANNING}._get_video_duration", lambda _path: float(duration))
+    monkeypatch.setattr(f"{_PLANNING}._validate_longform_path", lambda video: video)
+
+
+def _stub_scene(monkeypatch, anchors: list[float] | None) -> None:
+    if anchors is None:
+
+        def _boom(*_a: Any, **_kw: Any) -> list[float]:
+            raise RuntimeError("scene detector unavailable")
+
+        monkeypatch.setattr(f"{_PLANNING}.ai_scene_detect", _boom)
+        return
+    monkeypatch.setattr(f"{_PLANNING}._scene_anchors", lambda *_a, **_kw: list(anchors))
+
+
+@pytest.mark.parametrize(
+    "duration,chunk_seconds,overlap_seconds",
+    [
+        (MAX_VIDEO_DURATION, MAX_LONGFORM_TRANSCRIBE_CHUNK_SECONDS, LONGFORM_TRANSCRIBE_OVERLAP_SECONDS),
+        (3600.0, 600, 10),
+        (9000.0, 1200, 15),
+    ],
+)
+def test_plan_caps_at_max_video_duration(monkeypatch, duration, chunk_seconds, overlap_seconds) -> None:
+    _stub_probe(monkeypatch, duration)
+    _stub_scene(monkeypatch, [])
+    plan = plan_longform_transcription(
+        "/tmp/_any.mp4",
+        chunk_seconds=chunk_seconds,
+        overlap_seconds=overlap_seconds,
+        scene_aware=False,
+    )
+    assert isinstance(plan, LongformTranscribePlan)
+    assert plan.duration == float(duration)
+    assert plan.chunks[0].start == 0.0
+    assert plan.chunks[-1].end == float(duration)
+    assert plan.chunks
+
+
+@pytest.mark.parametrize(
+    "duration,chunk_seconds,overlap_seconds",
+    [(3600.0, 600, 10), (7200.0, 1500, 15), (1200.0, 600, 30), (1800.0, 800, 25)],
+)
+def test_plan_covers_full_duration_with_overlap_no_gaps(monkeypatch, duration, chunk_seconds, overlap_seconds) -> None:
+    _stub_probe(monkeypatch, duration)
+    _stub_scene(monkeypatch, [])
+    plan = plan_longform_transcription(
+        "/tmp/_any.mp4",
+        chunk_seconds=chunk_seconds,
+        overlap_seconds=overlap_seconds,
+        scene_aware=False,
+    )
+    prev_end = 0.0
+    for chunk in plan.chunks:
+        assert chunk.end > chunk.start
+        assert chunk.duration <= chunk_seconds + 1e-9
+        if prev_end > 0:
+            assert chunk.start <= prev_end, "gap between chunks"
+            assert prev_end - chunk.start <= float(overlap_seconds) + 1e-9
+        prev_end = chunk.end
+    assert prev_end == pytest.approx(float(duration))
+
+
+def test_plan_chunk_count_within_bound(monkeypatch) -> None:
+    _stub_probe(monkeypatch, float(MAX_VIDEO_DURATION))
+    _stub_scene(monkeypatch, [])
+    plan = plan_longform_transcription(
+        "/tmp/_any.mp4",
+        chunk_seconds=300,
+        overlap_seconds=15,
+        scene_aware=False,
+    )
+    assert 1 <= len(plan.chunks) <= MAX_LONGFORM_TRANSCRIBE_CHUNKS
+
+
+@pytest.mark.parametrize(
+    "duration,chunk_seconds,overlap_seconds",
+    [(4500.0, 900, 15), (1800.0, 600, 10), (3000.0, 1200, 30)],
+)
+def test_plan_is_deterministic_and_json_stable(monkeypatch, duration, chunk_seconds, overlap_seconds) -> None:
+    _stub_probe(monkeypatch, duration)
+    _stub_scene(monkeypatch, [])
+    kwargs = dict(chunk_seconds=chunk_seconds, overlap_seconds=overlap_seconds, scene_aware=False)
+    first = plan_longform_transcription("/tmp/_any.mp4", **kwargs)
+    second = plan_longform_transcription("/tmp/_any.mp4", **kwargs)
+    assert first.model_dump() == second.model_dump()
+    assert LongformTranscribePlan.model_validate_json(first.model_dump_json()) == first
+
+
+def test_fixed_fallback_when_no_scene_anchors(monkeypatch) -> None:
+    _stub_probe(monkeypatch, 1800.0)
+    _stub_scene(monkeypatch, [])
+    plan = plan_longform_transcription(
+        "/tmp/_any.mp4",
+        chunk_seconds=600,
+        overlap_seconds=10,
+        scene_aware=True,
+    )
+    assert all(c.anchor == "fixed" for c in plan.chunks)
+    assert plan.chunks[0].start == 0.0
+    assert plan.chunks[-1].end == 1800.0
+
+
+def test_scene_anchors_preserved_without_gaps(monkeypatch) -> None:
+    """Anchors relabel chunks but never relocate them past the next step."""
+    _stub_probe(monkeypatch, 2400.0)
+    _stub_scene(monkeypatch, [400.0, 1200.0])
+    plan = plan_longform_transcription(
+        "/tmp/_any.mp4",
+        chunk_seconds=600,
+        overlap_seconds=10,
+        scene_aware=True,
+    )
+    assert any(c.anchor == "scene" for c in plan.chunks)
+    assert plan.chunks[0].start == 0.0
+    assert plan.chunks[-1].end == 2400.0
+    for prev, cur in zip(plan.chunks, plan.chunks[1:], strict=False):
+        assert cur.start <= prev.end
+    for chunk in plan.chunks:
+        assert chunk.duration <= 600 + 1e-9
+
+
+def test_scene_anchors_filter_to_body(monkeypatch) -> None:
+    """Out-of-range anchors are dropped; only body anchors participate."""
+    monkeypatch.setattr(f"{_PLANNING}._get_video_duration", lambda _p: 1000.0)
+    monkeypatch.setattr(f"{_PLANNING}._validate_longform_path", lambda v: v)
+    monkeypatch.setattr(
+        f"{_PLANNING}.ai_scene_detect",
+        lambda *_a, **_kw: [
+            {"timestamp": 1.0},
+            {"timestamp": 10.0},
+            {"timestamp": 500.0},
+            {"timestamp": 900.0},
+            {"timestamp": None},
+        ],
+    )
+    plan = plan_longform_transcription(
+        "/tmp/_any.mp4",
+        chunk_seconds=600,
+        overlap_seconds=200,
+        scene_aware=True,
+    )
+    assert plan.chunks[0].start == 0.0
+    assert plan.chunks[-1].end == 1000.0
+
+
+def test_scene_detector_exceptions_degrade_to_fixed(monkeypatch) -> None:
+    """Scene seam blowing up must yield a fixed-only plan (no leak)."""
+    _stub_probe(monkeypatch, 1800.0)
+    _stub_scene(monkeypatch, None)
+    plan = plan_longform_transcription(
+        "/tmp/_any.mp4",
+        chunk_seconds=600,
+        overlap_seconds=10,
+        scene_aware=True,
+    )
+    assert all(c.anchor == "fixed" for c in plan.chunks)
+    assert plan.chunks[0].start == 0.0
+    assert plan.chunks[-1].end == 1800.0
+
+
+def test_build_plan_rejects_too_many_chunks() -> None:
+    with pytest.raises(MCPVideoError) as exc:
+        _build_plan(
+            "/tmp/_any.mp4",
+            duration=float(MAX_VIDEO_DURATION),
+            chunk_seconds=MIN_LONGFORM_TRANSCRIBE_CHUNK_SECONDS,
+            overlap_seconds=1,
+            anchors=None,
+        )
+    assert exc.value.code == "too_many_chunks"
+
+
+def test_scene_anchors_returns_empty_when_detector_fails(monkeypatch) -> None:
+    def _boom(*_a: Any, **_kw: Any) -> list[float]:
+        raise RuntimeError("ffmpeg missing")
+
+    monkeypatch.setattr(f"{_PLANNING}.ai_scene_detect", _boom)
+    assert _scene_anchors("/tmp/x.mp4", 1800.0, 600, 10) == []

--- a/tests/test_longform_planning.py
+++ b/tests/test_longform_planning.py
@@ -184,6 +184,20 @@ def test_scene_detector_exceptions_degrade_to_fixed(monkeypatch) -> None:
     assert plan.chunks[-1].end == 1800.0
 
 
+def test_scene_boundary_rejects_overlap_that_would_stall_cursor() -> None:
+    with pytest.raises(MCPVideoError) as exc:
+        _build_plan(
+            "/tmp/_any.mp4",
+            duration=1200.0,
+            chunk_seconds=600,
+            overlap_seconds=300,
+            anchors=[300.0],
+        )
+
+    assert exc.value.code == "invalid_overlap"
+    assert "reduce overlap_seconds or disable scene-aware planning" in str(exc.value)
+
+
 def test_build_plan_rejects_too_many_chunks() -> None:
     with pytest.raises(MCPVideoError) as exc:
         _build_plan(


### PR DESCRIPTION
Progresses #402; stacked on #411.

Adds deterministic long-form chunk planning:
- validates policy/path before planning
- covers the complete source with bounded overlap and no gaps
- uses nearby scene boundaries without exceeding the chunk cap
- degrades scene failures to fixed planning
- enforces chunk-count bounds and JSON-stable replay

Final stacked diff: 367 additions across two files. Focused foundation/planning verification: 39 passed; Ruff and diff checks pass.

Draft pending GLM 5.2 ULTRACODE review and exact-head hosted CI. #411 remains draft while the GLM endpoint is returning upstream overload errors; neither PR will be marked ready without the required review gate.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/kinocut/pr/412"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787366171&installation_model_id=20207&pr_number=412&repository=KyaniteLabs%2Fkinocut&return_to=https%3A%2F%2Fgithub.com%2FKyaniteLabs%2Fkinocut%2Fpull%2F412&signature=23aa82d260ad5e67697daec366cda4e4fc8972fb4218e899228f6a7cbfc1287a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->