### PR TITLE
feat: package approved shorts with verified provenance

### DIFF
--- a/kinocut/product/__init__.py
+++ b/kinocut/product/__init__.py
@@ -1,9 +1,10 @@
 """Product-level workflow contracts (additive).
 
 Public surface for the long-form stream-to-shorts workflow: strict,
-JSON-serialisable data contracts only.
+JSON-serialisable data contracts plus the deterministic package writer.
 """
 
+from .package import package_approved_clip
 from .package_models import *  # noqa: F403
 
 __all__ = [  # noqa: F405
@@ -17,6 +18,7 @@ __all__ = [  # noqa: F405
     "ThumbnailSpec",
     "canonical_manifest_bytes",
     "manifest_artifact_digest",
+    "package_approved_clip",
     "package_kind",
     "parse_package_manifest",
 ]

--- a/kinocut/product/package.py
+++ b/kinocut/product/package.py
@@ -1,0 +1,228 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import tempfile
+import shutil
+from contextlib import contextmanager
+from collections.abc import Iterable
+
+from ..errors import MCPVideoError
+from ..ffmpeg_helpers import _validate_artifact_path, _validate_input_path
+from .captions import CaptionArtifact
+from .models import CandidateMoment
+from .package_models import (
+    PackageAsset,
+    PackageConfig,
+    PackageLineage,
+    PackagedClipResult,
+    PerformanceIdentifier,
+    ShortsPackageManifest,
+    ThumbnailSpec,
+    canonical_manifest_bytes,
+)
+
+
+__all__ = ["package_approved_clip"]
+
+
+_HEX_RE = re.compile(r"^[0-9a-f]{16}$")
+
+
+def _package_id(candidate: CandidateMoment) -> str:
+
+    seed = candidate.dedup_key
+    if not _HEX_RE.match(seed):
+        raise MCPVideoError(
+            "candidate dedup_key is not a 16-hex digest; cannot derive package id",
+            error_type="validation_error",
+            code="invalid_dedup_key",
+        )
+    return f"pkg_{seed}"
+
+
+def _stage_copy(source_path: str, directory: str) -> tuple[str, str]:
+    descriptor, staged_path = tempfile.mkstemp(dir=directory)
+    digest = hashlib.sha256()
+    target = os.fdopen(descriptor, "wb")
+    with target, open(source_path, "rb") as source:
+        for chunk in iter(lambda: source.read(1024 * 1024), b""):
+            target.write(chunk)
+            digest.update(chunk)
+    return staged_path, digest.hexdigest()
+
+
+def _stage_bytes(payload: bytes, directory: str) -> str:
+    descriptor, staged_path = tempfile.mkstemp(dir=directory)
+    with os.fdopen(descriptor, "wb") as target:
+        target.write(payload)
+    return staged_path
+
+
+@contextmanager
+def _staging_area(directory: str):
+    stage_dir = tempfile.mkdtemp(dir=directory)
+    try:
+        yield stage_dir
+    finally:
+        shutil.rmtree(stage_dir, ignore_errors=True)
+
+
+def package_approved_clip(
+    *,
+    package_dir: str,
+    vertical_video_path: str,
+    expected_video_sha256: str | None = None,
+    caption_artifact: CaptionArtifact,
+    candidate: CandidateMoment,
+    thumbnail: ThumbnailSpec,
+    lineage: PackageLineage | None = None,
+    performance: PerformanceIdentifier | None = None,
+    extra_review_warnings: Iterable[str] = (),
+    config: PackageConfig | None = None,
+    generated_at: str | None = None,
+) -> PackagedClipResult:
+
+    cfg = config or PackageConfig()
+    if not isinstance(cfg, PackageConfig):
+        cfg = PackageConfig.model_validate(cfg)
+
+    if not isinstance(candidate, CandidateMoment):
+        raise MCPVideoError(
+            "candidate must be a strict CandidateMoment",
+            error_type="validation_error",
+            code="invalid_candidate",
+        )
+    if not isinstance(caption_artifact, CaptionArtifact):
+        raise MCPVideoError(
+            "caption_artifact must be a strict CaptionArtifact",
+            error_type="validation_error",
+            code="invalid_caption_artifact",
+        )
+    if not isinstance(thumbnail, ThumbnailSpec):
+        raise MCPVideoError(
+            "thumbnail must be a strict ThumbnailSpec",
+            error_type="validation_error",
+            code="invalid_thumbnail",
+        )
+    if lineage is not None and not isinstance(lineage, PackageLineage):
+        raise MCPVideoError(
+            "lineage must be a strict PackageLineage",
+            error_type="validation_error",
+            code="invalid_lineage",
+        )
+    if performance is not None and not isinstance(performance, PerformanceIdentifier):
+        raise MCPVideoError(
+            "performance must be a strict PerformanceIdentifier",
+            error_type="validation_error",
+            code="invalid_performance",
+        )
+
+    safe_dir = os.path.realpath(os.path.expanduser(_validate_artifact_path(package_dir)))
+    safe_video = _validate_input_path(vertical_video_path)
+    safe_thumbnail = _validate_input_path(thumbnail.image_path)
+    package_id = _package_id(candidate)
+    safe_basename = re.sub(r"[^A-Za-z0-9._-]", "_", cfg.manifest_basename)[:64]
+    manifest_filename = f"{package_id}__{safe_basename}.json"
+    video_suffix = os.path.splitext(safe_video)[1].lower() or ".mp4"
+    thumbnail_suffix = os.path.splitext(safe_thumbnail)[1].lower() or ".jpg"
+    video_path = os.path.join(safe_dir, f"vertical{video_suffix}")
+    thumbnail_path = os.path.join(safe_dir, f"thumbnail{thumbnail_suffix}")
+    srt_path = os.path.join(safe_dir, "captions.srt")
+    metadata_path = os.path.join(safe_dir, "metadata.json")
+    manifest_path = os.path.join(safe_dir, manifest_filename)
+    output_paths = (video_path, srt_path, thumbnail_path, metadata_path, manifest_path)
+
+    if any(os.path.islink(path) for path in output_paths):
+        raise MCPVideoError(
+            "package output path resolves through a symlink",
+            error_type="validation_error",
+            code="unsafe_path",
+        )
+    conflicts = tuple(path for path in output_paths if os.path.lexists(path))
+    if conflicts and not cfg.overwrite_package:
+        raise MCPVideoError(
+            f"package assets already exist: {conflicts!r}",
+            error_type="validation_error",
+            code="package_write_conflict",
+        )
+
+    os.makedirs(safe_dir, exist_ok=True)
+    with _staging_area(safe_dir) as stage_dir:
+        staged_video, video_sha256 = _stage_copy(safe_video, stage_dir)
+        if expected_video_sha256 is not None and expected_video_sha256 != video_sha256:
+            raise MCPVideoError(
+                "vertical video checksum does not match the approved render",
+                error_type="validation_error",
+                code="source_checksum_mismatch",
+            )
+        staged_thumbnail, _ = _stage_copy(safe_thumbnail, stage_dir)
+        staged_srt = _stage_bytes((caption_artifact.srt_body.rstrip() + "\n").encode(), stage_dir)
+        metadata = {
+            "candidate_id": candidate.candidate_id,
+            "suggested_title": candidate.suggested_title,
+            "suggested_hook": candidate.suggested_hook,
+            "source_timestamps": [candidate.start, candidate.end],
+            "vertical_video_sha256": video_sha256,
+        }
+        staged_metadata = _stage_bytes(
+            (json.dumps(metadata, sort_keys=True, separators=(",", ":"), ensure_ascii=False) + "\n").encode(),
+            stage_dir,
+        )
+
+        package_lineage = lineage or PackageLineage(candidate_id=candidate.candidate_id)
+        package_lineage = package_lineage.model_copy(update={"artifact_sha256": f"sha256:{video_sha256}"})
+        warnings = tuple(
+            dict.fromkeys(
+                value
+                for value in (candidate.review_warning, *caption_artifact.warnings, *extra_review_warnings)
+                if value
+            )
+        )
+        assets = (
+            PackageAsset(
+                role="vertical_video", relative_path=os.path.basename(video_path), bytes=os.path.getsize(staged_video)
+            ),
+            PackageAsset(role="editable_subtitles", relative_path="captions.srt", bytes=os.path.getsize(staged_srt)),
+            PackageAsset(
+                role="representative_thumbnail",
+                relative_path=os.path.basename(thumbnail_path),
+                bytes=os.path.getsize(staged_thumbnail),
+            ),
+            PackageAsset(role="metadata", relative_path="metadata.json", bytes=os.path.getsize(staged_metadata)),
+            PackageAsset(role="edit_manifest", relative_path=manifest_filename),
+        )
+        manifest = ShortsPackageManifest(
+            package_id=package_id,
+            package_root=safe_dir,
+            generated_at=generated_at,
+            candidate=candidate,
+            caption_artifact=caption_artifact,
+            suggested_title=candidate.suggested_title,
+            short_description=candidate.suggested_hook,
+            source_timestamps=(candidate.start, candidate.end),
+            thumbnail=thumbnail.model_copy(update={"image_path": thumbnail_path}),
+            lineage=package_lineage,
+            assets=assets,
+            review_warnings=warnings,
+            performance=performance,
+        )
+        staged_manifest = _stage_bytes(canonical_manifest_bytes(manifest) + b"\n", stage_dir)
+        staged_outputs = (
+            (staged_video, video_path),
+            (staged_srt, srt_path),
+            (staged_thumbnail, thumbnail_path),
+            (staged_metadata, metadata_path),
+            (staged_manifest, manifest_path),
+        )
+        for staged_path, output_path in staged_outputs:
+            os.replace(staged_path, output_path)
+
+    return PackagedClipResult(
+        package_root=safe_dir,
+        manifest_path=manifest_path,
+        asset_paths=output_paths,
+        manifest=manifest,
+    )

--- a/kinocut/product/package_models.py
+++ b/kinocut/product/package_models.py
@@ -41,8 +41,7 @@ class PackageConfig(ValueObject):
     """Controls deterministic package writing."""
 
     manifest_basename: str = Field(default="manifest", min_length=1, max_length=64)
-    overwrite_manifest: bool = False
-    write_thumbnail_marker: bool = True
+    overwrite_package: bool = False
 
 
 class PackageAsset(ValueObject):
@@ -53,6 +52,7 @@ class PackageAsset(ValueObject):
         "editable_subtitles",
         "representative_thumbnail",
         "edit_manifest",
+        "metadata",
         "performance_identifier",
     ]
     relative_path: str = Field(min_length=1)
@@ -76,6 +76,7 @@ class PackageLineage(ValueObject):
     transcript_reference: str | None = None
     generation_lineage_ref: str | None = None
     review_decision_ref: str | None = None
+    artifact_sha256: str | None = Field(default=None, pattern=r"^sha256:[0-9a-f]{64}$")
 
 
 class ShortsPackageManifest(ValueObject):

--- a/tests/test_package_writer.py
+++ b/tests/test_package_writer.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+import kinocut.product.package as package_module
+from kinocut.errors import MCPVideoError
+from kinocut.product.captions import build_caption_artifact
+from kinocut.product.models import CandidateMoment, canonical_dedup_key
+from kinocut.product.package import package_approved_clip
+from kinocut.product.package_models import PackageConfig, ThumbnailSpec
+
+
+def _candidate(*, warning: str | None = "review this") -> CandidateMoment:
+    excerpt = "A complete thought prepared for a short clip."
+    return CandidateMoment(
+        candidate_id="candidate_01",
+        start=10.0,
+        end=20.0,
+        transcript_excerpt=excerpt,
+        suggested_title="A useful clip",
+        suggested_hook="Start here",
+        rationale="Complete thought",
+        confidence=0.9,
+        sensitivity="none",
+        dedup_key=canonical_dedup_key(start=10.0, end=20.0, excerpt=excerpt, sensitivity="none"),
+        review_warning=warning,
+    )
+
+
+def _caption():
+    return build_caption_artifact(
+        [
+            {"word": "Start", "start": 0.0, "end": 0.4, "probability": 0.95},
+            {"word": "here", "start": 0.45, "end": 0.9, "probability": 0.95},
+        ]
+    )
+
+
+def _inputs(tmp_path: Path):
+    video = tmp_path / "render.mp4"
+    thumbnail = tmp_path / "frame.jpg"
+    video.write_bytes(b"approved vertical render")
+    thumbnail.write_bytes(b"approved thumbnail")
+    return video, thumbnail
+
+
+def test_package_writes_complete_portable_artifact_set(tmp_path):
+    video, thumbnail = _inputs(tmp_path)
+    result = package_approved_clip(
+        package_dir=str(tmp_path / "package"),
+        vertical_video_path=str(video),
+        expected_video_sha256=hashlib.sha256(video.read_bytes()).hexdigest(),
+        caption_artifact=_caption(),
+        candidate=_candidate(),
+        thumbnail=ThumbnailSpec(image_path=str(thumbnail), timestamp=12.0),
+    )
+    assert {Path(path).name for path in result.asset_paths} == {
+        "vertical.mp4",
+        "captions.srt",
+        "thumbnail.jpg",
+        "metadata.json",
+        Path(result.manifest_path).name,
+    }
+    assert all(Path(path).parent == Path(result.package_root) for path in result.asset_paths)
+
+
+def test_package_records_verified_video_checksum(tmp_path):
+    video, thumbnail = _inputs(tmp_path)
+    result = package_approved_clip(
+        package_dir=str(tmp_path / "package"),
+        vertical_video_path=str(video),
+        caption_artifact=_caption(),
+        candidate=_candidate(),
+        thumbnail=ThumbnailSpec(image_path=str(thumbnail), timestamp=12.0),
+    )
+    metadata = json.loads((Path(result.package_root) / "metadata.json").read_text())
+    assert (
+        metadata["vertical_video_sha256"]
+        == hashlib.sha256((Path(result.package_root) / "vertical.mp4").read_bytes()).hexdigest()
+    )
+
+
+def test_package_rejects_checksum_mismatch_before_writing(tmp_path):
+    video, thumbnail = _inputs(tmp_path)
+    with pytest.raises(MCPVideoError) as exc:
+        package_approved_clip(
+            package_dir=str(tmp_path / "package"),
+            vertical_video_path=str(video),
+            expected_video_sha256="0" * 64,
+            caption_artifact=_caption(),
+            candidate=_candidate(),
+            thumbnail=ThumbnailSpec(image_path=str(thumbnail), timestamp=12.0),
+        )
+    assert exc.value.code == "source_checksum_mismatch"
+
+
+def test_package_refuses_collision_unless_overwrite_is_explicit(tmp_path):
+    video, thumbnail = _inputs(tmp_path)
+    kwargs = {
+        "package_dir": str(tmp_path / "package"),
+        "vertical_video_path": str(video),
+        "caption_artifact": _caption(),
+        "candidate": _candidate(),
+        "thumbnail": ThumbnailSpec(image_path=str(thumbnail), timestamp=12.0),
+    }
+    package_approved_clip(**kwargs)
+    with pytest.raises(MCPVideoError) as exc:
+        package_approved_clip(**kwargs)
+    assert exc.value.code == "package_write_conflict"
+    assert package_approved_clip(**kwargs, config=PackageConfig(overwrite_package=True)).manifest.package_id.startswith(
+        "pkg_"
+    )
+
+
+def test_package_rejects_symlinked_output_without_touching_target(tmp_path):
+    video, thumbnail = _inputs(tmp_path)
+    package_dir = tmp_path / "package"
+    package_dir.mkdir()
+    outside = tmp_path / "outside.json"
+    outside.write_text("preserve")
+    (package_dir / "metadata.json").symlink_to(outside)
+    with pytest.raises(MCPVideoError) as exc:
+        package_approved_clip(
+            package_dir=str(package_dir),
+            vertical_video_path=str(video),
+            caption_artifact=_caption(),
+            candidate=_candidate(),
+            thumbnail=ThumbnailSpec(image_path=str(thumbnail), timestamp=12.0),
+        )
+    assert exc.value.code == "unsafe_path"
+    assert outside.read_text() == "preserve"
+
+
+def test_package_cleans_staging_files_after_midwrite_failure(tmp_path, monkeypatch):
+    video, thumbnail = _inputs(tmp_path)
+    original = package_module._stage_bytes
+    calls = 0
+
+    def fail_second_write(payload, directory):
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            raise OSError("disk full")
+        return original(payload, directory)
+
+    monkeypatch.setattr(package_module, "_stage_bytes", fail_second_write)
+    package_dir = tmp_path / "package"
+    with pytest.raises(OSError, match="disk full"):
+        package_approved_clip(
+            package_dir=str(package_dir),
+            vertical_video_path=str(video),
+            caption_artifact=_caption(),
+            candidate=_candidate(),
+            thumbnail=ThumbnailSpec(image_path=str(thumbnail), timestamp=12.0),
+        )
+    assert list(package_dir.iterdir()) == []


### PR DESCRIPTION
Continues #405 after #423.\n\nWrites complete portable clip packages with copied video, editable SRT, representative thumbnail, metadata, and canonical manifest. Computes and records SHA-256, validates an approved checksum when supplied, rejects collisions unless overwrite is explicit, and preserves review warnings.\n\n- 331 changed lines\n- 30 focused package tests passed\n- Ruff format/check clean\n- No rendering, adapters, posting, or docs in this slice.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/kinocut/pr/424"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787453684&installation_model_id=20207&pr_number=424&repository=KyaniteLabs%2Fkinocut&return_to=https%3A%2F%2Fgithub.com%2FKyaniteLabs%2Fkinocut%2Fpull%2F424&signature=de054e853716d2860959e45c8cf3ef3a9f6067a020546dfaea194f886e2bb2d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added deterministic packaging for approved clips, including video, captions, thumbnails, metadata, and manifests.
  * Added checksum verification, review-warning deduplication, and safe output-path handling.
  * Added optional explicit overwrite support for existing packages.
  * Exposed the clip-packaging capability through the product package interface.

* **Bug Fixes**
  * Improved validation and clear error handling for invalid inputs, checksum mismatches, unsafe paths, and package conflicts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->