### PR TITLE
feat: generate editable phrase captions

### DIFF
--- a/kinocut/product/captions.py
+++ b/kinocut/product/captions.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Iterable, Mapping, Sequence
 from itertools import pairwise
+from typing import Any, Literal
 
 from pydantic import Field, model_validator
 
@@ -49,6 +50,28 @@ class PhraseCue(ValueObject):
         return self
 
 
+LowConfidencePolicy = Literal["omit", "flag"]
+
+
+class CaptionConfig(ValueObject):
+    """Immutable, bounded phrase-grouping policy."""
+
+    max_words_per_cue: int = Field(default=8, ge=1, le=100)
+    max_cue_duration: float = Field(default=4.0, gt=0.0, le=60.0)
+    low_confidence_threshold: float = Field(default=0.5, ge=0.0, le=1.0)
+    on_low_confidence: LowConfidencePolicy = "flag"
+
+
+class CaptionArtifact(ValueObject):
+    """Editable phrase cues and their deterministic SRT serialization."""
+
+    cues: tuple[PhraseCue, ...]
+    srt_body: str
+    warnings: tuple[str, ...]
+    low_confidence_token_count: int = Field(ge=0)
+    omitted_token_count: int = Field(ge=0)
+
+
 def build_srt_body(cues: Sequence[PhraseCue]) -> str:
     """Serialize ordered, non-overlapping cues into a stable SRT body."""
 
@@ -62,4 +85,98 @@ def build_srt_body(cues: Sequence[PhraseCue]) -> str:
     return "\n\n".join(blocks) + ("\n" if blocks else "")
 
 
-__all__ = ["PhraseCue", "WordTiming", "build_srt_body"]
+def build_caption_artifact(
+    words: Iterable[WordTiming | Mapping[str, Any]],
+    *,
+    config: CaptionConfig | None = None,
+) -> CaptionArtifact:
+    """Build truthful phrase cues without changing any source timestamp."""
+
+    cfg = config or CaptionConfig()
+    normalized = sorted((_coerce_word(item) for item in words), key=lambda word: word.start)
+    for previous, current in pairwise(normalized):
+        if current.start < previous.end:
+            raise ValueError("caption words must be unambiguously ordered and non-overlapping")
+
+    groups: list[list[WordTiming]] = []
+    current_group: list[WordTiming] = []
+    for word in normalized:
+        if word.end - word.start > cfg.max_cue_duration:
+            raise ValueError("a source word exceeds max_cue_duration and cannot be split truthfully")
+        exceeds_limit = current_group and (
+            len(current_group) >= cfg.max_words_per_cue or word.end - current_group[0].start > cfg.max_cue_duration
+        )
+        if exceeds_limit:
+            groups.append(current_group)
+            current_group = []
+        current_group.append(word)
+        if _is_clause_terminal(word.word):
+            groups.append(current_group)
+            current_group = []
+    if current_group:
+        groups.append(current_group)
+
+    cues: list[PhraseCue] = []
+    warnings: list[str] = []
+    low_confidence_count = 0
+    omitted_count = 0
+    for group in groups:
+        visible_tokens: list[str] = []
+        for word in group:
+            is_low_confidence = word.probability is not None and word.probability < cfg.low_confidence_threshold
+            if not is_low_confidence:
+                visible_tokens.append(word.word)
+                continue
+            low_confidence_count += 1
+            if cfg.on_low_confidence == "flag":
+                visible_tokens.append("[?]")
+            else:
+                omitted_count += 1
+        text = " ".join(visible_tokens).strip()
+        if not text:
+            if "empty_visible_cue_dropped" not in warnings:
+                warnings.append("empty_visible_cue_dropped")
+            continue
+        cues.append(
+            PhraseCue(
+                start=group[0].start,
+                end=group[-1].end,
+                text=text,
+                words=tuple(group),
+            )
+        )
+
+    if low_confidence_count:
+        action = "omitted" if cfg.on_low_confidence == "omit" else "flagged"
+        warnings.insert(0, f"low_confidence_tokens_{action}")
+    cue_tuple = tuple(cues)
+    return CaptionArtifact(
+        cues=cue_tuple,
+        srt_body=build_srt_body(cue_tuple),
+        warnings=tuple(warnings),
+        low_confidence_token_count=low_confidence_count,
+        omitted_token_count=omitted_count,
+    )
+
+
+def _coerce_word(item: WordTiming | Mapping[str, Any]) -> WordTiming:
+    if isinstance(item, WordTiming):
+        return item
+    if isinstance(item, Mapping):
+        return WordTiming.model_validate(item)
+    raise TypeError(f"expected WordTiming or mapping, got {type(item).__name__}")
+
+
+def _is_clause_terminal(text: str) -> bool:
+    return text.rstrip().rstrip("\"')]").endswith((".", "!", "?"))
+
+
+__all__ = [
+    "CaptionArtifact",
+    "CaptionConfig",
+    "LowConfidencePolicy",
+    "PhraseCue",
+    "WordTiming",
+    "build_caption_artifact",
+    "build_srt_body",
+]

--- a/tests/test_captions_grouping.py
+++ b/tests/test_captions_grouping.py
@@ -1,0 +1,167 @@
+"""Behavior tests for deterministic phrase-level caption artifacts."""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+from pydantic import ValidationError
+
+from kinocut.product.captions import CaptionConfig, WordTiming, build_caption_artifact
+
+
+def _word(
+    text: str,
+    start: float,
+    end: float,
+    probability: float | None = None,
+) -> WordTiming:
+    return WordTiming(word=text, start=start, end=end, probability=probability)
+
+
+def test_groups_words_into_editable_phrase_cues() -> None:
+    words = [_word("Hello", 0.1, 0.4), _word("there", 0.5, 0.9)]
+
+    artifact = build_caption_artifact(words)
+
+    assert artifact.cues[0].text == "Hello there"
+    assert artifact.cues[0].words == tuple(words)
+    assert artifact.srt_body.endswith("Hello there\n")
+
+
+def test_clause_terminal_punctuation_closes_phrase() -> None:
+    words = [_word("One.", 0.0, 0.4), _word("Two", 0.5, 0.9), _word("three?", 1.0, 1.4)]
+
+    artifact = build_caption_artifact(words)
+
+    assert [cue.text for cue in artifact.cues] == ["One.", "Two three?"]
+
+
+def test_word_and_duration_bounds_split_without_changing_times() -> None:
+    config = CaptionConfig(max_words_per_cue=2, max_cue_duration=1.0)
+    words = [
+        _word("a", 0.0, 0.2),
+        _word("b", 0.3, 0.5),
+        _word("c", 0.6, 0.8),
+        _word("d", 1.5, 1.8),
+    ]
+
+    artifact = build_caption_artifact(words, config=config)
+
+    assert [(cue.start, cue.end, cue.text) for cue in artifact.cues] == [
+        (0.0, 0.5, "a b"),
+        (0.6, 0.8, "c"),
+        (1.5, 1.8, "d"),
+    ]
+
+
+def test_srt_is_parseable_and_monotonic() -> None:
+    artifact = build_caption_artifact([_word("First.", 0.125, 0.875), _word("Second.", 1.0, 1.75)])
+    blocks = artifact.srt_body.strip().split("\n\n")
+    timestamp = re.compile(r"^\d{2}:\d{2}:\d{2},\d{3} --> \d{2}:\d{2}:\d{2},\d{3}$")
+
+    assert [block.splitlines()[0] for block in blocks] == ["1", "2"]
+    assert all(timestamp.fullmatch(block.splitlines()[1]) for block in blocks)
+    assert blocks[0].splitlines()[1].split(" --> ")[1] <= blocks[1].splitlines()[1].split(" --> ")[0]
+
+
+def test_mapping_input_is_coerced_to_word_timing() -> None:
+    artifact = build_caption_artifact([{"word": "mapped", "start": 0.0, "end": 0.4, "probability": 0.8}])
+
+    assert artifact.cues[0].words == (_word("mapped", 0.0, 0.4, 0.8),)
+
+
+def test_low_confidence_flag_is_canonical_and_metadata_is_truthful() -> None:
+    source = _word("uncertain", 0.0, 0.4, 0.2)
+    artifact = build_caption_artifact(
+        [source],
+        config=CaptionConfig(low_confidence_threshold=0.5, on_low_confidence="flag"),
+    )
+
+    assert artifact.cues[0].text == "[?]"
+    assert artifact.cues[0].words == (source,)
+    assert artifact.low_confidence_token_count == 1
+    assert artifact.omitted_token_count == 0
+
+
+def test_low_confidence_omit_retains_metadata_and_counts() -> None:
+    hidden = _word("uncertain", 0.4, 0.8, 0.2)
+    artifact = build_caption_artifact(
+        [_word("keep", 0.0, 0.3, 0.9), hidden],
+        config=CaptionConfig(low_confidence_threshold=0.5, on_low_confidence="omit"),
+    )
+
+    assert artifact.cues[0].text == "keep"
+    assert artifact.cues[0].words[1] == hidden
+    assert artifact.low_confidence_token_count == 1
+    assert artifact.omitted_token_count == 1
+
+
+def test_empty_visible_cue_is_dropped_with_warning() -> None:
+    artifact = build_caption_artifact(
+        [_word("hidden.", 0.0, 0.4, 0.1)],
+        config=CaptionConfig(on_low_confidence="omit"),
+    )
+
+    assert artifact.cues == ()
+    assert artifact.srt_body == ""
+    assert "empty_visible_cue_dropped" in artifact.warnings
+    assert artifact.omitted_token_count == 1
+
+
+def test_unknown_confidence_is_preserved_and_visible() -> None:
+    artifact = build_caption_artifact([_word("unknown", 0.0, 0.4)])
+
+    assert artifact.cues[0].text == "unknown"
+    assert artifact.cues[0].words[0].probability is None
+    assert artifact.low_confidence_token_count == 0
+
+
+def test_empty_input_returns_empty_editable_artifact() -> None:
+    artifact = build_caption_artifact([])
+
+    assert artifact.cues == ()
+    assert artifact.srt_body == ""
+    assert artifact.warnings == ()
+
+
+def test_ambiguous_overlap_is_rejected_after_sorting() -> None:
+    words = [_word("later", 0.4, 0.8), _word("earlier", 0.0, 0.5)]
+
+    with pytest.raises(ValueError, match="unambiguously ordered"):
+        build_caption_artifact(words)
+
+
+def test_non_overlapping_input_is_sorted_deterministically() -> None:
+    words = [_word("second", 0.5, 0.9), _word("first", 0.0, 0.4)]
+
+    first = build_caption_artifact(words)
+    second = build_caption_artifact(words)
+
+    assert first == second
+    assert first.cues[0].text == "first second"
+
+
+def test_no_cumulative_timing_drift_over_sixty_seconds() -> None:
+    words = [_word(f"w{index}", index / 10, (index + 1) / 10) for index in range(600)]
+
+    artifact = build_caption_artifact(words)
+    flattened = [word for cue in artifact.cues for word in cue.words]
+
+    assert flattened == words
+    assert artifact.cues[0].start == words[0].start
+    assert artifact.cues[-1].end == words[-1].end == 60.0
+
+
+@pytest.mark.parametrize(
+    "values",
+    [
+        {"max_words_per_cue": 0},
+        {"max_cue_duration": float("inf")},
+        {"low_confidence_threshold": float("nan")},
+        {"on_low_confidence": "replace"},
+    ],
+)
+def test_config_is_bounded_and_closed(values: dict[str, object]) -> None:
+    with pytest.raises(ValidationError):
+        CaptionConfig(**values)


### PR DESCRIPTION
Progresses #403; stacked on #418.

Adds mandatory editable phrase-caption artifacts:
- bounded phrase grouping by word count, duration, and punctuation
- deterministic monotonic SRT with unchanged source timings
- low-confidence `flag` and `omit` policies that retain truthful source metadata
- canonical `[?]` flags rather than invented replacement words
- explicit warnings/counts for uncertain or empty visible cues
- mapping coercion, overlap rejection, and zero-drift coverage over 60 seconds

Exact stacked diff: 288 changed lines (+286/-2) across two files. Caption/discovery verification: 68 passed; Ruff and diff checks pass.

Draft pending exact-head hosted CI and required GLM 5.2 ULTRACODE adversarial review. Burn-in remains optional and outside this slice; PR #400 remains a draft review-only umbrella and must never merge.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/kinocut/pr/419"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787372428&installation_model_id=20207&pr_number=419&repository=KyaniteLabs%2Fkinocut&return_to=https%3A%2F%2Fgithub.com%2FKyaniteLabs%2Fkinocut%2Fpull%2F419&signature=8afc824e0b4856117aa6de7794e3236f146755bed630c08874942e6cad5f2cfb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->