### PR TITLE
feat: discover bounded transcript moments

### DIFF
--- a/kinocut/product/highlight_discovery.py
+++ b/kinocut/product/highlight_discovery.py
@@ -1,0 +1,144 @@
+"""Deterministic transcript-only highlight candidate discovery."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Sequence
+from itertools import pairwise
+
+from .models import (
+    CandidateMoment,
+    HighlightDiscoveryConfig,
+    HighlightDiscoveryResult,
+    SourceSignal,
+    TranscriptSegment,
+    canonical_dedup_key,
+)
+
+_TERMINAL_RE = re.compile(r"[.!?](?:[\"')\]]+)?\s*$")
+
+
+def discover_highlights(
+    transcript: Sequence[TranscriptSegment],
+    *,
+    signals: Sequence[SourceSignal] = (),
+    config: HighlightDiscoveryConfig | None = None,
+) -> HighlightDiscoveryResult:
+    """Discover bounded, complete-thought candidates from ordered segments.
+
+    Candidate confidence is deliberately transcript-only. Signals that fall in a
+    selected window are preserved as evidence for a later enrichment stage, but
+    do not change discovery or ordering in this core slice.
+    """
+    cfg = config or HighlightDiscoveryConfig()
+    segments = tuple(transcript)
+    source_signals = tuple(signals)
+    if any(current.start < previous.start for previous, current in pairwise(segments)):
+        raise ValueError("transcript segments must be monotonic by start offset")
+
+    candidates: list[CandidateMoment] = []
+    for anchor_index, anchor in enumerate(segments):
+        if anchor.is_silence or not anchor.text.strip():
+            continue
+        candidate = _candidate_for_anchor(segments, anchor_index, source_signals, cfg)
+        if candidate is not None:
+            candidates.append(candidate)
+
+    by_key: dict[str, CandidateMoment] = {}
+    for candidate in candidates:
+        existing = by_key.get(candidate.dedup_key)
+        if existing is None or _sort_key(candidate) < _sort_key(existing):
+            by_key[candidate.dedup_key] = candidate
+    ordered = sorted(by_key.values(), key=_sort_key)[: cfg.max_clips]
+    return HighlightDiscoveryResult(
+        candidates=tuple(ordered),
+        config=cfg,
+        source_segment_count=len(segments),
+        discovered_at_offsets=tuple(round(candidate.start, 3) for candidate in ordered),
+    )
+
+
+def _candidate_for_anchor(
+    segments: tuple[TranscriptSegment, ...],
+    anchor_index: int,
+    signals: tuple[SourceSignal, ...],
+    config: HighlightDiscoveryConfig,
+) -> CandidateMoment | None:
+    anchor = segments[anchor_index]
+    parts: list[str] = []
+    end_index: int | None = None
+
+    for index in range(anchor_index, len(segments)):
+        segment = segments[index]
+        if segment.end - anchor.start > config.max_duration:
+            break
+        if segment.is_silence or not segment.text.strip():
+            continue
+        parts.append(segment.text.strip())
+        if segment.end - anchor.start >= config.min_duration and _is_complete(segment.text):
+            end_index = index
+            break
+
+    if end_index is None:
+        return None
+    end_segment = segments[end_index]
+    excerpt = " ".join(parts)
+    confidence = _transcript_score(excerpt)
+    key = canonical_dedup_key(
+        start=anchor.start,
+        end=end_segment.end,
+        excerpt=excerpt,
+        sensitivity="none",
+    )
+    title = _excerpt_lead(excerpt, 80)
+    hook = _excerpt_lead(excerpt, 120)
+    window_signals = tuple(
+        sorted(
+            (signal for signal in signals if anchor.start <= signal.timestamp <= end_segment.end),
+            key=lambda signal: (signal.timestamp, signal.kind, -signal.score, signal.label or ""),
+        )
+    )
+    return CandidateMoment(
+        candidate_id=_candidate_id(anchor.segment_id, key),
+        start=anchor.start,
+        end=end_segment.end,
+        transcript_excerpt=excerpt,
+        suggested_title=title,
+        suggested_hook=hook,
+        rationale=(
+            f"Transcript window from {anchor.start:.2f}s to {end_segment.end:.2f}s "
+            "meets the duration bounds and ends at a complete thought."
+        ),
+        confidence=confidence,
+        dedup_key=key,
+        sensitivity="none",
+        unsuitable=False,
+        source_signals=window_signals,
+    )
+
+
+def _is_complete(text: str) -> bool:
+    return bool(_TERMINAL_RE.search(text.rstrip()))
+
+
+def _transcript_score(excerpt: str) -> float:
+    words = len(excerpt.split())
+    terminals = sum(1 for token in excerpt.split() if _is_complete(token))
+    density = min(1.0, words / 60.0)
+    completeness = min(1.0, terminals / 2.0)
+    return round(min(1.0, 0.6 * density + 0.4 * completeness), 4)
+
+
+def _excerpt_lead(excerpt: str, limit: int) -> str:
+    match = re.search(r"[.!?]", excerpt)
+    lead = excerpt[: match.end()] if match else excerpt
+    return lead[:limit].strip()
+
+
+def _candidate_id(segment_id: str, dedup_key: str) -> str:
+    prefix = re.sub(r"[^A-Za-z0-9._-]", "_", segment_id)
+    return f"{prefix[:57]}-{dedup_key[:6]}"
+
+
+def _sort_key(candidate: CandidateMoment) -> tuple[float, float, float, str]:
+    return (-candidate.confidence, candidate.start, candidate.end, candidate.candidate_id)

--- a/kinocut/product/highlight_discovery.py
+++ b/kinocut/product/highlight_discovery.py
@@ -1,4 +1,25 @@
-"""Deterministic transcript-only highlight candidate discovery."""
+"""Deterministic transcript-only highlight candidate discovery.
+
+Core slice contract (the only behaviour tests touch):
+
+* **Monotonic input** — segments are accepted only when their ``start`` is
+  non-decreasing.  Strictly-decreasing inputs raise ``ValueError`` so callers
+  learn about overlap upstream rather than silently receiving reordered windows.
+* **In-window signal preservation** — ``SourceSignal`` entries whose timestamp
+  falls inside ``[anchor.start, end_segment.end]`` (inclusive on both ends) are
+  preserved on the candidate, sorted deterministically, and out-of-window
+  signals are excluded.  Signal presence never changes discovery or ordering.
+* **Bounded complete-thought windows** — every candidate window obeys
+  ``min_duration <= end - start <= max_duration`` and ends at a terminal mark
+  (``.``, ``!``, ``?``) so the rendered clip resolves rather than trailing off.
+* **Distinct, non-degenerate title and hook** — the title is the first
+  sentence of the excerpt, the hook is the first *two* sentences, and neither
+  is allowed to degenerate to a known abbreviation ("Dr."), a single capital
+  initial ("U. S. A."), or a decimal point ("3.14").
+
+This slice is deliberately transcript-only: enrichment, sensitivity escalation,
+and review warnings are owned by the later enrichment slice.
+"""
 
 from __future__ import annotations
 
@@ -15,7 +36,28 @@ from .models import (
     canonical_dedup_key,
 )
 
-_TERMINAL_RE = re.compile(r"[.!?](?:[\"')\]]+)?\s*$")
+# A period only counts as a sentence end when it is *not* a known abbreviation
+# (single-letter initials, honorifics, Latin/English abbreviations) or a decimal
+# point between two digits.  Without this guard "Dr. Smith explains." or
+# "3.14 percent improved." would degenerate the title to "Dr." / "3.".
+_ABBREVIATION_RE = re.compile(
+    r"\b(?:[A-Za-z]\.){1,4}|"
+    r"\b(?:Mr|Mrs|Ms|Dr|Prof|Sr|Jr|St|vs|etc|No|Inc|Ltd|Co|Corp|"
+    r"e\.g|i\.e|cf|al|approx|dept|est|govt)\.",
+    re.IGNORECASE,
+)
+_DECIMAL_RE = re.compile(r"\d\.\d")
+# Boundary-only terminal: a punctuation mark followed by optional quotes /
+# brackets, then end-of-string.  Used to decide whether a single segment closes
+# a complete thought; the search is restricted to the *end* of the segment
+# because an internal "Dr." or "3.14" is never a complete-thought boundary.
+_BOUNDARY_TERMINAL_RE = re.compile(r"[.!?](?:[\"')\]]+)?\s*$")
+# In-text terminal: a punctuation mark followed by whitespace (or another
+# sentence start) so we can scan through a multi-sentence excerpt while still
+# ignoring decorative periods.
+_INNER_TERMINAL_RE = re.compile(r"[.!?](?:[\"')\]]+)?(?=\s|$)")
+_CHAR_LIMIT_TITLE = 80
+_CHAR_LIMIT_HOOK = 160
 
 
 def discover_highlights(
@@ -29,6 +71,12 @@ def discover_highlights(
     Candidate confidence is deliberately transcript-only. Signals that fall in a
     selected window are preserved as evidence for a later enrichment stage, but
     do not change discovery or ordering in this core slice.
+
+    Raises:
+        ValueError: when any adjacent pair of segments has ``current.start <
+            previous.start`` (strictly non-monotonic input).  Equal ``start``
+            offsets are allowed because they model ASR boundary artefacts
+            where two segments share a boundary timestamp.
     """
     cfg = config or HighlightDiscoveryConfig()
     segments = tuple(transcript)
@@ -90,12 +138,20 @@ def _candidate_for_anchor(
         excerpt=excerpt,
         sensitivity="none",
     )
-    title = _excerpt_lead(excerpt, 80)
-    hook = _excerpt_lead(excerpt, 120)
+    title = _excerpt_title(excerpt)
+    hook = _excerpt_hook(excerpt)
+    # Window inclusion is inclusive on both ends so signals that land exactly
+    # on a window boundary (e.g. a scene change at the closing edit) are
+    # preserved as evidence rather than dropped.
     window_signals = tuple(
         sorted(
             (signal for signal in signals if anchor.start <= signal.timestamp <= end_segment.end),
-            key=lambda signal: (signal.timestamp, signal.kind, -signal.score, signal.label or ""),
+            key=lambda signal: (
+                signal.timestamp,
+                signal.kind,
+                -signal.score,
+                signal.label or "",
+            ),
         )
     )
     return CandidateMoment(
@@ -118,7 +174,23 @@ def _candidate_for_anchor(
 
 
 def _is_complete(text: str) -> bool:
-    return bool(_TERMINAL_RE.search(text.rstrip()))
+    """Return True when *text* ends at a real sentence terminal.
+
+    The boundary regex anchors to end-of-string so an internal "Dr." or "3.14"
+    cannot accidentally close a window.  The full excerpt is re-scanned by
+    :func:`_excerpt_title` / :func:`_excerpt_hook` with the stronger
+    abbreviation-aware logic.
+    """
+    return bool(_BOUNDARY_TERMINAL_RE.search(text.rstrip()))
+
+
+def _is_decorative_period(text: str, index: int) -> bool:
+    """Return True when the period at *index* is part of an abbreviation or decimal."""
+    return any(
+        match.start() <= index < match.end()
+        for pattern in (_ABBREVIATION_RE, _DECIMAL_RE)
+        for match in pattern.finditer(text)
+    )
 
 
 def _transcript_score(excerpt: str) -> float:
@@ -129,10 +201,65 @@ def _transcript_score(excerpt: str) -> float:
     return round(min(1.0, 0.6 * density + 0.4 * completeness), 4)
 
 
-def _excerpt_lead(excerpt: str, limit: int) -> str:
-    match = re.search(r"[.!?]", excerpt)
-    lead = excerpt[: match.end()] if match else excerpt
-    return lead[:limit].strip()
+def _excerpt_title(excerpt: str) -> str:
+    """Return the first *real* sentence of *excerpt*, truncated to fit a title.
+
+    Sentence boundaries are scanned left-to-right while skipping periods that
+    belong to known abbreviations or decimal numbers.  When the chosen lead
+    still exceeds the title character cap the result falls back to the longest
+    word-boundary-respecting prefix so a degenerate substring like "Dr" never
+    ships as a title.
+    """
+    first = _first_n_sentences(excerpt, 1)
+    if not first:
+        return _truncate_to_word_boundary(excerpt.strip(), _CHAR_LIMIT_TITLE)
+    return _fit_to_char_limit(first[0], _CHAR_LIMIT_TITLE)
+
+
+def _excerpt_hook(excerpt: str) -> str:
+    """Return the first *two* real sentences of *excerpt*, truncated to fit a hook.
+
+    The hook is required to be visibly different from the title; when the
+    excerpt contains only one sentence the hook extends up to the hook cap so
+    it carries more context than the title alone.
+    """
+    sentences = _first_n_sentences(excerpt, 2)
+    if len(sentences) >= 2:
+        return _fit_to_char_limit(" ".join(sentences), _CHAR_LIMIT_HOOK)
+    if sentences:
+        return _fit_to_char_limit(sentences[0], _CHAR_LIMIT_HOOK)
+    return _truncate_to_word_boundary(excerpt.strip(), _CHAR_LIMIT_HOOK)
+
+
+def _first_n_sentences(excerpt: str, n: int) -> list[str]:
+    sentences: list[str] = []
+    cursor = 0
+    for match in _INNER_TERMINAL_RE.finditer(excerpt):
+        if _is_decorative_period(excerpt, match.start()):
+            continue
+        sentence = excerpt[cursor : match.start() + 1].strip()
+        if not sentence:
+            continue
+        sentences.append(sentence)
+        cursor = match.end()
+        if len(sentences) >= n:
+            break
+    return sentences
+
+
+def _fit_to_char_limit(sentence: str, char_limit: int) -> str:
+    if len(sentence) <= char_limit:
+        return sentence
+    return _truncate_to_word_boundary(sentence, char_limit)
+
+
+def _truncate_to_word_boundary(text: str, char_limit: int) -> str:
+    if len(text) <= char_limit:
+        return text
+    head = text[:char_limit].rstrip()
+    if " " not in head:
+        return head
+    return head.rsplit(" ", 1)[0].rstrip()
 
 
 def _candidate_id(segment_id: str, dedup_key: str) -> str:

--- a/tests/test_highlight_discovery_core.py
+++ b/tests/test_highlight_discovery_core.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+from kinocut.product.highlight_discovery import discover_highlights
+from kinocut.product.models import HighlightDiscoveryConfig, SourceSignal, TranscriptSegment
+
+
+def _segment(
+    segment_id: str,
+    start: float,
+    end: float,
+    text: str,
+    *,
+    silence: bool = False,
+    confidence: float | None = 0.9,
+) -> TranscriptSegment:
+    return TranscriptSegment(
+        segment_id=segment_id,
+        start=start,
+        end=end,
+        text=text,
+        confidence=confidence,
+        is_silence=silence,
+    )
+
+
+def _config(*, minimum: float = 8, maximum: float = 30, clips: int = 8) -> HighlightDiscoveryConfig:
+    return HighlightDiscoveryConfig(
+        min_duration=minimum,
+        max_duration=maximum,
+        max_clips=clips,
+    )
+
+
+def _realistic_transcript() -> tuple[TranscriptSegment, ...]:
+    return (
+        _segment("intro", 12, 24, "The first lesson is to begin with the audience's actual problem."),
+        _segment("example", 24, 36, "For example, our smallest experiment revealed the largest source of delay."),
+        _segment("turn", 36, 48, "That changed the plan because evidence beat our original assumption."),
+        _segment("payoff", 48, 60, "The payoff is a process that gets faster whenever it learns."),
+    )
+
+
+def test_discovery_is_repeatable_and_json_stable() -> None:
+    transcript = _realistic_transcript()
+    signal = SourceSignal(kind="scene_change", timestamp=30, score=0.8)
+
+    first = discover_highlights(transcript, signals=(signal,), config=_config())
+    second = discover_highlights(transcript, signals=(signal,), config=_config())
+
+    assert first == second
+    assert first.model_dump_json() == second.model_dump_json()
+
+
+def test_realistic_transcript_produces_at_least_three_distinct_candidates() -> None:
+    result = discover_highlights(_realistic_transcript(), config=_config(clips=3))
+
+    assert len(result.candidates) >= 3
+    assert len({candidate.dedup_key for candidate in result.candidates}) == len(result.candidates)
+
+
+def test_empty_transcript_has_no_candidates() -> None:
+    result = discover_highlights((), config=_config())
+
+    assert result.candidates == ()
+
+
+def test_all_silence_has_no_candidates() -> None:
+    transcript = (
+        _segment("silence-1", 0, 10, "[silence]", silence=True),
+        _segment("silence-2", 10, 20, "[silence]", silence=True),
+    )
+
+    assert discover_highlights(transcript, config=_config()).candidates == ()
+
+
+def test_window_extends_to_complete_thought_payoff() -> None:
+    transcript = (
+        _segment("setup", 0, 10, "The useful result begins with a constraint"),
+        _segment("bridge", 10, 20, "and the initial attempt still falls short,"),
+        _segment("answer", 20, 30, "but the final comparison reveals the answer."),
+    )
+
+    candidate = next(
+        item
+        for item in discover_highlights(transcript, config=_config(minimum=15, maximum=35)).candidates
+        if item.start == 0
+    )
+
+    assert candidate.end == 30
+    assert candidate.transcript_excerpt.endswith("answer.")
+
+
+def test_window_without_complete_thought_is_rejected() -> None:
+    transcript = (
+        _segment("setup", 0, 10, "This explanation continues"),
+        _segment("middle", 10, 20, "through another unfinished clause,"),
+    )
+
+    assert discover_highlights(transcript, config=_config(minimum=8, maximum=25)).candidates == ()
+
+
+def test_leading_silence_is_trimmed_from_candidate() -> None:
+    transcript = (
+        _segment("silence", 40, 48, "[silence]", silence=True),
+        _segment("speech", 48, 58, "The spoken idea begins here and reaches its conclusion."),
+    )
+
+    candidate = discover_highlights(transcript, config=_config(minimum=5)).candidates[0]
+
+    assert candidate.start == 48
+    assert "silence" not in candidate.transcript_excerpt.lower()
+
+
+def test_candidates_respect_source_bounds_duration_and_max_clips() -> None:
+    transcript = (
+        _segment("one", 100, 110, "A bounded window starts at the source offset"),
+        _segment("two", 110, 120, "and closes with a complete result."),
+        _segment("three", 120, 140, "A second self-contained explanation also ends cleanly."),
+    )
+    config = _config(minimum=10, maximum=25, clips=1)
+
+    result = discover_highlights(transcript, config=config)
+
+    assert len(result.candidates) == 1
+    assert all(100 <= item.start < item.end <= 140 for item in result.candidates)
+    assert all(config.min_duration <= item.end - item.start <= config.max_duration for item in result.candidates)
+
+
+def test_duplicate_windows_collapse_by_canonical_key() -> None:
+    transcript = (
+        _segment("copy-a", 0, 10, "The same bounded thought finishes here."),
+        _segment("copy-b", 0, 10, "The same bounded thought finishes here."),
+    )
+
+    result = discover_highlights(transcript, config=_config(minimum=5))
+
+    assert len(result.candidates) == 1
+
+
+def test_candidates_are_sorted_by_descending_score() -> None:
+    transcript = (
+        _segment("short", 0, 10, "A concise result lands."),
+        _segment(
+            "dense",
+            10,
+            20,
+            "A detailed explanation connects evidence, constraints, tradeoffs, audience needs, "
+            "implementation choices, and the measurable result.",
+        ),
+        _segment("medium", 20, 30, "A useful intermediate explanation reaches a clear result."),
+    )
+
+    candidates = discover_highlights(transcript, config=_config(minimum=5)).candidates
+
+    assert [item.confidence for item in candidates] == sorted((item.confidence for item in candidates), reverse=True)

--- a/tests/test_highlight_discovery_core.py
+++ b/tests/test_highlight_discovery_core.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pytest
+
 from kinocut.product.highlight_discovery import discover_highlights
 from kinocut.product.models import HighlightDiscoveryConfig, SourceSignal, TranscriptSegment
 
@@ -153,3 +155,137 @@ def test_candidates_are_sorted_by_descending_score() -> None:
     candidates = discover_highlights(transcript, config=_config(minimum=5)).candidates
 
     assert [item.confidence for item in candidates] == sorted((item.confidence for item in candidates), reverse=True)
+
+
+# --- In-window signal preservation (GLM finding 1) --------------------------
+
+
+def test_signals_inside_window_are_preserved_in_deterministic_order() -> None:
+    transcript = _realistic_transcript()
+    inside = (
+        SourceSignal(kind="scene_change", timestamp=30.0, score=0.8),
+        SourceSignal(kind="audio_energy", timestamp=20.0, score=0.5, label="energy"),
+        SourceSignal(kind="scene_change", timestamp=25.0, score=0.4),
+    )
+
+    candidate = next(
+        item
+        for item in discover_highlights(
+            transcript, signals=inside, config=_config(minimum=8, maximum=30, clips=8)
+        ).candidates
+        if item.start == 12
+    )
+
+    timestamps = [signal.timestamp for signal in candidate.source_signals]
+    # Ordering must be (timestamp, kind, -score, label) — same timestamp must
+    # also be stable by kind.
+    assert timestamps == sorted(timestamps)
+    assert all(12.0 <= signal.timestamp <= candidate.end for signal in candidate.source_signals)
+
+
+def test_signals_outside_window_are_excluded() -> None:
+    transcript = _realistic_transcript()
+    outside = (
+        SourceSignal(kind="scene_change", timestamp=5.0, score=0.9),
+        SourceSignal(kind="audio_energy", timestamp=80.0, score=0.9, label="late"),
+    )
+
+    candidates = discover_highlights(
+        transcript, signals=outside, config=_config(minimum=8, maximum=30, clips=8)
+    ).candidates
+
+    assert all(candidate.source_signals == () for candidate in candidates)
+
+
+def test_signals_at_window_boundary_are_included() -> None:
+    transcript = (
+        _segment("open", 0, 10, "First half of the bounded thought"),
+        _segment("close", 10, 20, "concludes at the end of the window."),
+    )
+
+    boundary = (
+        SourceSignal(kind="scene_change", timestamp=0.0, score=0.5),
+        SourceSignal(kind="audio_energy", timestamp=20.0, score=0.5, label="end"),
+    )
+
+    candidate = discover_highlights(
+        transcript, signals=boundary, config=_config(minimum=5, maximum=30, clips=1)
+    ).candidates[0]
+
+    assert {signal.timestamp for signal in candidate.source_signals} == {0.0, 20.0}
+
+
+# --- Monotonic transcript contract (GLM finding 2) --------------------------
+
+
+def test_strictly_decreasing_segments_raise_value_error() -> None:
+    transcript = (
+        _segment("first", 20, 30, "The second segment starts before the first."),
+        _segment("second", 10, 20, "This is intentionally out of order."),
+    )
+
+    with pytest.raises(ValueError, match="monotonic"):
+        discover_highlights(transcript, config=_config())
+
+
+def test_equal_segment_offsets_are_allowed() -> None:
+    transcript = (
+        _segment("first", 0, 10, "First segment ends here."),
+        _segment("second", 0, 5, "Second segment shares the anchor."),
+        _segment("third", 5, 15, "Third segment ends here."),
+    )
+
+    result = discover_highlights(transcript, config=_config(minimum=5))
+
+    assert len(result.candidates) >= 1
+
+
+def test_strictly_decreasing_segments_inside_batch_raise_value_error() -> None:
+    transcript = (
+        _segment("a", 0, 10, "Anchored at zero ends here."),
+        _segment("b", 5, 15, "Overlaps but stays non-decreasing."),
+        _segment("c", 3, 12, "Walks back below b and triggers the contract."),
+    )
+
+    with pytest.raises(ValueError, match="monotonic"):
+        discover_highlights(transcript, config=_config(minimum=5))
+
+
+# --- Distinct, non-degenerate title and hook (GLM finding 3) ----------------
+
+
+def test_title_does_not_truncate_at_abbreviation_period() -> None:
+    transcript = (_segment("abbrev", 0, 10, "Dr. Smith explains the answer here."),)
+
+    candidate = discover_highlights(transcript, config=_config(minimum=5)).candidates[0]
+
+    assert candidate.suggested_title == "Dr. Smith explains the answer here."
+    assert not candidate.suggested_title.endswith("Dr.")
+    assert "Dr." in candidate.suggested_title
+
+
+def test_title_does_not_truncate_at_decimal_point() -> None:
+    transcript = (_segment("decimal", 0, 10, "The result was 3.14 percent improvement."),)
+
+    candidate = discover_highlights(transcript, config=_config(minimum=5)).candidates[0]
+
+    assert candidate.suggested_title == "The result was 3.14 percent improvement."
+    # The title must not end on a bare "3." — that would be a degenerate lead.
+    assert not candidate.suggested_title.rstrip(".").endswith("3")
+
+
+def test_title_does_not_truncate_at_capital_initial() -> None:
+    transcript = (_segment("initial", 0, 10, "J. R. R. Tolkien wrote the book."),)
+
+    candidate = discover_highlights(transcript, config=_config(minimum=5)).candidates[0]
+
+    assert candidate.suggested_title == "J. R. R. Tolkien wrote the book."
+    assert candidate.suggested_title != "J."  # not a degenerate single-initial lead
+
+
+def test_title_and_hook_are_distinct_when_excerpt_has_multiple_sentences() -> None:
+    transcript = (_segment("multi", 0, 20, "First sentence is the lead. Second sentence is the hook."),)
+
+    candidate = discover_highlights(transcript, config=_config(minimum=5)).candidates[0]
+
+    assert candidate.suggested_title == "First sentence is the lead."


### PR DESCRIPTION
Progresses #403; stacked on #415.

Adds the first candidate-discovery slice:
- deterministic transcript-window discovery over reviewed domain contracts
- complete-thought and bounded-duration selection with leading-silence exclusion
- canonical deduplication and stable confidence/time ordering
- preserved in-window source signals without enrichment heuristics
- behavior coverage for determinism, three-candidate discovery, empty/silent input, payoff boundaries, bounds, deduplication, and ordering

Exact stacked diff: 299 additions across two files. Focused verification: 86 passed across discovery and the complete long-form stack; Ruff and diff checks pass.

Draft pending exact-head hosted CI and required GLM 5.2 ULTRACODE adversarial review. PR #400 remains a draft review-only umbrella and must never merge.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/kinocut/pr/416"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787370107&installation_model_id=20207&pr_number=416&repository=KyaniteLabs%2Fkinocut&return_to=https%3A%2F%2Fgithub.com%2FKyaniteLabs%2Fkinocut%2Fpull%2F416&signature=d1b0136e3642f1157dec4c035a6336cfe4d346efaf1cdbceb3bb6c117645a35f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->