### PR TITLE
feat: fade audio edit boundaries before normalization

### DIFF
--- a/kinocut/engine_audio_normalize.py
+++ b/kinocut/engine_audio_normalize.py
@@ -63,11 +63,13 @@ def normalize_audio(
     output_path: str | None = None,
     *,
     true_peak_dbtp: float = -1.0,
+    fade_seconds: float = 0.01,
 ) -> EditResult:
     """Normalize audio with FFmpeg's two-pass loudnorm filter."""
     input_path = _validate_input_path(input_path)
     target, loudness_range = _number(target_lufs, "target_lufs", -70, -5), _number(lra, "lra", 0, 50)
     peak = _number(true_peak_dbtp, "true_peak_dbtp", -12, 0)
+    fade = _number(fade_seconds, "fade_seconds", 0, 1)
     _require_filter("loudnorm", "Audio normalization")
     output = output_path or _auto_output(input_path, "normalized")
     _validate_output_path(output)
@@ -80,7 +82,8 @@ def normalize_audio(
         _escaped(loudness_range, "lra"),
         _escaped(peak, "true_peak_dbtp"),
     )
-    has_audio = _has_audio(_run_ffprobe_json(input_path))
+    probe = _run_ffprobe_json(input_path)
+    has_audio = _has_audio(probe)
     with _timed_operation() as timing:
         if not has_audio:
             _run_ffmpeg(
@@ -92,12 +95,40 @@ def normalize_audio(
                 )
             )
         else:
+            duration_value = next(
+                (
+                    stream.get("duration")
+                    for stream in probe.get("streams", [])
+                    if stream.get("codec_type") == "audio" and stream.get("duration") is not None
+                ),
+                None,
+            )
+            if duration_value is None:
+                format_data = probe.get("format")
+                duration_value = format_data.get("duration") if isinstance(format_data, dict) else None
+            try:
+                duration = float(duration_value)
+            except (TypeError, ValueError):
+                duration = 0.0
+            if not math.isfinite(duration) or duration <= 0:
+                raise MCPVideoError(
+                    "Could not determine a finite positive media duration for boundary fades",
+                    error_type="processing_error",
+                    code="invalid_media_duration",
+                )
+            boundary = min(fade, duration / 2)
+            if boundary > 0:
+                boundary_s = _escaped(boundary, "fade_seconds")
+                fade_out_start_s = _escaped(duration - boundary, "fade_out_start")
+                fade_filter = f"afade=t=in:st=0:d={boundary_s},afade=t=out:st={fade_out_start_s}:d={boundary_s},"
+            else:
+                fade_filter = ""
             analysis = _run_ffmpeg(
                 [
                     "-i",
                     input_path,
                     "-af",
-                    f"loudnorm=I={target_s}:LRA={lra_s}:TP={peak_s}:print_format=json",
+                    f"{fade_filter}loudnorm=I={target_s}:LRA={lra_s}:TP={peak_s}:print_format=json",
                     "-f",
                     "null",
                     "-",
@@ -108,10 +139,12 @@ def normalize_audio(
             except MCPVideoError:
                 if "input_i" not in analysis.stderr or "-inf" not in analysis.stderr:
                     raise
-                render_filter = f"loudnorm=I={target_s}:LRA={lra_s}:TP={peak_s}"
+                render_filter = f"{fade_filter}loudnorm=I={target_s}:LRA={lra_s}:TP={peak_s}"
             else:
                 measured_filter = ":".join(f"{key}={_escaped(value, key)}" for key, value in measured.items())
-                render_filter = f"loudnorm=I={target_s}:LRA={lra_s}:TP={peak_s}:{measured_filter}:linear=true"
+                render_filter = (
+                    f"{fade_filter}loudnorm=I={target_s}:LRA={lra_s}:TP={peak_s}:{measured_filter}:linear=true"
+                )
             _run_ffmpeg(
                 _build_ffmpeg_cmd(
                     input_path,

--- a/tests/test_audio_fades.py
+++ b/tests/test_audio_fades.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import inspect
+import json
+import math
+from types import SimpleNamespace
+
+import pytest
+
+from kinocut.engine_audio_normalize import _measurement, normalize_audio
+from kinocut.errors import MCPVideoError
+from kinocut.ffmpeg_helpers import _run_ffmpeg
+
+
+MEASUREMENT = json.dumps({"input_i": -20, "input_lra": 2, "input_tp": -3, "input_thresh": -30, "target_offset": 1})
+
+
+def _mock_normalize(monkeypatch, tmp_path, *, duration: object = "2.0", audio: bool = True, stderr: str = MEASUREMENT):
+    source, output = tmp_path / "in.wav", tmp_path / "out.wav"
+    source.write_bytes(b"x")
+    calls: list[list[str]] = []
+    streams = [{"codec_type": "audio" if audio else "video"}]
+    monkeypatch.setattr("kinocut.engine_audio_normalize._require_filter", lambda *args: None)
+    monkeypatch.setattr(
+        "kinocut.engine_audio_normalize._run_ffprobe_json",
+        lambda _path: {"streams": streams, "format": {"duration": duration}},
+    )
+    monkeypatch.setattr(
+        "kinocut.engine_audio_normalize._run_ffmpeg",
+        lambda command: calls.append(command) or SimpleNamespace(stderr=stderr),
+    )
+    monkeypatch.setattr("kinocut.engine_audio_normalize._build_edit_result", lambda *args, **kwargs: args[0])
+    return source, output, calls
+
+
+def _filters(calls: list[list[str]]) -> list[str]:
+    return [command[command.index("-af") + 1] for command in calls if "-af" in command]
+
+
+def test_signature_adds_keyword_only_fade_without_moving_positional_api() -> None:
+    params = list(inspect.signature(normalize_audio).parameters.values())
+    assert [param.name for param in params[:4]] == ["input_path", "target_lufs", "lra", "output_path"]
+    assert params[4].name == "true_peak_dbtp"
+    assert params[5].name == "fade_seconds"
+    assert params[5].kind is inspect.Parameter.KEYWORD_ONLY
+    assert params[5].default == 0.01
+
+
+def test_default_fades_precede_loudnorm_in_analysis_and_render(tmp_path, monkeypatch) -> None:
+    source, output, calls = _mock_normalize(monkeypatch, tmp_path)
+    normalize_audio(str(source), -14, 8, str(output), true_peak_dbtp=-2)
+
+    assert len(calls) == 2
+    for audio_filter in _filters(calls):
+        assert audio_filter.startswith("afade=t=in:st=0:d=0.01,afade=t=out:st=1.99:d=0.01,loudnorm=")
+    assert "print_format=json" in _filters(calls)[0]
+    assert "measured_I=-20.0" in _filters(calls)[1]
+
+
+def test_zero_fade_is_explicit_filter_bypass(tmp_path, monkeypatch) -> None:
+    source, output, calls = _mock_normalize(monkeypatch, tmp_path)
+    normalize_audio(str(source), output_path=str(output), fade_seconds=0)
+
+    assert all(audio_filter.startswith("loudnorm=") for audio_filter in _filters(calls))
+    assert all("afade" not in audio_filter for audio_filter in _filters(calls))
+
+
+@pytest.mark.parametrize(
+    ("duration", "fade", "expected"),
+    [("4", 0.25, "st=3.75:d=0.25"), ("0.006", 0.01, "st=0.003:d=0.003")],
+)
+def test_custom_fade_and_half_duration_clamp(duration, fade, expected, tmp_path, monkeypatch) -> None:
+    source, output, calls = _mock_normalize(monkeypatch, tmp_path, duration=duration)
+    normalize_audio(str(source), output_path=str(output), fade_seconds=fade)
+
+    assert expected in _filters(calls)[0]
+    assert expected in _filters(calls)[1]
+
+
+def test_no_audio_copy_has_no_fades(tmp_path, monkeypatch) -> None:
+    source, output, calls = _mock_normalize(monkeypatch, tmp_path, duration=None, audio=False)
+    normalize_audio(str(source), output_path=str(output))
+
+    assert len(calls) == 1
+    assert "-af" not in calls[0]
+    assert calls[0][calls[0].index("-c:a") + 1] == "copy"
+
+
+@pytest.mark.parametrize("value", [True, -0.01, 1.01, math.inf, math.nan, "0.1"])
+def test_invalid_fade_values(value, tmp_path, monkeypatch) -> None:
+    source, _, _ = _mock_normalize(monkeypatch, tmp_path)
+    with pytest.raises(MCPVideoError, match="fade_seconds"):
+        normalize_audio(str(source), fade_seconds=value)
+
+
+@pytest.mark.parametrize("duration", [None, "bad", "nan", "inf", "0", "-1"])
+def test_invalid_audio_duration_is_actionable(duration, tmp_path, monkeypatch) -> None:
+    source, output, _ = _mock_normalize(monkeypatch, tmp_path, duration=duration)
+    with pytest.raises(MCPVideoError, match="finite positive media duration") as excinfo:
+        normalize_audio(str(source), output_path=str(output))
+    assert excinfo.value.code == "invalid_media_duration"
+
+
+def test_short_audio_one_pass_fallback_retains_clamped_fades(tmp_path, monkeypatch) -> None:
+    stderr = json.dumps(
+        {"input_i": "-inf", "input_lra": "0", "input_tp": "-inf", "input_thresh": "-70", "target_offset": "0"}
+    )
+    source, output, calls = _mock_normalize(monkeypatch, tmp_path, duration="0.006", stderr=stderr)
+    normalize_audio(str(source), output_path=str(output))
+
+    render_filter = _filters(calls)[1]
+    assert render_filter.startswith("afade=t=in:st=0:d=0.003,afade=t=out:st=0.003:d=0.003,loudnorm=")
+    assert "measured_I" not in render_filter
+
+
+def _window_rms(samples: list[int], start: int, stop: int) -> float:
+    window = samples[start:stop]
+    return math.sqrt(sum(sample * sample for sample in window) / len(window))
+
+
+def test_real_fixture_fades_boundaries_and_preserves_target_loudness(tmp_path) -> None:
+    source, output, decoded = tmp_path / "tone.wav", tmp_path / "normalized.m4a", tmp_path / "decoded.s16le"
+    _run_ffmpeg(["-f", "lavfi", "-i", "sine=frequency=440:sample_rate=48000:duration=2", str(source)])
+    normalize_audio(str(source), target_lufs=-14, output_path=str(output), fade_seconds=0.1)
+    _run_ffmpeg(
+        [
+            "-i",
+            str(output),
+            "-f",
+            "s16le",
+            "-ac",
+            "1",
+            "-ar",
+            "48000",
+            "-c:a",
+            "pcm_s16le",
+            str(decoded),
+        ]
+    )
+
+    rate = 48_000
+    raw = decoded.read_bytes()
+    count = len(raw) // 2
+    samples = [int.from_bytes(raw[index : index + 2], "little", signed=True) for index in range(0, len(raw), 2)]
+    edge = int(rate * 0.05)
+    middle = _window_rms(samples, count // 2 - edge // 2, count // 2 + edge // 2)
+    assert _window_rms(samples, 0, edge) < middle * 0.7
+    assert _window_rms(samples, count - edge, count) < middle * 0.7
+
+    analysis = _run_ffmpeg(
+        ["-i", str(output), "-af", "loudnorm=I=-14:TP=-1:LRA=11:print_format=json", "-f", "null", "-"]
+    )
+    assert _measurement(analysis.stderr)["measured_I"] == pytest.approx(-14, abs=1)

--- a/tests/test_audio_loudnorm.py
+++ b/tests/test_audio_loudnorm.py
@@ -50,7 +50,7 @@ def test_two_pass_commands_and_measured_values(tmp_path, monkeypatch) -> None:
     monkeypatch.setattr("kinocut.engine_audio_normalize._require_filter", lambda *args: None)
     monkeypatch.setattr(
         "kinocut.engine_audio_normalize._run_ffprobe_json",
-        lambda _path: {"streams": [{"codec_type": "audio"}]},
+        lambda _path: {"format": {"duration": "1.0"}, "streams": [{"codec_type": "audio"}]},
     )
     monkeypatch.setattr("kinocut.engine_audio_normalize._run_ffmpeg", lambda command: calls.append(command) or analysis)
     monkeypatch.setattr("kinocut.engine_audio_normalize._build_edit_result", lambda *args, **kwargs: args[0])
@@ -99,7 +99,7 @@ def test_short_audio_uses_one_pass_fallback_for_infinite_measurement(tmp_path, m
     monkeypatch.setattr("kinocut.engine_audio_normalize._require_filter", lambda *args: None)
     monkeypatch.setattr(
         "kinocut.engine_audio_normalize._run_ffprobe_json",
-        lambda _path: {"streams": [{"codec_type": "audio"}]},
+        lambda _path: {"format": {"duration": "0.1"}, "streams": [{"codec_type": "audio"}]},
     )
     monkeypatch.setattr(
         "kinocut.engine_audio_normalize._run_ffmpeg",


### PR DESCRIPTION
Progresses #404; stacked on #421.

Adds restrained boundary finishing before loudness measurement:
- keyword-only finite boundary-fade policy with 10ms default and explicit zero bypass
- fade-in/fade-out applied before loudnorm in analysis and render passes
- audio-stream duration preference with safe container fallback
- half-duration clamp for very short media
- no-audio stream-copy path remains filter-free
- actionable invalid-duration failure rather than negative fade timing
- real FFmpeg edge attenuation and ±1 LU verification

Exact stacked diff: 185 changed lines (+179/-6) across three files. Focused audio verification: 31 passed; Ruff and diff checks pass.

Draft pending #421's remediated exact-head CI, this head's hosted CI, and required GLM 5.2 ULTRACODE adversarial review. PR #400 remains a draft review-only umbrella and must never merge.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/kinocut/pr/422"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787375384&installation_model_id=20207&pr_number=422&repository=KyaniteLabs%2Fkinocut&return_to=https%3A%2F%2Fgithub.com%2FKyaniteLabs%2Fkinocut%2Fpull%2F422&signature=4dd503e8e8062c761277a340f24d0caffac7b7362583d1cee8d0e50901ceadf2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->