### PR TITLE
feat: enrich candidate editorial evidence

### DIFF
--- a/kinocut/product/highlight_discovery.py
+++ b/kinocut/product/highlight_discovery.py
@@ -1,6 +1,6 @@
-"""Deterministic transcript-only highlight candidate discovery.
+"""Deterministic, evidence-grounded highlight candidate discovery.
 
-Core slice contract (the only behaviour tests touch):
+Discovery contract:
 
 * **Monotonic input** — segments are accepted only when their ``start`` is
   non-decreasing.  Strictly-decreasing inputs raise ``ValueError`` so callers
@@ -8,7 +8,8 @@ Core slice contract (the only behaviour tests touch):
 * **In-window signal preservation** — ``SourceSignal`` entries whose timestamp
   falls inside ``[anchor.start, end_segment.end]`` (inclusive on both ends) are
   preserved on the candidate, sorted deterministically, and out-of-window
-  signals are excluded.  Signal presence never changes discovery or ordering.
+  signals are excluded.  In-window evidence may truthfully affect confidence
+  and therefore candidate ordering.
 * **Bounded complete-thought windows** — every candidate window obeys
   ``min_duration <= end - start <= max_duration`` and ends at a terminal mark
   (``.``, ``!``, ``?``) so the rendered clip resolves rather than trailing off.
@@ -17,8 +18,8 @@ Core slice contract (the only behaviour tests touch):
   is allowed to degenerate to a known abbreviation ("Dr."), a single capital
   initial ("U. S. A."), or a decimal point ("3.14").
 
-This slice is deliberately transcript-only: enrichment, sensitivity escalation,
-and review warnings are owned by the later enrichment slice.
+Transcript evidence remains authoritative; enrichment adds bounded signal
+weighting, sensitivity escalation, context, rationale, and review warnings.
 """
 
 from __future__ import annotations
@@ -58,6 +59,8 @@ _BOUNDARY_TERMINAL_RE = re.compile(r"[.!?](?:[\"')\]]+)?\s*$")
 _INNER_TERMINAL_RE = re.compile(r"[.!?](?:[\"')\]]+)?(?=\s|$)")
 _CHAR_LIMIT_TITLE = 80
 _CHAR_LIMIT_HOOK = 160
+_UNSAFE_RE = re.compile(r"\b(?:suicide|self-harm|kill|murder|overdose)\b", re.IGNORECASE)
+_UNSAFE_WARNING = "Unsafe or sensitive transcript terms require editorial review."
 
 
 def discover_highlights(
@@ -66,11 +69,13 @@ def discover_highlights(
     signals: Sequence[SourceSignal] = (),
     config: HighlightDiscoveryConfig | None = None,
 ) -> HighlightDiscoveryResult:
-    """Discover bounded, complete-thought candidates from ordered segments.
+    """Discover bounded, complete-thought candidates with editorial evidence.
 
-    Candidate confidence is deliberately transcript-only. Signals that fall in a
-    selected window are preserved as evidence for a later enrichment stage, but
-    do not change discovery or ordering in this core slice.
+    Candidate confidence is transcript-only at the base; in-window signals are
+    blended in via ``HighlightDiscoveryConfig.signal_weight`` so the same
+    transcript re-discovered with a richer signal set produces a strictly
+    ordered set of candidates.  Sensitivity escalation, context, rationale,
+    and review warnings are attached as evidence without inventing copy.
 
     Raises:
         ValueError: when any adjacent pair of segments has ``current.start <
@@ -131,12 +136,12 @@ def _candidate_for_anchor(
         return None
     end_segment = segments[end_index]
     excerpt = " ".join(parts)
-    confidence = _transcript_score(excerpt)
+    sensitivity = "unsafe" if _UNSAFE_RE.search(excerpt) else "none"
     key = canonical_dedup_key(
         start=anchor.start,
         end=end_segment.end,
         excerpt=excerpt,
-        sensitivity="none",
+        sensitivity=sensitivity,
     )
     title = _excerpt_title(excerpt)
     hook = _excerpt_hook(excerpt)
@@ -154,6 +159,12 @@ def _candidate_for_anchor(
             ),
         )
     )
+    confidence = _confidence(excerpt, window_signals, config.signal_weight)
+    signal_kinds = ", ".join(sorted({signal.kind for signal in window_signals}))
+    rationale = "Complete transcript thought"
+    if signal_kinds:
+        rationale += f" with in-window {signal_kinds} evidence"
+    rationale += "."
     return CandidateMoment(
         candidate_id=_candidate_id(anchor.segment_id, key),
         start=anchor.start,
@@ -161,14 +172,14 @@ def _candidate_for_anchor(
         transcript_excerpt=excerpt,
         suggested_title=title,
         suggested_hook=hook,
-        rationale=(
-            f"Transcript window from {anchor.start:.2f}s to {end_segment.end:.2f}s "
-            "meets the duration bounds and ends at a complete thought."
-        ),
+        rationale=rationale,
         confidence=confidence,
+        review_warning=_UNSAFE_WARNING if sensitivity == "unsafe" else None,
+        context_before=_adjacent_context(segments, anchor_index - 1),
+        context_after=_adjacent_context(segments, end_index + 1),
         dedup_key=key,
-        sensitivity="none",
-        unsuitable=False,
+        sensitivity=sensitivity,
+        unsuitable=sensitivity == "unsafe",
         source_signals=window_signals,
     )
 
@@ -199,6 +210,20 @@ def _transcript_score(excerpt: str) -> float:
     density = min(1.0, words / 60.0)
     completeness = min(1.0, terminals / 2.0)
     return round(min(1.0, 0.6 * density + 0.4 * completeness), 4)
+
+
+def _confidence(excerpt: str, signals: tuple[SourceSignal, ...], weight: float) -> float:
+    transcript_score = _transcript_score(excerpt)
+    if not signals:
+        return transcript_score
+    signal_score = max(signal.score for signal in signals)
+    return round((1.0 - weight) * transcript_score + weight * signal_score, 4)
+
+
+def _adjacent_context(segments: tuple[TranscriptSegment, ...], index: int) -> str | None:
+    if 0 <= index < len(segments):
+        return segments[index].text.strip() or None
+    return None
 
 
 def _excerpt_title(excerpt: str) -> str:

--- a/tests/test_highlight_discovery_enrichment.py
+++ b/tests/test_highlight_discovery_enrichment.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+from kinocut.product.highlight_discovery import discover_highlights
+from kinocut.product.models import HighlightDiscoveryConfig, SourceSignal, TranscriptSegment
+
+
+def _segment(segment_id: str, start: float, text: str) -> TranscriptSegment:
+    return TranscriptSegment(segment_id=segment_id, start=start, end=start + 10, text=text)
+
+
+def _config(*, clips: int = 8, signal_weight: float = 0.25) -> HighlightDiscoveryConfig:
+    return HighlightDiscoveryConfig(
+        min_duration=5,
+        max_duration=15,
+        max_clips=clips,
+        signal_weight=signal_weight,
+    )
+
+
+def _candidate(
+    transcript: tuple[TranscriptSegment, ...],
+    *,
+    start: float,
+    signals: tuple[SourceSignal, ...] = (),
+    config: HighlightDiscoveryConfig | None = None,
+):
+    return next(
+        item
+        for item in discover_highlights(transcript, signals=signals, config=config or _config()).candidates
+        if item.start == start
+    )
+
+
+def test_context_is_the_immediately_adjacent_transcript() -> None:
+    transcript = (
+        _segment("before", 0, "The discussion starts here."),
+        _segment("focus", 10, "The central finding is concise and complete."),
+        _segment("after", 20, "The discussion continues here."),
+    )
+
+    candidate = _candidate(transcript, start=10)
+
+    assert candidate.context_before == transcript[0].text
+    assert candidate.context_after == transcript[2].text
+
+
+def test_context_at_source_edges_is_absent() -> None:
+    transcript = (
+        _segment("first", 0, "The first bounded idea is complete."),
+        _segment("last", 10, "The last bounded idea is complete."),
+    )
+
+    assert _candidate(transcript, start=0).context_before is None
+    assert _candidate(transcript, start=10).context_after is None
+
+
+def test_editorial_copy_only_uses_excerpt_words() -> None:
+    transcript = (
+        _segment(
+            "focus",
+            0,
+            "Careful editors preserve every original phrase while choosing a concise opening for viewers today.",
+        ),
+    )
+    candidate = _candidate(transcript, start=0)
+    excerpt_words = set(candidate.transcript_excerpt.split())
+
+    assert set(candidate.suggested_title.split()) <= excerpt_words
+    assert set(candidate.suggested_hook.split()) <= excerpt_words
+
+
+def test_only_in_window_signals_blend_confidence() -> None:
+    transcript = (_segment("focus", 10, "A short but complete finding lands clearly."),)
+    inside = SourceSignal(kind="audio_energy", timestamp=15, score=1.0)
+    outside = SourceSignal(kind="audio_energy", timestamp=30, score=1.0)
+    baseline = _candidate(transcript, start=10)
+
+    enriched = _candidate(transcript, start=10, signals=(outside, inside), config=_config(signal_weight=0.5))
+    unchanged = _candidate(transcript, start=10, signals=(outside,), config=_config(signal_weight=0.5))
+
+    assert enriched.source_signals == (inside,)
+    assert enriched.confidence == round(0.5 * baseline.confidence + 0.5, 4)
+    assert unchanged.confidence == baseline.confidence
+
+
+def test_unsafe_term_blocks_candidate_with_stable_warning() -> None:
+    transcript = (_segment("risk", 0, "The report discusses suicide prevention and support."),)
+
+    first = _candidate(transcript, start=0)
+    second = _candidate(transcript, start=0)
+
+    assert first.sensitivity == "unsafe"
+    assert first.unsuitable is True
+    assert first.review_warning == "Unsafe or sensitive transcript terms require editorial review."
+    assert second.review_warning == first.review_warning
+
+
+def test_duplicate_window_keeps_stable_identity_and_dedup() -> None:
+    transcript = (
+        _segment("copy-a", 0, "The same complete result appears here."),
+        _segment("copy-b", 0, "The same complete result appears here."),
+    )
+
+    first = discover_highlights(transcript, config=_config())
+    second = discover_highlights(transcript, config=_config())
+
+    assert len(first.candidates) == 1
+    assert first.candidates[0].dedup_key == second.candidates[0].dedup_key
+    assert first.candidates[0].candidate_id == second.candidates[0].candidate_id
+
+
+def test_core_duration_ordering_and_cap_are_preserved() -> None:
+    transcript = (
+        _segment("one", 0, "A compact complete thought lands."),
+        _segment("two", 10, "A much more detailed complete thought offers evidence and a useful conclusion."),
+        _segment("three", 20, "Another complete thought lands."),
+    )
+    result = discover_highlights(transcript, config=_config(clips=2))
+
+    assert len(result.candidates) == 2
+    assert all(5 <= item.end - item.start <= 15 for item in result.candidates)
+    assert [item.confidence for item in result.candidates] == sorted(
+        (item.confidence for item in result.candidates), reverse=True
+    )


### PR DESCRIPTION
Progresses #403; stacked on #416.

Completes candidate-discovery editorial evidence:
- adjacent before/after transcript context
- suggested title and hook built only from transcript words
- deterministic in-window signal contribution to confidence
- conservative unsafe-term escalation with unsuitable status and review warning
- explicit rationale naming complete-thought and in-window evidence
- stable sensitivity-aware dedup keys and candidate IDs

Exact stacked diff: 177 changed lines (+158/-19) across two files. Focused discovery plus complete long-form stack verification: 93 passed; Ruff and diff checks pass.

Draft pending exact-head hosted CI and required GLM 5.2 ULTRACODE adversarial review. PR #400 remains a draft review-only umbrella and must never merge.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/kinocut/pr/417"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787371237&installation_model_id=20207&pr_number=417&repository=KyaniteLabs%2Fkinocut&return_to=https%3A%2F%2Fgithub.com%2FKyaniteLabs%2Fkinocut%2Fpull%2F417&signature=7cb4934fb0acc7416f41fe653f28144e9109cc83919fd50af2c3c22c4daad1b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->