### PR TITLE
feat: define deterministic shorts package contracts

### DIFF
--- a/kinocut/product/__init__.py
+++ b/kinocut/product/__init__.py
@@ -1,1 +1,22 @@
-"""Product-level workflow contracts."""
+"""Product-level workflow contracts (additive).
+
+Public surface for the long-form stream-to-shorts workflow: strict,
+JSON-serialisable data contracts only.
+"""
+
+from .package_models import *  # noqa: F403
+
+__all__ = [  # noqa: F405
+    "PackageAsset",
+    "PackageConfig",
+    "PackageLineage",
+    "PackagedClipResult",
+    "PerformanceIdentifier",
+    "PerformanceStatus",
+    "ShortsPackageManifest",
+    "ThumbnailSpec",
+    "canonical_manifest_bytes",
+    "manifest_artifact_digest",
+    "package_kind",
+    "parse_package_manifest",
+]

--- a/kinocut/product/package_models.py
+++ b/kinocut/product/package_models.py
@@ -1,0 +1,174 @@
+"""Strict package contracts and canonical manifest helpers."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any, Literal
+
+from pydantic import Field, field_validator, model_validator
+
+from kinocut.contracts._common import ValueObject
+from kinocut.errors import MCPVideoError
+
+from .captions import CaptionArtifact
+from .models import CandidateMoment
+
+PerformanceStatus = Literal["draft", "experimental"]
+
+_PACKAGE_KIND = "shorts_package"
+package_kind: str = _PACKAGE_KIND
+
+_DRAFTING_ONLY_TAGS: tuple[str, ...] = ("suggested_title", "suggested_hook", "short_description")
+
+
+class ThumbnailSpec(ValueObject):
+    """Representative thumbnail chosen for an approved clip."""
+
+    image_path: str = Field(min_length=1)
+    timestamp: float = Field(ge=0.0)
+    notes: str | None = None
+
+
+class PerformanceIdentifier(ValueObject):
+    """Optional drafting-only performance identifier."""
+
+    status: PerformanceStatus
+    label: str = Field(min_length=1, max_length=64)
+
+
+class PackageConfig(ValueObject):
+    """Controls deterministic package writing."""
+
+    manifest_basename: str = Field(default="manifest", min_length=1, max_length=64)
+    overwrite_manifest: bool = False
+    write_thumbnail_marker: bool = True
+
+
+class PackageAsset(ValueObject):
+    """Portable package asset with a bounded role."""
+
+    role: Literal[
+        "vertical_video",
+        "editable_subtitles",
+        "representative_thumbnail",
+        "edit_manifest",
+        "performance_identifier",
+    ]
+    relative_path: str = Field(min_length=1)
+    bytes: int | None = Field(default=None, ge=0)
+
+    @model_validator(mode="after")
+    def _no_traversal_in_path(self) -> PackageAsset:
+        normalized = self.relative_path.replace("\\", "/")
+        drive_path = len(normalized) > 1 and normalized[0].isalpha() and normalized[1] == ":"
+        if normalized.startswith("/") or drive_path or ".." in normalized.split("/"):
+            raise ValueError(f"asset path escapes package root: {self.relative_path!r}")
+        if any(ord(character) < 32 for character in normalized):
+            raise ValueError(f"asset path contains control character: {self.relative_path!r}")
+        return self
+
+
+class PackageLineage(ValueObject):
+    """Provenance references for the packaged clip."""
+
+    candidate_id: str = Field(min_length=1)
+    transcript_reference: str | None = None
+    generation_lineage_ref: str | None = None
+    review_decision_ref: str | None = None
+
+
+class ShortsPackageManifest(ValueObject):
+    """Machine-readable, JSON-stable edit manifest."""
+
+    schema_version: int = Field(default=1, ge=1, le=1)
+    package_kind: Literal["shorts_package"] = _PACKAGE_KIND
+    package_id: str = Field(min_length=1)
+    package_root: str = Field(min_length=1)
+    generated_at: str | None = None
+    candidate: CandidateMoment
+    caption_artifact: CaptionArtifact
+    suggested_title: str | None = None
+    short_description: str | None = None
+    source_timestamps: tuple[float, float] | None = None
+    thumbnail: ThumbnailSpec
+    lineage: PackageLineage
+    assets: tuple[PackageAsset, ...]
+    review_warnings: tuple[str, ...]
+    drafting_only_flags: tuple[str, ...] = tuple(_DRAFTING_ONLY_TAGS)
+    performance: PerformanceIdentifier | None = None
+
+    @field_validator("schema_version", mode="before")
+    @classmethod
+    def _strict_schema_version(cls, value: Any) -> int:
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise ValueError("schema_version must be the integer 1")
+        return value
+
+
+class PackagedClipResult(ValueObject):
+    """Deterministic package writer result."""
+
+    package_root: str = Field(min_length=1)
+    manifest_path: str = Field(min_length=1)
+    asset_paths: tuple[str, ...]
+    manifest: ShortsPackageManifest
+
+
+def parse_package_manifest(payload: str | bytes) -> ShortsPackageManifest:
+    """Parse a JSON-encoded manifest. Bytes payloads are decoded UTF-8 strict."""
+
+    if isinstance(payload, bytes):
+        try:
+            payload = payload.decode("utf-8", errors="strict")
+        except UnicodeDecodeError as exc:
+            raise MCPVideoError(
+                "manifest payload is not valid UTF-8",
+                error_type="validation_error",
+                code="invalid_manifest_encoding",
+            ) from exc
+    try:
+        data: Any = json.loads(payload)
+    except json.JSONDecodeError as exc:
+        raise MCPVideoError(
+            "manifest payload is not valid JSON",
+            error_type="validation_error",
+            code="invalid_manifest_json",
+        ) from exc
+    return ShortsPackageManifest.model_validate(data)
+
+
+def canonical_manifest_bytes(manifest: ShortsPackageManifest) -> bytes:
+    """Render a manifest to canonical JSON bytes."""
+
+    payload = manifest.model_dump(mode="json")
+    return json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def manifest_artifact_digest(manifest: ShortsPackageManifest) -> str:
+    """Stable 16-hex prefix of the manifest's canonical digest."""
+
+    digest = hashlib.sha256(canonical_manifest_bytes(manifest)).hexdigest()
+    return digest[:16]
+
+
+__all__ = [
+    "PackageAsset",
+    "PackageConfig",
+    "PackageLineage",
+    "PackagedClipResult",
+    "PerformanceIdentifier",
+    "PerformanceStatus",
+    "ShortsPackageManifest",
+    "ThumbnailSpec",
+    "canonical_manifest_bytes",
+    "manifest_artifact_digest",
+    "package_kind",
+    "parse_package_manifest",
+]

--- a/tests/test_package_models.py
+++ b/tests/test_package_models.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+from pydantic import ValidationError
+
+from kinocut.errors import MCPVideoError
+from kinocut.product import (
+    PackagedClipResult,
+    PackageAsset,
+    PackageLineage,
+    ShortsPackageManifest,
+    PerformanceIdentifier,
+    ThumbnailSpec,
+    canonical_manifest_bytes,
+    manifest_artifact_digest,
+    parse_package_manifest,
+)
+from kinocut.product.captions import CaptionArtifact, build_caption_artifact
+from kinocut.product.models import CandidateMoment, canonical_dedup_key
+
+
+def _candidate(**overrides) -> CandidateMoment:
+    base = {
+        "candidate_id": "cand_pkg_01",
+        "start": 10.0,
+        "end": 20.0,
+        "transcript_excerpt": "Hello world this is a test of the package",
+        "suggested_title": "A test clip",
+        "suggested_hook": "Watch this short",
+        "rationale": "ends on a complete thought",
+        "confidence": 0.85,
+        "sensitivity": "none",
+    }
+    base.update(overrides)
+    base["dedup_key"] = canonical_dedup_key(
+        start=base["start"],
+        end=base["end"],
+        excerpt=base["transcript_excerpt"],
+        sensitivity=base["sensitivity"],
+    )
+    return CandidateMoment.model_validate(base)
+
+
+def _caption_artifact() -> CaptionArtifact:
+    return build_caption_artifact(
+        [
+            {"word": "Hello", "start": 0.0, "end": 0.4, "probability": 0.9},
+            {"word": "world", "start": 0.45, "end": 0.9, "probability": 0.95},
+            {"word": "this", "start": 1.0, "end": 1.3, "probability": 0.95},
+            {"word": "is", "start": 1.35, "end": 1.55, "probability": 0.95},
+            {"word": "a", "start": 1.6, "end": 1.75, "probability": 0.95},
+            {"word": "test", "start": 1.8, "end": 2.2, "probability": 0.95},
+        ]
+    )
+
+
+def _manifest_inputs(**overrides) -> dict:
+    inputs = {
+        "package_id": "pkg_test",
+        "package_root": "/tmp/pkg_test",
+        "candidate": _candidate().model_dump(mode="json"),
+        "caption_artifact": _caption_artifact().model_dump(mode="json"),
+        "thumbnail": ThumbnailSpec(image_path="/tmp/t.jpg", timestamp=12.5).model_dump(mode="json"),
+        "lineage": PackageLineage(candidate_id="cand_pkg_01").model_dump(mode="json"),
+        "assets": (PackageAsset(role="vertical_video", relative_path="v.mp4", bytes=10).model_dump(mode="json"),),
+        "review_warnings": (),
+    }
+    inputs.update(overrides)
+    return inputs
+
+
+def _manifest(**overrides) -> ShortsPackageManifest:
+    return ShortsPackageManifest.model_validate(_manifest_inputs(**overrides))
+
+
+def test_pkg_strict_manifest_rejects_unknown_field():
+    with pytest.raises(ValidationError):
+        ShortsPackageManifest.model_validate({**_manifest_inputs(), "unknown_field": "boom"})
+
+
+def test_pkg_strict_manifest_rejects_non_finite_floats():
+    payload = _manifest_inputs(thumbnail={"image_path": "/tmp/t.jpg", "timestamp": float("nan")})
+    with pytest.raises(ValidationError):
+        ShortsPackageManifest.model_validate(payload)
+
+
+@pytest.mark.parametrize(
+    "path",
+    ("../escape.mp4", "oops\\..\\bad.srt", "/etc/passwd", "C:\\secret.mp4", "\\\\server\\share", "bad\nname"),
+)
+def test_pkg_asset_rejects_paths_that_escape_or_corrupt_package(path):
+    with pytest.raises(ValidationError):
+        PackageAsset(role="vertical_video", relative_path=path)
+
+
+def test_pkg_traversal_manifest_rejects_traversal_in_asset_tuple():
+    inputs = _manifest_inputs(
+        assets=(
+            {"role": "vertical_video", "relative_path": "ok.mp4", "bytes": 4},
+            {"role": "editable_subtitles", "relative_path": "oops/../bad.srt", "bytes": 4},
+        )
+    )
+    with pytest.raises(ValidationError):
+        ShortsPackageManifest.model_validate(inputs)
+
+
+def test_pkg_manifest_rejects_noncanonical_package_kind():
+    with pytest.raises(ValidationError):
+        _manifest(package_kind="production_final")
+
+
+@pytest.mark.parametrize("version", (True, 1.0, "1"))
+def test_pkg_manifest_rejects_coerced_schema_version(version):
+    with pytest.raises(ValidationError):
+        _manifest(schema_version=version)
+
+
+def test_pkg_roundtrip_canonical_bytes_use_sorted_keys_and_compact_separators():
+    encoded = canonical_manifest_bytes(_manifest()).decode("utf-8")
+    assert json.dumps(json.loads(encoded), sort_keys=True, separators=(",", ":")) == encoded
+
+
+def test_pkg_roundtrip_parse_bytes_payload_matches_structural_copy():
+    assert parse_package_manifest(canonical_manifest_bytes(_manifest())) == _manifest()
+
+
+def test_pkg_roundtrip_parse_text_payload_matches_structural_copy():
+    encoded = canonical_manifest_bytes(_manifest()).decode("utf-8")
+    assert parse_package_manifest(encoded) == _manifest()
+
+
+def test_pkg_digest_is_stable_and_16_hex():
+    d = manifest_artifact_digest(_manifest())
+    assert d == manifest_artifact_digest(_manifest()) and len(d) == 16 and int(d, 16) >= 0
+
+
+def test_pkg_digest_changes_when_semantic_content_changes():
+    assert manifest_artifact_digest(_manifest(review_warnings=("alpha",))) != manifest_artifact_digest(
+        _manifest(review_warnings=("beta",))
+    )
+
+
+def test_pkg_drafting_only_flags_default_to_three_canonical_tags():
+    assert set(_manifest().drafting_only_flags) == {
+        "suggested_title",
+        "suggested_hook",
+        "short_description",
+    }
+
+
+def test_pkg_drafting_only_performance_status_accepts_canonical_values():
+    assert PerformanceIdentifier(status="draft", label="lane-a").status == "draft"
+    assert PerformanceIdentifier(status="experimental", label="lane-b").status == "experimental"
+
+
+def test_pkg_drafting_only_performance_status_rejects_non_canonical_value():
+    with pytest.raises(ValidationError):
+        PerformanceIdentifier(status="published", label="boom")
+
+
+def test_pkg_result_packaged_clip_result_round_trips_via_json():
+    m = _manifest()
+    result = PackagedClipResult(
+        package_root="/tmp/pkg",
+        manifest_path="/tmp/pkg/manifest.json",
+        asset_paths=("/tmp/pkg/v.mp4", "/tmp/pkg/manifest.json"),
+        manifest=m,
+    )
+    assert PackagedClipResult.model_validate(result.model_dump(mode="json")) == result
+
+
+def test_pkg_parse_rejects_invalid_json():
+    with pytest.raises(MCPVideoError) as exc:
+        parse_package_manifest("{this is not json")
+    assert exc.value.code == "invalid_manifest_json"
+
+
+def test_pkg_parse_rejects_invalid_utf8():
+    with pytest.raises(MCPVideoError) as exc:
+        parse_package_manifest(b"\xff\xfe\xfd")
+    assert exc.value.code == "invalid_manifest_encoding"
+
+
+def test_pkg_parse_rejects_non_object_payload():
+    with pytest.raises(ValidationError):
+        parse_package_manifest("[]")
+    with pytest.raises(ValidationError):
+        parse_package_manifest('"plain string"')


### PR DESCRIPTION
Closes part of #405.\n\nAdds the strict portable package contract layer consumed by later package-writer and shorts-orchestrator slices. Includes canonical JSON parsing/encoding/digest behavior, traversal rejection, drafting-only metadata constraints, and focused unhappy-path tests.\n\n- 384 changed lines\n- `pytest -q tests/test_package_models.py`: 20 passed\n- Ruff format/check clean\n- No rendering, publishing, adapters, or docs in this slice.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/kinocut/pr/423"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787450531&installation_model_id=20207&pr_number=423&repository=KyaniteLabs%2Fkinocut&return_to=https%3A%2F%2Fgithub.com%2FKyaniteLabs%2Fkinocut%2Fpull%2F423&signature=6070251c37e677ffc08a7fc247f0e87bf46fe96177bf9a2abaf243ac78b0ceb0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added structured packaging contracts for shorts workflow manifests and packaged clip results.
  * Added validation for package configuration, assets, thumbnails, lineage, performance metadata, and drafting-only flags.
  * Added support for parsing manifests from text or bytes with clear validation errors.
  * Added stable manifest serialization and compact artifact digest generation.
  * Added safeguards against invalid paths, malformed data, and unexpected fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->