### PR TITLE
feat: merge long-form transcript overlaps truthfully

### DIFF
--- a/kinocut/ai_engine/_longform_merge.py
+++ b/kinocut/ai_engine/_longform_merge.py
@@ -1,0 +1,137 @@
+"""Timestamp remapping and overlap deduplication for long-form chunks."""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+from ._longform_models import LongformChunk, LongformSegment, LongformWord
+
+
+def _word_probability(word: dict[str, Any]) -> float | None:
+    """Return an observed probability, or an exp(logprob) fallback, without invention."""
+    raw = word.get("probability")
+    if raw is not None:
+        try:
+            value = float(raw)
+        except (TypeError, ValueError):
+            value = math.nan
+        if math.isfinite(value) and 0.0 <= value <= 1.0:
+            return value
+    raw = word.get("avg_logprob")
+    if raw is None:
+        return None
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(value):
+        return None
+    return 1.0 if value >= 0.0 else math.exp(value)
+
+
+def _segment_no_speech_prob(segment: dict[str, Any]) -> float | None:
+    raw = segment.get("no_speech_prob")
+    if raw is None:
+        return None
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        return None
+    return value if math.isfinite(value) and 0.0 <= value <= 1.0 else None
+
+
+def _segment_avg_logprob(segment: dict[str, Any]) -> float | None:
+    raw = segment.get("avg_logprob")
+    if raw is None:
+        return None
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        return None
+    return value if math.isfinite(value) and value <= 0.0 else None
+
+
+def _extract_segment_words(
+    segment: dict[str, Any],
+) -> list[tuple[str, float, float, float | None]]:
+    """Extract valid real word spans; absent confidence remains ``None``."""
+    extracted: list[tuple[str, float, float, float | None]] = []
+    for word in segment.get("words") or ():
+        if not isinstance(word, dict):
+            continue
+        text = str(word.get("word", "")).strip()
+        try:
+            start = float(word.get("start", 0.0) or 0.0)
+            end = float(word.get("end", start) or start)
+        except (TypeError, ValueError):
+            continue
+        if not text or not math.isfinite(start) or not math.isfinite(end) or start < 0.0 or end <= start:
+            continue
+        extracted.append((text, start, end, _word_probability(word)))
+    return extracted
+
+
+def _build_dedup_tail(words: list[LongformWord], overlap_start: float) -> set[str]:
+    return {word.word.strip().casefold() for word in words if word.start >= overlap_start}
+
+
+def _merge_chunk(
+    accumulated_words: list[LongformWord],
+    accumulated_segments: list[LongformSegment],
+    chunk_result: dict[str, Any],
+    chunk: LongformChunk,
+    overlap_seconds: int,
+    prev_chunk_end: float | None,
+) -> None:
+    """Append one chunk in global source time, dropping repeated overlap-tail words."""
+    offset = chunk.start
+    overlap_end = prev_chunk_end if prev_chunk_end is not None else offset + overlap_seconds
+    prior_tail = _build_dedup_tail(accumulated_words, offset)
+    new_words: list[LongformWord] = []
+    for raw_segment in chunk_result.get("segments") or ():
+        if not isinstance(raw_segment, dict):
+            continue
+        try:
+            local_start = float(raw_segment.get("start", 0.0) or 0.0)
+            local_end = float(raw_segment.get("end", local_start) or local_start)
+        except (TypeError, ValueError):
+            continue
+        text = str(raw_segment.get("text", "")).strip()
+        if not text or local_start < 0.0 or local_end <= local_start:
+            continue
+        for word_text, word_start, word_end, probability in _extract_segment_words(raw_segment):
+            global_start = word_start + offset
+            normalized = word_text.casefold()
+            if offset <= global_start < overlap_end and normalized in prior_tail:
+                continue
+            new_words.append(
+                LongformWord(
+                    word=word_text,
+                    start=global_start,
+                    end=word_end + offset,
+                    chunk_index=chunk.index,
+                    probability=probability,
+                )
+            )
+        accumulated_segments.append(
+            LongformSegment(
+                start=local_start + offset,
+                end=local_end + offset,
+                text=text,
+                chunk_index=chunk.index,
+                avg_logprob=_segment_avg_logprob(raw_segment),
+                no_speech_prob=_segment_no_speech_prob(raw_segment),
+            )
+        )
+    accumulated_words.extend(new_words)
+
+
+__all__ = [
+    "_build_dedup_tail",
+    "_extract_segment_words",
+    "_merge_chunk",
+    "_segment_avg_logprob",
+    "_segment_no_speech_prob",
+    "_word_probability",
+]

--- a/tests/test_longform_merge.py
+++ b/tests/test_longform_merge.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+from copy import deepcopy
+import math
+
+import pytest
+
+from kinocut.ai_engine._longform_merge import (
+    _build_dedup_tail,
+    _extract_segment_words,
+    _merge_chunk,
+    _segment_avg_logprob,
+    _segment_no_speech_prob,
+    _word_probability,
+)
+from kinocut.ai_engine._longform_models import LongformChunk, LongformSegment, LongformWord
+
+
+def _chunk(index: int, start: float, end: float) -> LongformChunk:
+    return LongformChunk(index=index, start=start, end=end, duration=end - start)
+
+
+def _segment(
+    text: str,
+    start: float,
+    end: float,
+    words: list[dict] | None = None,
+    **extra,
+) -> dict:
+    return {"text": text, "start": start, "end": end, "words": words or [], **extra}
+
+
+@pytest.mark.parametrize(
+    "word,expected",
+    [
+        ({"probability": 0.7, "avg_logprob": -10}, 0.7),
+        ({"avg_logprob": math.log(0.4)}, 0.4),
+        ({"avg_logprob": 1.0}, 1.0),
+        ({}, None),
+        ({"probability": "bad"}, None),
+        ({"probability": float("nan")}, None),
+    ],
+)
+def test_word_probability_is_truthful(word, expected) -> None:
+    actual = _word_probability(word)
+    if expected is None:
+        assert actual is None
+    else:
+        assert actual == pytest.approx(expected)
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [(0.2, 0.2), (None, None), ("bad", None), (-0.1, None), (1.1, None), (float("nan"), None)],
+)
+def test_segment_no_speech_probability_is_bounded(value, expected) -> None:
+    assert _segment_no_speech_prob({"no_speech_prob": value}) == expected
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [(-0.2, -0.2), (0.0, 0.0), (None, None), ("bad", None), (0.1, None), (float("nan"), None), (float("inf"), None)],
+)
+def test_segment_avg_logprob_is_finite_and_non_positive(value, expected) -> None:
+    assert _segment_avg_logprob({"avg_logprob": value}) == expected
+
+
+def test_extract_segment_words_preserves_timings_and_unknown_confidence() -> None:
+    segment = _segment(
+        "hello world",
+        0,
+        2,
+        [
+            {"word": " hello ", "start": 0.1, "end": 0.6, "probability": 0.8},
+            {"word": "world", "start": 1.2, "end": 1.8},
+            {"word": "", "start": 0, "end": 1},
+            {"word": "zero", "start": 1, "end": 1},
+        ],
+    )
+    assert _extract_segment_words(segment) == [
+        ("hello", 0.1, 0.6, 0.8),
+        ("world", 1.2, 1.8, None),
+    ]
+
+
+def test_extract_segment_words_skips_non_mapping_entries() -> None:
+    assert _extract_segment_words({"words": [None, "bad", 1]}) == []
+
+
+def test_build_dedup_tail_uses_casefolded_overlap_words() -> None:
+    words = [
+        LongformWord(word="Before", start=4, end=5, chunk_index=0),
+        LongformWord(word=" Again ", start=5, end=6, chunk_index=0),
+    ]
+    assert _build_dedup_tail(words, 5) == {"again"}
+
+
+def test_merge_remaps_global_time_dedups_overlap_and_keeps_unique_words() -> None:
+    words = [LongformWord(word="Again", start=5.2, end=5.7, chunk_index=0, probability=0.9)]
+    segments: list[LongformSegment] = []
+    raw = {
+        "segments": [
+            _segment(
+                "again now",
+                0,
+                2,
+                [
+                    {"word": " again ", "start": 0.2, "end": 0.7, "probability": 0.4},
+                    {"word": "now", "start": 1.0, "end": 1.5},
+                ],
+                avg_logprob=-0.3,
+                no_speech_prob=0.1,
+            )
+        ]
+    }
+    before = deepcopy(raw)
+    _merge_chunk(words, segments, raw, _chunk(1, 5, 10), overlap_seconds=2, prev_chunk_end=7)
+    assert [word.word for word in words] == ["Again", "now"]
+    assert words[-1].start == 6.0
+    assert words[-1].end == 6.5
+    assert words[-1].probability is None
+    assert segments[0].start == 5
+    assert segments[0].end == 7
+    assert segments[0].avg_logprob == -0.3
+    assert segments[0].no_speech_prob == 0.1
+    assert raw == before
+
+
+def test_merge_keeps_unique_word_inside_overlap_tail() -> None:
+    words = [LongformWord(word="old", start=9, end=9.5, chunk_index=0)]
+    segments: list[LongformSegment] = []
+    raw = {"segments": [_segment("new", 0.2, 1, [{"word": "new", "start": 0.2, "end": 0.8}])]}
+    _merge_chunk(words, segments, raw, _chunk(1, 9, 15), overlap_seconds=2, prev_chunk_end=11)
+    assert [word.word for word in words] == ["old", "new"]
+    assert words[-1].start == pytest.approx(9.2)
+
+
+def test_merge_segment_without_words_retains_truthful_metadata() -> None:
+    words: list[LongformWord] = []
+    segments: list[LongformSegment] = []
+    raw = {"segments": [_segment("spoken", 1, 2, avg_logprob=-0.5)]}
+    _merge_chunk(words, segments, raw, _chunk(0, 10, 20), overlap_seconds=2, prev_chunk_end=None)
+    assert words == []
+    assert segments == [
+        LongformSegment(
+            start=11,
+            end=12,
+            text="spoken",
+            chunk_index=0,
+            avg_logprob=-0.5,
+            no_speech_prob=None,
+        )
+    ]
+
+
+def test_merge_skips_invalid_empty_or_zero_width_segments() -> None:
+    words: list[LongformWord] = []
+    segments: list[LongformSegment] = []
+    raw = {
+        "segments": [
+            None,
+            "bad",
+            _segment("", 0, 1),
+            _segment("zero", 1, 1),
+            {"text": "bad", "start": "x"},
+            _segment("metadata", 2, 3, avg_logprob=float("nan")),
+        ]
+    }
+    _merge_chunk(words, segments, raw, _chunk(0, 0, 10), overlap_seconds=2, prev_chunk_end=None)
+    assert words == []
+    assert segments == [
+        LongformSegment(
+            start=2,
+            end=3,
+            text="metadata",
+            chunk_index=0,
+            avg_logprob=None,
+            no_speech_prob=None,
+        )
+    ]


### PR DESCRIPTION
Progresses #402; stacked on #413.

Adds deterministic timestamp remapping and overlap deduplication:
- preserves real word spans and observed probability
- uses exp(logprob) only as an evidence-backed fallback
- keeps missing confidence as `None`
- casefold-deduplicates repeated boundary words while retaining unique overlap content
- preserves segment log-probability/no-speech provenance
- skips malformed zero-width source entries without mutating input payloads

Final stacked diff: 270 additions across two files. Focused stack verification: 67 passed; Ruff and diff checks pass.

Draft pending required GLM 5.2 ULTRACODE review and exact-head hosted CI.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/kinocut/pr/414"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787367971&installation_model_id=20207&pr_number=414&repository=KyaniteLabs%2Fkinocut&return_to=https%3A%2F%2Fgithub.com%2FKyaniteLabs%2Fkinocut%2Fpull%2F414&signature=8f10422e4107482567916af0c5498262159b53c40d250a2fb8334e07081a0ffb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->