### PR TITLE
feat: orchestrate replay-safe long-form transcription

### DIFF
--- a/kinocut/ai_engine/transcribe_longform.py
+++ b/kinocut/ai_engine/transcribe_longform.py
@@ -1,0 +1,153 @@
+"""Public long-form transcription facade and orchestration."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import tempfile
+
+from ..errors import MCPVideoError
+from ..ffmpeg_helpers import _get_video_duration
+from ..limits import LONGFORM_TRANSCRIBE_OVERLAP_SECONDS, MAX_LONGFORM_TRANSCRIBE_CHUNK_SECONDS
+from ._longform_merge import _merge_chunk, _word_probability
+from ._longform_models import (
+    LongformChunk,
+    LongformSegment,
+    LongformTranscribePlan,
+    LongformTranscribeResult,
+    LongformWord,
+)
+from ._longform_planning import plan_longform_transcription
+from ._longform_runtime import _format_chunk_result, _transcribe_chunk
+from ._longform_validation import (
+    _validate_chunk_seconds,
+    _validate_longform_path,
+    _validate_overlap_seconds,
+)
+from .transcribe import _validate_whisper_model
+
+_MIN_WORD_WIDTH_SECONDS = 0.001
+
+
+def _invalid_plan(message: str) -> MCPVideoError:
+    return MCPVideoError(message, error_type="validation_error", code="invalid_plan")
+
+
+def _validate_replay_plan(video: str, plan: LongformTranscribePlan, *, verify_media: bool) -> None:
+    """Fail closed when a replay plan does not describe this complete source."""
+    if not plan.chunks:
+        raise _invalid_plan("Long-form plan is empty; refusing to transcribe")
+    if Path(plan.video_path).resolve() != Path(video).resolve():
+        raise _invalid_plan("Long-form plan source does not match the requested video")
+    if verify_media and abs(_get_video_duration(video) - plan.duration) > 0.05:
+        raise _invalid_plan("Long-form plan duration does not match the requested video")
+    previous_end = 0.0
+    for expected_index, chunk in enumerate(plan.chunks):
+        if chunk.index != expected_index:
+            raise _invalid_plan("Long-form plan chunk indices must be contiguous")
+        if chunk.end > plan.duration + 1e-9 or chunk.duration > plan.chunk_seconds + 1e-9:
+            raise _invalid_plan("Long-form plan chunk exceeds its source or configured cap")
+        if expected_index == 0 and chunk.start != 0.0:
+            raise _invalid_plan("Long-form plan must start at zero")
+        if expected_index and (chunk.start > previous_end or previous_end - chunk.start > plan.overlap_seconds + 1e-9):
+            raise _invalid_plan("Long-form plan chunks must provide bounded, gap-free coverage")
+        previous_end = chunk.end
+    if abs(previous_end - plan.duration) > 1e-9:
+        raise _invalid_plan("Long-form plan must cover the complete source duration")
+
+
+def _enforce_monotonic_words(words: list[LongformWord]) -> None:
+    """Snap boundary overlaps forward while retaining at least 1ms word width."""
+    for index in range(1, len(words)):
+        previous = words[index - 1]
+        current = words[index]
+        if current.start < previous.end:
+            start = previous.end
+            end = max(current.end, start + _MIN_WORD_WIDTH_SECONDS)
+            words[index] = current.model_copy(update={"start": start, "end": end})
+
+
+def transcribe_longform(
+    video: str,
+    *,
+    model: str = "base",
+    language: str | None = None,
+    chunk_seconds: int = MAX_LONGFORM_TRANSCRIBE_CHUNK_SECONDS,
+    overlap_seconds: int = LONGFORM_TRANSCRIBE_OVERLAP_SECONDS,
+    scene_aware: bool = True,
+    plan: LongformTranscribePlan | None = None,
+) -> LongformTranscribeResult:
+    """Transcribe media through deterministic overlapping Whisper chunks."""
+    _validate_whisper_model(model)
+    if plan is None:
+        plan = plan_longform_transcription(
+            video,
+            chunk_seconds=chunk_seconds,
+            overlap_seconds=overlap_seconds,
+            scene_aware=scene_aware,
+        )
+        video = plan.video_path
+        _validate_replay_plan(video, plan, verify_media=False)
+    else:
+        video = _validate_longform_path(video)
+        _validate_chunk_seconds(plan.chunk_seconds)
+        _validate_overlap_seconds(plan.overlap_seconds, plan.chunk_seconds)
+        _validate_replay_plan(video, plan, verify_media=True)
+
+    words: list[LongformWord] = []
+    segments: list[LongformSegment] = []
+    detected_language = language or "unknown"
+    previous_end: float | None = None
+    with tempfile.TemporaryDirectory(prefix="kc_longform_") as work_dir:
+        for chunk in plan.chunks:
+            chunk_result = _transcribe_chunk(
+                video,
+                chunk,
+                model=model,
+                language=language,
+                work_dir=work_dir,
+            )
+            if chunk_result.get("language", "unknown") != "unknown":
+                detected_language = str(chunk_result["language"])
+            _merge_chunk(
+                words,
+                segments,
+                chunk_result,
+                chunk,
+                overlap_seconds=plan.overlap_seconds,
+                prev_chunk_end=previous_end,
+            )
+            previous_end = chunk.end
+
+    words.sort(key=lambda word: (word.start, word.end, word.chunk_index))
+    segments.sort(key=lambda segment: (segment.start, segment.end, segment.chunk_index))
+    _enforce_monotonic_words(words)
+    transcript = " ".join(word.word for word in words).strip()
+    if not transcript:
+        transcript = " ".join(segment.text for segment in segments).strip()
+    return LongformTranscribeResult(
+        video_path=video,
+        duration=plan.duration,
+        language=detected_language,
+        transcript=transcript,
+        segments=tuple(segments),
+        words=tuple(words),
+        chunk_count=len(plan.chunks),
+        model=model,
+        plan=plan,
+    )
+
+
+__all__ = [
+    "LongformChunk",
+    "LongformSegment",
+    "LongformTranscribePlan",
+    "LongformTranscribeResult",
+    "LongformWord",
+    "_format_chunk_result",
+    "_merge_chunk",
+    "_validate_chunk_seconds",
+    "_validate_overlap_seconds",
+    "_word_probability",
+    "plan_longform_transcription",
+    "transcribe_longform",
+]

--- a/tests/test_longform_orchestrator.py
+++ b/tests/test_longform_orchestrator.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+from copy import deepcopy
+
+import pytest
+
+from kinocut.ai_engine import transcribe as legacy
+from kinocut.ai_engine import transcribe_longform as facade
+from kinocut.ai_engine._longform_models import LongformChunk, LongformTranscribePlan
+from kinocut.errors import MCPVideoError
+from kinocut.limits import MAX_AI_TRANSCRIBE_DURATION
+
+
+def _plan(*, path: str = "source.mp4", duration: float = 60) -> LongformTranscribePlan:
+    return LongformTranscribePlan(
+        video_path=path,
+        duration=duration,
+        chunk_seconds=40,
+        overlap_seconds=5,
+        chunks=(
+            LongformChunk(index=0, start=0, end=40, duration=40),
+            LongformChunk(index=1, start=35, end=duration, duration=duration - 35),
+        ),
+    )
+
+
+def _stub_validation(monkeypatch, duration: float = 60) -> None:
+    monkeypatch.setattr(facade, "_validate_whisper_model", lambda model: model)
+    monkeypatch.setattr(facade, "_validate_longform_path", lambda path: path)
+    monkeypatch.setattr(facade, "_get_video_duration", lambda path: duration)
+
+
+def _chunk_results() -> list[dict]:
+    return [
+        {
+            "language": "en",
+            "segments": [
+                {
+                    "text": "alpha beta",
+                    "start": 0,
+                    "end": 36,
+                    "words": [
+                        {"word": "alpha", "start": 0, "end": 1, "probability": 0.9},
+                        {"word": "beta", "start": 35.5, "end": 36, "probability": 0.8},
+                    ],
+                }
+            ],
+        },
+        {
+            "language": "en",
+            "segments": [
+                {
+                    "text": "beta gamma",
+                    "start": 0.5,
+                    "end": 2,
+                    "words": [
+                        {"word": "beta", "start": 0.5, "end": 1},
+                        {"word": "gamma", "start": 0.8, "end": 0.9},
+                    ],
+                }
+            ],
+        },
+    ]
+
+
+def test_transcribe_longform_merges_dedups_and_preserves_positive_width(monkeypatch) -> None:
+    _stub_validation(monkeypatch)
+    results = _chunk_results()
+    original = deepcopy(results)
+    monkeypatch.setattr(facade, "_transcribe_chunk", lambda video, chunk, **kwargs: results[chunk.index])
+    result = facade.transcribe_longform("source.mp4", model="base", plan=_plan())
+    assert result.transcript == "alpha beta gamma"
+    assert result.language == "en"
+    assert result.chunk_count == 2
+    assert [word.word for word in result.words] == ["alpha", "beta", "gamma"]
+    assert [word.start for word in result.words] == sorted(word.start for word in result.words)
+    assert [segment.start for segment in result.segments] == sorted(segment.start for segment in result.segments)
+    assert result.words[-1].start == result.words[-2].end
+    assert result.words[-1].end - result.words[-1].start >= 0.001 - 1e-9
+    assert isinstance(result.words, tuple)
+    assert results == original
+
+
+def test_transcribe_longform_uses_planner_when_plan_absent(monkeypatch) -> None:
+    _stub_validation(monkeypatch)
+    plan = _plan()
+    monkeypatch.setattr(facade, "plan_longform_transcription", lambda *args, **kwargs: plan)
+    monkeypatch.setattr(
+        facade,
+        "_transcribe_chunk",
+        lambda *args, **kwargs: {"language": "en", "segments": []},
+    )
+    result = facade.transcribe_longform("source.mp4")
+    assert result.plan is plan
+    assert result.transcript == ""
+
+
+def test_transcribe_longform_falls_back_to_segment_text(monkeypatch) -> None:
+    _stub_validation(monkeypatch)
+    monkeypatch.setattr(
+        facade,
+        "_transcribe_chunk",
+        lambda *args, **kwargs: {
+            "language": "en",
+            "segments": [{"text": "spoken phrase", "start": 0, "end": 1, "words": []}],
+        },
+    )
+    result = facade.transcribe_longform("source.mp4", plan=_plan())
+    assert result.transcript == "spoken phrase spoken phrase"
+    assert result.words == ()
+
+
+def test_transcribe_longform_rejects_bad_model_before_planning(monkeypatch) -> None:
+    def reject(model):
+        raise MCPVideoError("bad model", error_type="validation_error", code="invalid_parameter")
+
+    monkeypatch.setattr(facade, "_validate_whisper_model", reject)
+    monkeypatch.setattr(
+        facade,
+        "plan_longform_transcription",
+        lambda *args, **kwargs: pytest.fail("planning must not run"),
+    )
+    with pytest.raises(MCPVideoError) as exc:
+        facade.transcribe_longform("source.mp4", model="invalid")
+    assert exc.value.code == "invalid_parameter"
+
+
+def test_replay_rejects_empty_plan(monkeypatch) -> None:
+    _stub_validation(monkeypatch)
+    empty = LongformTranscribePlan(
+        video_path="source.mp4",
+        duration=60,
+        chunk_seconds=40,
+        overlap_seconds=5,
+        chunks=(),
+    )
+    with pytest.raises(MCPVideoError) as exc:
+        facade.transcribe_longform("source.mp4", plan=empty)
+    assert exc.value.code == "invalid_plan"
+
+
+@pytest.mark.parametrize(
+    "video,plan,duration",
+    [
+        ("other.mp4", _plan(), 60),
+        ("source.mp4", _plan(), 61),
+        (
+            "source.mp4",
+            LongformTranscribePlan(
+                video_path="source.mp4",
+                duration=60,
+                chunk_seconds=40,
+                overlap_seconds=5,
+                chunks=(
+                    LongformChunk(index=0, start=0, end=30, duration=30),
+                    LongformChunk(index=1, start=40, end=60, duration=20),
+                ),
+            ),
+            60,
+        ),
+    ],
+)
+def test_replay_plan_must_match_complete_source(monkeypatch, video, plan, duration) -> None:
+    _stub_validation(monkeypatch, duration)
+    with pytest.raises(MCPVideoError) as exc:
+        facade.transcribe_longform(video, plan=plan)
+    assert exc.value.code == "invalid_plan"
+
+
+def test_legacy_transcribe_still_rejects_over_3600_seconds(monkeypatch) -> None:
+    monkeypatch.setattr(legacy, "_get_video_duration", lambda path: MAX_AI_TRANSCRIBE_DURATION + 1)
+    with pytest.raises(MCPVideoError) as exc:
+        legacy._validate_transcribe_duration("source.mp4")
+    assert exc.value.code == "duration_too_long"


### PR DESCRIPTION
Completes the implementation stack for #402; stacked on #414.

Adds the public `transcribe_longform` facade shared by later orchestrator/adapters:
- validates replay plans against source identity, duration, complete coverage, ordering, overlap, and caps
- drives bounded chunk transcription and truthful overlap merging
- sorts segment/word timelines chronologically
- snaps real boundary overlaps forward while preserving at least 1ms word width
- returns deeply immutable strict results
- preserves the ordinary transcription >3600s rejection

Final stacked diff: 327 additions across two files. Focused stack verification: 76 passed; Ruff and diff checks pass.

Draft pending required GLM 5.2 ULTRACODE review and exact-head hosted CI.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/kinocut/pr/415"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787368322&installation_model_id=20207&pr_number=415&repository=KyaniteLabs%2Fkinocut&return_to=https%3A%2F%2Fgithub.com%2FKyaniteLabs%2Fkinocut%2Fpull%2F415&signature=069f90a6c50238c11f282eb84c6ecf01ea8a11068e052d4746547f685babba42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->