### PR TITLE
feat: transcribe bounded long-form audio chunks

### DIFF
--- a/kinocut/ai_engine/_longform_runtime.py
+++ b/kinocut/ai_engine/_longform_runtime.py
@@ -1,0 +1,68 @@
+"""Per-chunk Whisper execution for long-form transcription."""
+
+from __future__ import annotations
+
+from contextlib import suppress
+import os
+from typing import Any
+
+from ..errors import MCPVideoError
+from ._longform_models import LongformChunk
+from .transcribe import _extract_audio_segment, _format_json_transcript
+
+
+def _format_chunk_result(result_data: dict[str, Any]) -> dict[str, Any]:
+    """Normalize Whisper output while retaining its real word timing entries."""
+    raw_segments = list(result_data.get("segments") or ())
+    formatted = _format_json_transcript(
+        str(result_data.get("text", "")).strip(),
+        raw_segments,
+        str(result_data.get("language", "unknown")),
+    )
+    for normalized, raw in zip(formatted["segments"], raw_segments, strict=True):
+        normalized["words"] = list(raw.get("words") or ())
+    return formatted
+
+
+def _transcribe_chunk(
+    video: str,
+    chunk: LongformChunk,
+    *,
+    model: str,
+    language: str | None,
+    work_dir: str,
+) -> dict[str, Any]:
+    """Extract and locally transcribe one chunk; always remove its temporary WAV."""
+    audio_path: str | None = None
+    try:
+        audio_path = _extract_audio_segment(
+            video,
+            chunk.start,
+            chunk.duration,
+            output_dir=work_dir,
+        )
+        try:
+            import whisper  # type: ignore[import-not-found]
+        except ImportError as exc:
+            raise MCPVideoError(
+                'Whisper not installed. Install with: pip install "mcp-video[transcribe]"',
+                error_type="dependency_error",
+                code="missing_whisper",
+                suggested_action={
+                    "auto_fix": False,
+                    "description": 'Run: pip install "mcp-video[transcribe]" to enable transcription',
+                },
+            ) from exc
+        whisper_model = whisper.load_model(model)
+        options: dict[str, Any] = {"word_timestamps": True, "task": "transcribe"}
+        if language:
+            options["language"] = language
+        result = whisper_model.transcribe(audio_path, **options)
+        return _format_chunk_result(result)
+    finally:
+        if audio_path is not None:
+            with suppress(OSError):
+                os.unlink(audio_path)
+
+
+__all__ = ["_format_chunk_result", "_transcribe_chunk"]

--- a/kinocut/ai_engine/transcribe.py
+++ b/kinocut/ai_engine/transcribe.py
@@ -9,6 +9,8 @@ Optional dependencies:
 from __future__ import annotations
 
 import logging
+import math
+import os
 import tempfile
 from pathlib import Path
 from typing import Any
@@ -38,6 +40,77 @@ def _validate_transcribe_duration(video_path: str) -> None:
             error_type="validation_error",
             code="duration_too_long",
         )
+
+
+def _extract_audio_segment(
+    video_path: str,
+    start: float,
+    duration: float,
+    *,
+    sample_rate: int = 16000,
+    output_dir: str | None = None,
+) -> str:
+    """Extract a fixed-duration audio segment to a temp WAV file.
+
+    Used by the long-form transcription workflow to slice media up to
+    MAX_VIDEO_DURATION into per-chunk WAV files for Whisper.  Output is
+    Whisper-optimal 16-bit mono PCM at the requested sample rate.
+
+    Returns the path of the generated WAV file.  The caller is responsible
+    for cleanup (long-form paths use a single temp dir per run).
+    """
+    if isinstance(start, bool) or not isinstance(start, (int, float)) or not math.isfinite(start) or start < 0:
+        raise MCPVideoError(
+            f"start must be a non-negative number, got {start!r}",
+            error_type="validation_error",
+            code="invalid_parameter",
+        )
+    if (
+        isinstance(duration, bool)
+        or not isinstance(duration, (int, float))
+        or not math.isfinite(duration)
+        or duration <= 0
+    ):
+        raise MCPVideoError(
+            f"duration must be a positive number, got {duration!r}",
+            error_type="validation_error",
+            code="invalid_parameter",
+        )
+    if isinstance(sample_rate, bool) or not isinstance(sample_rate, int) or sample_rate <= 0:
+        raise MCPVideoError(
+            f"sample_rate must be a positive int, got {sample_rate!r}",
+            error_type="validation_error",
+            code="invalid_parameter",
+        )
+    out_fd, out_path = tempfile.mkstemp(suffix=".wav", prefix="kc_longform_", dir=output_dir)
+    os.close(out_fd)
+
+    try:
+        _run_command(
+            [
+                "ffmpeg",
+                "-y",
+                "-ss",
+                f"{float(start):.6f}",
+                "-i",
+                str(video_path),
+                "-t",
+                f"{float(duration):.6f}",
+                "-vn",
+                "-acodec",
+                "pcm_s16le",
+                "-ar",
+                str(sample_rate),
+                "-ac",
+                "1",
+                out_path,
+            ],
+            timeout=DEFAULT_FFMPEG_TIMEOUT,
+        )
+    except Exception:
+        Path(out_path).unlink(missing_ok=True)
+        raise
+    return out_path
 
 
 def ai_transcribe(

--- a/tests/test_longform_runtime.py
+++ b/tests/test_longform_runtime.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from kinocut.ai_engine import _longform_runtime as runtime
+from kinocut.ai_engine import transcribe
+from kinocut.ai_engine._longform_models import LongformChunk
+from kinocut.errors import MCPVideoError
+
+
+def _chunk() -> LongformChunk:
+    return LongformChunk(index=2, start=12.5, end=20, duration=7.5)
+
+
+def test_extract_audio_segment_builds_bounded_ffmpeg_command(monkeypatch, tmp_path) -> None:
+    calls = []
+    monkeypatch.setattr(transcribe, "_run_command", lambda command, **kwargs: calls.append((command, kwargs)))
+    output = transcribe._extract_audio_segment("source.mp4", 12.5, 7.5, sample_rate=16_000, output_dir=str(tmp_path))
+    command, kwargs = calls[0]
+    assert command[:6] == ["ffmpeg", "-y", "-ss", "12.500000", "-i", "source.mp4"]
+    assert command[command.index("-t") + 1] == "7.500000"
+    assert command[command.index("-ar") + 1] == "16000"
+    assert Path(output).parent == tmp_path
+    assert kwargs["timeout"] > 0
+    Path(output).unlink()
+
+
+@pytest.mark.parametrize(
+    "start,duration,sample_rate",
+    [(-1, 1, 16_000), (True, 1, 16_000), (0, 0, 16_000), (0, float("inf"), 16_000), (0, 1, 0)],
+)
+def test_extract_audio_segment_rejects_invalid_parameters(start, duration, sample_rate) -> None:
+    with pytest.raises(MCPVideoError) as exc:
+        transcribe._extract_audio_segment("source.mp4", start, duration, sample_rate=sample_rate)
+    assert exc.value.code == "invalid_parameter"
+
+
+def test_extract_audio_segment_removes_temp_file_when_ffmpeg_fails(monkeypatch, tmp_path) -> None:
+    def fail(command, **kwargs):
+        assert Path(command[-1]).exists()
+        raise RuntimeError("ffmpeg failed")
+
+    monkeypatch.setattr(transcribe, "_run_command", fail)
+    with pytest.raises(RuntimeError, match="ffmpeg failed"):
+        transcribe._extract_audio_segment("source.mp4", 0, 1, output_dir=str(tmp_path))
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_format_chunk_result_preserves_real_word_timings() -> None:
+    result = runtime._format_chunk_result(
+        {
+            "text": "hello world",
+            "language": "en",
+            "segments": [
+                {
+                    "start": 0.1,
+                    "end": 1.8,
+                    "text": "hello world",
+                    "words": [
+                        {"word": "hello", "start": 0.1, "end": 0.6, "probability": 0.8},
+                        {"word": "world", "start": 1.2, "end": 1.8},
+                    ],
+                }
+            ],
+        }
+    )
+    assert result["segments"][0]["words"][0]["start"] == 0.1
+    assert result["segments"][0]["words"][0]["probability"] == 0.8
+    assert result["segments"][0]["words"][1]["end"] == 1.8
+
+
+def test_transcribe_chunk_requests_word_timestamps_and_cleans_up(monkeypatch, tmp_path) -> None:
+    audio_path = tmp_path / "chunk.wav"
+    audio_path.write_bytes(b"wav")
+    seen = {}
+
+    class Model:
+        def transcribe(self, path, **options):
+            seen.update(path=path, options=options)
+            return {"text": "hello", "language": "en", "segments": []}
+
+    monkeypatch.setattr(runtime, "_extract_audio_segment", lambda *args, **kwargs: str(audio_path))
+    monkeypatch.setitem(sys.modules, "whisper", SimpleNamespace(load_model=lambda name: Model()))
+    result = runtime._transcribe_chunk("source.mp4", _chunk(), model="base", language="en", work_dir=str(tmp_path))
+    assert result["transcript"] == "hello"
+    assert seen["options"] == {"word_timestamps": True, "task": "transcribe", "language": "en"}
+    assert not audio_path.exists()
+
+
+def test_transcribe_chunk_missing_whisper_is_actionable_and_cleans_up(monkeypatch, tmp_path) -> None:
+    audio_path = tmp_path / "chunk.wav"
+    audio_path.write_bytes(b"wav")
+    monkeypatch.setattr(runtime, "_extract_audio_segment", lambda *args, **kwargs: str(audio_path))
+    monkeypatch.setitem(sys.modules, "whisper", None)
+    with pytest.raises(MCPVideoError) as exc:
+        runtime._transcribe_chunk("source.mp4", _chunk(), model="base", language=None, work_dir=str(tmp_path))
+    assert exc.value.code == "missing_whisper"
+    assert exc.value.suggested_action["auto_fix"] is False
+    assert not audio_path.exists()


### PR DESCRIPTION
Progresses #402; stacked on #412.

Adds the per-chunk execution seam:
- extracts bounded mono PCM WAVs for Whisper without changing ordinary transcription's 3600s guard
- validates finite chunk parameters and cleans failed FFmpeg temp files
- requests real Whisper word timestamps and preserves them verbatim
- emits actionable missing-dependency errors
- always removes per-chunk temporary audio

Final stacked diff: 244 additions across three files. Focused/legacy AI verification: 126 passed, 9 skipped; Ruff and diff checks pass.

Draft pending required GLM 5.2 ULTRACODE review and exact-head hosted CI. Upstream GLM overload is being treated as a blocker, not bypassed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/kinocut/pr/413"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787366797&installation_model_id=20207&pr_number=413&repository=KyaniteLabs%2Fkinocut&return_to=https%3A%2F%2Fgithub.com%2FKyaniteLabs%2Fkinocut%2Fpull%2F413&signature=c8bf75ebd0ef399d0610bc15afdb95e7faf395cda8734b592d2b5f2270769b82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->