### PR TITLE
feat: block unsafe caption placements

### DIFF
--- a/kinocut/product/captions.py
+++ b/kinocut/product/captions.py
@@ -1,4 +1,4 @@
-"""Strict caption timing contracts and deterministic SRT serialization."""
+"""Strict caption timing contracts, deterministic SRT serialization, and safe-placement planner."""
 
 from __future__ import annotations
 
@@ -171,12 +171,149 @@ def _is_clause_terminal(text: str) -> bool:
     return text.rstrip().rstrip("\"')]").endswith((".", "!", "?"))
 
 
+# ---------------------------------------------------------------------------
+# Safe caption placement (issue #403)
+# ---------------------------------------------------------------------------
+# Burn-in is opt-in: ``plan_caption_placement`` only produces reviewable
+# placement evidence for the existing burn_in operator to consume later. It
+# never invokes ``kinocut.engine_subtitles`` or any other engine op.
+
+_HEX_COLOR_PATTERN = r"^#[0-9A-Fa-f]{6}$"
+CaptionStatus = Literal["ready", "blocked"]
+
+
+class CaptionRegion(ValueObject):
+    """Normalized caption rectangle: positive area, contained in the unit frame."""
+
+    x: float = Field(ge=0.0, le=1.0)
+    y: float = Field(ge=0.0, le=1.0)
+    width: float = Field(gt=0.0, le=1.0)
+    height: float = Field(gt=0.0, le=1.0)
+
+    @model_validator(mode="after")
+    def _stays_within_frame(self) -> CaptionRegion:
+        """Reject rectangles whose far edges leave the unit frame."""
+
+        if self.x + self.width > 1.0 or self.y + self.height > 1.0:
+            raise ValueError("region must stay within the unit frame")
+        return self
+
+
+class CaptionAppearance(ValueObject):
+    """Bounded, immutable visual treatment for a placed caption."""
+
+    font_family: str = Field(min_length=1, max_length=128)
+    font_size: int = Field(ge=8, le=200)
+    text_color: str = Field(pattern=_HEX_COLOR_PATTERN)
+    background_color: str = Field(pattern=_HEX_COLOR_PATTERN)
+
+
+class CaptionPlacement(ValueObject):
+    """Reviewable evidence describing a chosen (or blocked) caption placement."""
+
+    region: CaptionRegion | None = None
+    appearance: CaptionAppearance
+    status: CaptionStatus
+    warning: str | None = None
+    burn_in_requested: bool = False
+
+    @model_validator(mode="after")
+    def _status_matches_region(self) -> CaptionPlacement:
+        """A ready placement must carry a region; a blocked placement must warn."""
+
+        if self.status == "ready":
+            if self.region is None:
+                raise ValueError("ready placement requires a region")
+            if self.warning is not None:
+                raise ValueError("ready placement must not carry a warning")
+        else:
+            if self.region is not None:
+                raise ValueError("blocked placement must not select a region")
+            if not self.warning:
+                raise ValueError("blocked placement must include actionable warning")
+        return self
+
+
+_DEFAULT_APPEARANCE = CaptionAppearance(
+    font_family="Inter",
+    font_size=42,
+    text_color="#FFFFFF",
+    background_color="#000000",
+)
+
+
+def plan_caption_placement(
+    *,
+    candidate_regions: Sequence[CaptionRegion],
+    face_regions: Sequence[CaptionRegion] = (),
+    product_regions: Sequence[CaptionRegion] = (),
+    overlay_regions: Sequence[CaptionRegion] = (),
+    appearance: CaptionAppearance | None = None,
+    burn_in_requested: bool = False,
+) -> CaptionPlacement:
+    """Pick the first safe ``CaptionRegion`` or block the placement deterministically.
+
+    A candidate is safe when it has zero positive-area intersection with every
+    exclusion region (face, product, platform overlay). Touching edges are
+    allowed. When every candidate collides the result has ``status="blocked"``
+    with no region and an actionable warning -- never a placement over
+    exclusions. Inputs are normalized to deeply immutable tuples so the planner
+    is stable across runs and cannot mutate a caller's collection.
+    """
+
+    candidates = _freeze_regions(candidate_regions)
+    if not candidates:
+        raise ValueError("candidate_regions must be a non-empty sequence")
+    exclusions = _freeze_regions(face_regions) + _freeze_regions(product_regions) + _freeze_regions(overlay_regions)
+    chosen_appearance = appearance or _DEFAULT_APPEARANCE
+    for candidate in candidates:
+        if not any(_has_positive_overlap(candidate, region) for region in exclusions):
+            return CaptionPlacement(
+                region=candidate,
+                appearance=chosen_appearance,
+                status="ready",
+                burn_in_requested=burn_in_requested,
+            )
+    return CaptionPlacement(
+        region=None,
+        appearance=chosen_appearance,
+        status="blocked",
+        warning=(f"no_safe_caption_region:candidates={len(candidates)}:exclusions={len(exclusions)}"),
+        burn_in_requested=burn_in_requested,
+    )
+
+
+def _freeze_regions(regions: Sequence[CaptionRegion]) -> tuple[CaptionRegion, ...]:
+    """Validate and freeze a region sequence, preserving tuple immutability."""
+
+    materialised = tuple(regions)
+    for region in materialised:
+        if not isinstance(region, CaptionRegion):
+            raise TypeError("region inputs must be CaptionRegion instances")
+    return materialised
+
+
+def _has_positive_overlap(candidate: CaptionRegion, region: CaptionRegion) -> bool:
+    """Return ``True`` iff two rectangles share strictly-positive interior area."""
+
+    left = max(candidate.x, region.x)
+    bottom = max(candidate.y, region.y)
+    right = min(candidate.x + candidate.width, region.x + region.width)
+    top = min(candidate.y + candidate.height, region.y + region.height)
+    return right > left and top > bottom
+
+
 __all__ = [
+    "CaptionAppearance",
     "CaptionArtifact",
     "CaptionConfig",
+    "CaptionPlacement",
+    "CaptionRegion",
+    "CaptionStatus",
     "LowConfidencePolicy",
     "PhraseCue",
     "WordTiming",
     "build_caption_artifact",
     "build_srt_body",
+    "plan_caption_placement",
 ]

--- a/kinocut/product/captions.py
+++ b/kinocut/product/captions.py
@@ -119,6 +119,7 @@ def build_caption_artifact(
     cues: list[PhraseCue] = []
     warnings: list[str] = []
     low_confidence_count = 0
+    flagged_count = 0
     omitted_count = 0
     for group in groups:
         visible_tokens: list[str] = []
@@ -130,6 +131,7 @@ def build_caption_artifact(
             low_confidence_count += 1
             if cfg.on_low_confidence == "flag":
                 visible_tokens.append("[?]")
+                flagged_count += 1
             else:
                 omitted_count += 1
         text = " ".join(visible_tokens).strip()
@@ -146,9 +148,10 @@ def build_caption_artifact(
             )
         )
 
-    if low_confidence_count:
-        action = "omitted" if cfg.on_low_confidence == "omit" else "flagged"
-        warnings.insert(0, f"low_confidence_tokens_{action}")
+    if flagged_count:
+        warnings.insert(0, "low_confidence_tokens_flagged")
+    elif omitted_count:
+        warnings.insert(0, "low_confidence_tokens_omitted")
     cue_tuple = tuple(cues)
     return CaptionArtifact(
         cues=cue_tuple,

--- a/tests/test_captions_placement.py
+++ b/tests/test_captions_placement.py
@@ -1,0 +1,175 @@
+"""Behavior tests for deterministic safe caption placement (issue #403)."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from kinocut.product.captions import (
+    CaptionAppearance,
+    CaptionRegion,
+    plan_caption_placement,
+)
+
+
+def _region(x: float, y: float, width: float, height: float) -> CaptionRegion:
+    return CaptionRegion(x=x, y=y, width=width, height=height)
+
+
+def _default_appearance() -> CaptionAppearance:
+    return CaptionAppearance(font_family="Inter", font_size=42, text_color="#FFFFFF", background_color="#000000")
+
+
+def test_first_candidate_is_preferred_when_it_is_safe() -> None:
+    candidates = [_region(0.0, 0.8, 1.0, 0.1), _region(0.0, 0.4, 1.0, 0.1)]
+
+    placement = plan_caption_placement(candidate_regions=candidates)
+
+    assert placement.status == "ready"
+    assert placement.region == candidates[0]
+    assert placement.burn_in_requested is False
+
+
+def test_face_product_and_overlay_exclusions_are_each_avoided() -> None:
+    # face: first candidate overlaps the face; second does not
+    next_face = plan_caption_placement(
+        candidate_regions=[_region(0.0, 0.8, 1.0, 0.1), _region(0.0, 0.55, 1.0, 0.1)],
+        face_regions=[_region(0.0, 0.75, 1.0, 0.1)],
+    )
+    assert next_face.region == _region(0.0, 0.55, 1.0, 0.1)
+
+    # product: middle candidate overlaps the logo; bottom avoids it
+    next_product = plan_caption_placement(
+        candidate_regions=[_region(0.0, 0.8, 1.0, 0.1), _region(0.0, 0.6, 1.0, 0.1)],
+        product_regions=[_region(0.05, 0.78, 0.2, 0.05)],
+    )
+    assert next_product.region == _region(0.0, 0.6, 1.0, 0.1)
+
+    # platform overlay: top candidate overlaps the overlay; bottom avoids it
+    next_overlay = plan_caption_placement(
+        candidate_regions=[_region(0.0, 0.9, 1.0, 0.1), _region(0.0, 0.05, 1.0, 0.1)],
+        overlay_regions=[_region(0.0, 0.85, 1.0, 0.1)],
+    )
+    assert next_overlay.region == _region(0.0, 0.05, 1.0, 0.1)
+
+
+def test_face_product_and_overlay_exclusions_are_combined() -> None:
+    candidates = [_region(0.0, 0.9, 1.0, 0.05), _region(0.0, 0.7, 1.0, 0.05), _region(0.0, 0.5, 1.0, 0.05)]
+
+    placement = plan_caption_placement(
+        candidate_regions=candidates,
+        face_regions=[_region(0.0, 0.88, 1.0, 0.05)],
+        product_regions=[_region(0.0, 0.68, 1.0, 0.05)],
+    )
+
+    assert placement.region == candidates[2]
+
+
+def test_edge_touching_is_not_treated_as_overlap() -> None:
+    candidate = _region(0.0, 0.9, 0.5, 0.1)
+    face = _region(0.5, 0.9, 0.5, 0.1)
+
+    placement = plan_caption_placement(candidate_regions=[candidate], face_regions=[face])
+
+    assert placement.status == "ready"
+    assert placement.region == candidate
+
+
+def test_when_no_candidate_is_safe_placement_blocks_with_actionable_warning() -> None:
+    placement = plan_caption_placement(
+        candidate_regions=[_region(0.0, 0.8, 1.0, 0.1)],
+        face_regions=[_region(0.0, 0.0, 1.0, 1.0)],
+        burn_in_requested=True,
+    )
+
+    assert placement.status == "blocked"
+    assert placement.region is None
+    assert placement.warning is not None
+    assert placement.warning.startswith("no_safe_caption_region")
+    assert placement.burn_in_requested is True
+
+
+def test_empty_candidate_list_fails_closed() -> None:
+    with pytest.raises(ValueError, match="non-empty"):
+        plan_caption_placement(candidate_regions=[])
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"x": -0.01, "y": 0.0, "width": 0.5, "height": 0.1},  # negative origin
+        {"x": 0.0, "y": 0.0, "width": 0.0, "height": 0.1},  # zero width (degenerate)
+        {"x": 0.0, "y": 0.0, "width": 1.5, "height": 0.1},  # oversized width
+        {"x": 0.5, "y": 0.0, "width": 0.6, "height": 0.1},  # out of frame
+        {"x": 0.9, "y": 0.0, "width": 0.5, "height": 0.1},  # exclusion out of frame
+        {"x": 0.1, "y": 0.1, "width": 0.0, "height": 0.2},  # zero-height degenerate
+    ],
+)
+def test_invalid_and_out_of_frame_regions_are_rejected(kwargs: dict[str, float]) -> None:
+    with pytest.raises(ValidationError):
+        CaptionRegion(**kwargs)
+
+
+def test_appearance_is_configurable_and_bounded() -> None:
+    placement = plan_caption_placement(
+        candidate_regions=[_region(0.0, 0.8, 1.0, 0.1)],
+        appearance=CaptionAppearance(
+            font_family="Roboto Mono", font_size=72, text_color="#FFAA00", background_color="#112233"
+        ),
+    )
+    assert placement.appearance.font_family == "Roboto Mono"
+    assert placement.appearance.font_size == 72
+
+    with pytest.raises(ValidationError):
+        CaptionAppearance(font_family="", font_size=42, text_color="#FFFFFF", background_color="#000000")
+    with pytest.raises(ValidationError):
+        CaptionAppearance(font_family="X", font_size=999, text_color="#FFFFFF", background_color="#000000")
+    with pytest.raises(ValidationError):
+        CaptionAppearance(font_family="X", font_size=42, text_color="white", background_color="#000000")
+
+
+def test_burn_in_defaults_off_and_can_be_opted_in() -> None:
+    default = plan_caption_placement(candidate_regions=[_region(0.0, 0.8, 1.0, 0.1)])
+    explicit = plan_caption_placement(candidate_regions=[_region(0.0, 0.8, 1.0, 0.1)], burn_in_requested=True)
+
+    assert default.burn_in_requested is False
+    assert explicit.burn_in_requested is True
+    assert default.status == explicit.status == "ready"
+
+
+def test_planner_is_deterministic_across_repeated_calls() -> None:
+    candidates = (
+        _region(0.0, 0.9, 1.0, 0.05),
+        _region(0.0, 0.7, 1.0, 0.05),
+        _region(0.0, 0.5, 1.0, 0.05),
+    )
+    faces = (_region(0.0, 0.88, 1.0, 0.05),)
+
+    first = plan_caption_placement(candidate_regions=candidates, face_regions=faces)
+    second = plan_caption_placement(candidate_regions=candidates, face_regions=faces)
+
+    assert first == second
+    assert first.model_dump() == second.model_dump()
+
+
+def test_placement_and_regions_are_deeply_immutable() -> None:
+    placement = plan_caption_placement(candidate_regions=[_region(0.0, 0.8, 1.0, 0.1)])
+
+    with pytest.raises(ValidationError):
+        placement.region = None  # type: ignore[misc]
+    with pytest.raises(ValidationError):
+        placement.burn_in_requested = True  # type: ignore[misc]
+    replacement = placement.model_copy(update={"burn_in_requested": True})
+    assert replacement.burn_in_requested is True
+    assert placement.burn_in_requested is False
+
+
+def test_input_sequences_are_materialized_as_immutable_tuples() -> None:
+    candidates = [_region(0.0, 0.8, 1.0, 0.1)]
+    faces: list[CaptionRegion] = []
+
+    placement = plan_caption_placement(candidate_regions=candidates, face_regions=faces)
+
+    candidates.clear()
+    faces.append(_region(0.0, 0.0, 1.0, 1.0))
+    assert placement.status == "ready"

--- a/tests/test_captions_word_timed.py
+++ b/tests/test_captions_word_timed.py
@@ -1,0 +1,43 @@
+"""Behavior tests for the truthful low-confidence warning contract (issue #420)."""
+
+from __future__ import annotations
+
+from kinocut.product.captions import (
+    CaptionConfig,
+    WordTiming,
+    build_caption_artifact,
+)
+
+
+def _word(text: str, start: float, end: float, probability: float | None) -> WordTiming:
+    return WordTiming(word=text, start=start, end=end, probability=probability)
+
+
+def test_all_confident_words_emit_no_low_confidence_warning() -> None:
+    words = [
+        _word("hello", 0.0, 0.5, 0.99),
+        _word("world", 0.5, 1.0, 0.95),
+    ]
+
+    artifact = build_caption_artifact(words)
+
+    assert artifact.low_confidence_token_count == 0
+    assert artifact.omitted_token_count == 0
+    assert artifact.warnings == ()
+
+
+def test_flag_policy_marks_flagged_warning_when_a_token_is_below_threshold() -> None:
+    words = [
+        _word("hello", 0.0, 0.5, 0.99),
+        _word("world", 0.5, 1.0, 0.2),
+    ]
+
+    artifact = build_caption_artifact(
+        words,
+        config=CaptionConfig(on_low_confidence="flag"),
+    )
+
+    assert artifact.low_confidence_token_count == 1
+    assert artifact.omitted_token_count == 0
+    assert artifact.warnings == ("low_confidence_tokens_flagged",)
+    assert any("[?]" in cue.text for cue in artifact.cues)


### PR DESCRIPTION
Progresses #403; stacked on #419.

Adds deterministic reviewable caption placement without touching PR #378 files:
- normalized in-frame caption/exclusion regions
- separate face, product, and platform-overlay avoidance
- first-safe deterministic preference with edge-touch allowance
- fail-closed blocked result when every candidate overlaps protected content
- immutable configurable appearance
- optional burn-in evidence, off by default, without invoking the subtitle engine

Exact stacked diff: 314 changed lines (+313/-1) across two files. Focused caption verification: 68 passed; Ruff and diff checks pass.

Draft pending exact-head hosted CI and required GLM 5.2 ULTRACODE adversarial review. PR #400 remains a draft review-only umbrella and must never merge.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/kinocut/pr/420"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787373128&installation_model_id=20207&pr_number=420&repository=KyaniteLabs%2Fkinocut&return_to=https%3A%2F%2Fgithub.com%2FKyaniteLabs%2Fkinocut%2Fpull%2F420&signature=50668a0ffb6f9d8edd224be6af9966a9e88123a456f1256468fdd38b174633fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->