### PR TITLE
feat: persist exact shorts review plans

### DIFF
--- a/kinocut/product/__init__.py
+++ b/kinocut/product/__init__.py
@@ -1,24 +1,41 @@
 """Product-level workflow contracts (additive).
 
 Public surface for the long-form stream-to-shorts workflow: strict,
-JSON-serialisable data contracts plus the deterministic package writer.
+JSON-serialisable data contracts plus the deterministic package writer
+and the persisted human-review contract.
 """
 
 from .package import package_approved_clip
 from .package_models import *  # noqa: F403
+from .shorts_plan import (
+    IntakeReport,
+    ReviewAction,
+    ReviewDecision,
+    ShortsPlan,
+    ShortsPlanStatus,
+    load_shorts_plan,
+    save_shorts_plan,
+)
 
 __all__ = [  # noqa: F405
+    "IntakeReport",
     "PackageAsset",
     "PackageConfig",
     "PackageLineage",
     "PackagedClipResult",
     "PerformanceIdentifier",
     "PerformanceStatus",
+    "ReviewAction",
+    "ReviewDecision",
     "ShortsPackageManifest",
+    "ShortsPlan",
+    "ShortsPlanStatus",
     "ThumbnailSpec",
     "canonical_manifest_bytes",
+    "load_shorts_plan",
     "manifest_artifact_digest",
     "package_approved_clip",
     "package_kind",
     "parse_package_manifest",
+    "save_shorts_plan",
 ]

--- a/kinocut/product/shorts_plan.py
+++ b/kinocut/product/shorts_plan.py
@@ -1,0 +1,268 @@
+"""Strict persisted plans for human-reviewed shorts workflows."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import tempfile
+from pathlib import Path
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from ..errors import MCPVideoError
+from ..ffmpeg_helpers import _validate_artifact_path
+from .models import CandidateMoment, TranscriptSegment
+
+
+__all__ = [
+    "IntakeReport",
+    "ReviewAction",
+    "ReviewDecision",
+    "ShortsPlan",
+    "ShortsPlanStatus",
+    "load_shorts_plan",
+    "save_shorts_plan",
+]
+
+
+class _StrictModel(BaseModel):
+    """Frozen plan model."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True, allow_inf_nan=False)
+
+
+_JOB_ID_PATTERN = r"^shorts_[0-9a-f]{16}$"
+_PLAN_FILENAME_RE = re.compile(r"^shorts_[0-9a-f]{16}\.plan\.json$")
+
+
+ReviewAction = Literal[
+    "preview",
+    "approve",
+    "reject",
+    "trim",
+    "title_hook_edit",
+    "sensitive_unsuitable",
+]
+
+ShortsPlanStatus = Literal["review_required", "reviewed", "rendered", "packaged"]
+
+
+class IntakeReport(_StrictModel):
+    """Source-media facts captured at proposal time."""
+
+    source_path: str = Field(min_length=1)
+    source_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    duration: float = Field(gt=0.0)
+    width: int = Field(gt=0)
+    height: int = Field(gt=0)
+    audio_available: bool
+    format: str | None = None
+    problems: tuple[str, ...] = ()
+
+
+class ReviewDecision(_StrictModel):
+    """One append-only human review record."""
+
+    candidate_id: str = Field(pattern=r"^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$")
+    action: ReviewAction
+    start: float | None = Field(default=None, ge=0.0)
+    end: float | None = Field(default=None, gt=0.0)
+    title: str | None = Field(default=None, min_length=1, max_length=160)
+    hook: str | None = Field(default=None, min_length=1, max_length=240)
+    sensitive: bool | None = None
+    unsuitable: bool | None = None
+    evidence_ref: str | None = Field(default=None, min_length=1)
+
+    @model_validator(mode="after")
+    def _validate_action_shape(self) -> ReviewDecision:
+        if self.action == "trim":
+            if self.start is None or self.end is None or self.end <= self.start:
+                raise ValueError("trim decisions require 0 <= start < end")
+            forbidden = ("title", "hook", "sensitive", "unsuitable")
+            if any(getattr(self, name) is not None for name in forbidden):
+                raise ValueError("trim decisions must not carry title/hook/sensitive/unsuitable")
+        elif self.action == "title_hook_edit":
+            if self.title is None and self.hook is None:
+                raise ValueError("title_hook_edit decisions require title or hook")
+            if self.start is not None or self.end is not None:
+                raise ValueError("title_hook_edit decisions must not carry start/end")
+        elif self.action == "sensitive_unsuitable":
+            if self.sensitive is None and self.unsuitable is None:
+                raise ValueError("sensitive_unsuitable decisions require sensitive or unsuitable")
+            if any(getattr(self, name) is not None for name in ("start", "end", "title", "hook")):
+                raise ValueError("sensitive_unsuitable decisions must not carry trim/title fields")
+        else:
+            if any(
+                getattr(self, name) is not None for name in ("start", "end", "title", "hook", "sensitive", "unsuitable")
+            ):
+                raise ValueError(f"{self.action} decisions must not carry extra fields")
+        return self
+
+
+class ShortsPlan(_StrictModel):
+    """Persisted receipt consumed by downstream workflow stages."""
+
+    schema_version: Literal[1] = 1
+    job_id: str = Field(pattern=_JOB_ID_PATTERN)
+    status: ShortsPlanStatus = "review_required"
+    project_dir: str = Field(min_length=1)
+    output_dir: str = Field(min_length=1)
+    intake: IntakeReport
+    platforms: tuple[Literal["youtube-shorts", "instagram-reel"], ...]
+    config: dict[str, Any]
+    transcript: tuple[TranscriptSegment, ...]
+    proposals: tuple[CandidateMoment, ...]
+    decisions: tuple[ReviewDecision, ...] = ()
+
+    @model_validator(mode="after")
+    def _validate_invariants(self) -> ShortsPlan:
+        if not self.platforms:
+            raise ValueError("shorts plan must list at least one platform")
+        if not self.proposals:
+            raise ValueError("shorts plan must contain at least one proposal")
+        proposal_ids = {item.candidate_id for item in self.proposals}
+        if len(proposal_ids) != len(self.proposals):
+            raise ValueError("shorts plan proposals must have unique candidate ids")
+        for decision in self.decisions:
+            if decision.candidate_id not in proposal_ids:
+                raise ValueError(f"decision references unknown candidate {decision.candidate_id!r}")
+        return self
+
+
+def _plan_error(problem: str, *, code: str, cause: str, recovery: str) -> MCPVideoError:
+    return MCPVideoError(
+        f"Problem: {problem} Likely cause: {cause} Recovery: {recovery}",
+        error_type="validation_error",
+        code=code,
+        suggested_action={"auto_fix": False, "description": recovery},
+    )
+
+
+def _plan_filename(plan: ShortsPlan) -> str:
+    return f"{plan.job_id}.plan.json"
+
+
+def _candidate_plan_paths(root: str) -> list[str]:
+    """Return sorted plan files under the root and its shorts directory."""
+    if not os.path.isdir(root):
+        return []
+    primary = sorted(entry for entry in os.listdir(root) if _PLAN_FILENAME_RE.match(entry))
+    nested_dir = os.path.join(root, "shorts")
+    nested = []
+    if os.path.isdir(nested_dir):
+        nested = sorted(
+            os.path.join("shorts", entry) for entry in os.listdir(nested_dir) if _PLAN_FILENAME_RE.match(entry)
+        )
+    return [os.path.join(root, entry) for entry in (*primary, *nested)]
+
+
+def _resolve_plan_path(plan_path_or_dir: str) -> str:
+    if os.path.isfile(plan_path_or_dir):
+        return _validate_artifact_path(plan_path_or_dir)
+    if os.path.isdir(plan_path_or_dir):
+        candidates = _candidate_plan_paths(os.path.realpath(plan_path_or_dir))
+        if len(candidates) == 1:
+            return _validate_artifact_path(candidates[0])
+        code = "shorts_plan_not_found" if not candidates else "shorts_plan_ambiguous"
+        raise _plan_error(
+            "The saved shorts plan lookup was not exact.",
+            code=code,
+            cause=f"Found {len(candidates)} matching plans under {plan_path_or_dir!r}.",
+            recovery="Pass an exact plan path or a directory containing one plan.",
+        )
+    raise _plan_error(
+        "The saved shorts plan could not be found.",
+        code="shorts_plan_not_found",
+        cause=f"{plan_path_or_dir!r} is not a plan file or directory.",
+        recovery="Pass an exact plan path or a directory containing one plan.",
+    )
+
+
+def _plan_to_json(plan: ShortsPlan) -> str:
+    """Render a plan to canonical JSON."""
+    payload = plan.model_dump(mode="json")
+    return (
+        json.dumps(
+            payload,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+            allow_nan=False,
+        )
+        + "\n"
+    )
+
+
+def _safe_output_dir(plan: ShortsPlan) -> str:
+    requested = Path(plan.output_dir).expanduser().absolute()
+    resolved = os.path.realpath(_validate_artifact_path(str(requested)))
+    project_root = os.path.realpath(os.path.expanduser(plan.project_dir))
+    has_symlink = any(path.is_symlink() for path in (requested, *requested.parents))
+    if has_symlink or os.path.commonpath((project_root, resolved)) != project_root:
+        raise _plan_error(
+            "The plan output path is unsafe.",
+            code="unsafe_path",
+            cause=str(requested),
+            recovery="Choose a real directory inside project_dir.",
+        )
+    return resolved
+
+
+def save_shorts_plan(plan: ShortsPlan) -> ShortsPlan:
+    """Persist a plan atomically."""
+    if not isinstance(plan, ShortsPlan):
+        raise _plan_error(
+            "save_shorts_plan requires a strict ShortsPlan.",
+            code="invalid_plan",
+            cause=f"got {type(plan).__name__!r}.",
+            recovery="Construct the plan with ShortsPlan.model_validate(...) first.",
+        )
+    safe_output_dir = _safe_output_dir(plan)
+    os.makedirs(safe_output_dir, exist_ok=True)
+    target = os.path.join(safe_output_dir, _plan_filename(plan))
+    temp_path: str | None = None
+    try:
+        with tempfile.NamedTemporaryFile("w", dir=safe_output_dir, delete=False, encoding="utf-8") as handle:
+            temp_path = handle.name
+            handle.write(_plan_to_json(plan))
+        os.replace(temp_path, target)
+    except Exception:
+        if temp_path and os.path.lexists(temp_path):
+            os.unlink(temp_path)
+        raise
+    return plan
+
+
+def load_shorts_plan(plan_path_or_dir: str) -> ShortsPlan:
+    """Load one exact, unambiguous, strictly valid plan."""
+    plan_path = _resolve_plan_path(plan_path_or_dir)
+    try:
+        with open(plan_path, encoding="utf-8") as handle:
+            raw = handle.read()
+    except OSError as exc:
+        raise _plan_error(
+            "The saved shorts plan could not be read.",
+            code="shorts_plan_not_found",
+            cause=str(exc),
+            recovery="Restore the plan file or re-run discovery to regenerate it.",
+        ) from exc
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise _plan_error(
+            "The saved shorts plan is not valid JSON.",
+            code="shorts_plan_malformed",
+            cause=f"{exc.msg} at line {exc.lineno}, column {exc.colno}.",
+            recovery="Restore the plan from a previous good backup or rerun discovery.",
+        ) from exc
+    try:
+        return ShortsPlan.model_validate(payload)
+    except Exception as exc:  # pydantic.ValidationError or coercion failure
+        raise _plan_error(
+            "The saved shorts plan failed strict validation.",
+            code="shorts_plan_malformed",
+            cause=str(exc).splitlines()[0] if str(exc) else "unknown validation failure",
+            recovery="Restore the plan from a previous good backup or rerun discovery.",
+        ) from exc

--- a/tests/test_shorts_plan.py
+++ b/tests/test_shorts_plan.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+import kinocut.product.shorts_plan as plan_module
+from kinocut.errors import MCPVideoError
+from kinocut.product.models import CandidateMoment, TranscriptSegment, canonical_dedup_key
+from kinocut.product.shorts_plan import IntakeReport, ReviewDecision, ShortsPlan, load_shorts_plan, save_shorts_plan
+
+
+def _candidate() -> CandidateMoment:
+    excerpt = "A complete candidate thought."
+    return CandidateMoment(
+        candidate_id="candidate_01",
+        start=10.0,
+        end=20.0,
+        transcript_excerpt=excerpt,
+        suggested_title="A useful clip",
+        suggested_hook="Start here",
+        rationale="Complete thought",
+        confidence=0.9,
+        dedup_key=canonical_dedup_key(start=10.0, end=20.0, excerpt=excerpt, sensitivity="none"),
+    )
+
+
+def _plan(output_dir: Path, **updates) -> ShortsPlan:
+    values = {
+        "job_id": "shorts_0123456789abcdef",
+        "project_dir": str(output_dir.parent),
+        "output_dir": str(output_dir),
+        "intake": IntakeReport(
+            source_path="/tmp/source.mp4",
+            source_sha256="0" * 64,
+            duration=60.0,
+            width=1920,
+            height=1080,
+            audio_available=True,
+        ),
+        "platforms": ("youtube-shorts", "instagram-reel"),
+        "config": {},
+        "transcript": (TranscriptSegment(segment_id="segment_01", start=0.0, end=30.0, text="Transcript"),),
+        "proposals": (_candidate(),),
+    }
+    values.update(updates)
+    return ShortsPlan.model_validate(values)
+
+
+def test_plan_save_load_is_source_free(tmp_path):
+    plan = _plan(tmp_path / "plans")
+    save_shorts_plan(plan)
+    path = Path(plan.output_dir) / f"{plan.job_id}.plan.json"
+    assert load_shorts_plan(str(path)) == plan
+
+
+def test_plan_directory_lookup_requires_exactly_one_plan(tmp_path):
+    first = _plan(tmp_path, job_id="shorts_0123456789abcdef")
+    second = _plan(tmp_path, job_id="shorts_fedcba9876543210")
+    save_shorts_plan(first)
+    save_shorts_plan(second)
+    with pytest.raises(MCPVideoError) as exc:
+        load_shorts_plan(str(tmp_path))
+    assert exc.value.code == "shorts_plan_ambiguous"
+
+
+def test_plan_load_rejects_malformed_receipt(tmp_path):
+    path = tmp_path / "shorts_0123456789abcdef.plan.json"
+    path.write_text(json.dumps({"schema_version": 1}))
+    with pytest.raises(MCPVideoError) as exc:
+        load_shorts_plan(str(path))
+    assert exc.value.code == "shorts_plan_malformed"
+
+
+@pytest.mark.parametrize(
+    "payload",
+    (
+        {"candidate_id": "candidate_01", "action": "trim", "start": 9.0, "end": 8.0},
+        {"candidate_id": "candidate_01", "action": "approve", "title": "not allowed"},
+        {"candidate_id": "candidate_01", "action": "title_hook_edit"},
+        {"candidate_id": "candidate_01", "action": "sensitive_unsuitable", "sensitive": True, "start": 1.0},
+    ),
+)
+def test_review_decision_rejects_action_shape_mismatches(payload):
+    with pytest.raises(ValidationError):
+        ReviewDecision.model_validate(payload)
+
+
+def test_plan_save_rejects_intermediate_symlink(tmp_path):
+    real_dir = tmp_path / "real"
+    real_dir.mkdir()
+    linked_dir = tmp_path / "linked"
+    linked_dir.symlink_to(real_dir)
+    with pytest.raises(MCPVideoError) as exc:
+        save_shorts_plan(_plan(linked_dir / "plans"))
+    assert exc.value.code == "unsafe_path"
+
+
+def test_plan_save_cleans_temp_file_after_serialization_failure(tmp_path, monkeypatch):
+    plan = _plan(tmp_path / "plans")
+
+    def fail_serialization(_plan):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(plan_module, "_plan_to_json", fail_serialization)
+    with pytest.raises(OSError, match="disk full"):
+        save_shorts_plan(plan)
+    assert list(Path(plan.output_dir).iterdir()) == []


### PR DESCRIPTION
Continues #405 after package contracts/writer.\n\nAdds strict JSON-stable ShortsPlan persistence with atomic saves, exact file or unambiguous directory selection, source-free loading, fail-closed malformed/ambiguous recovery, candidate/decision invariants, and no process-global cache.\n\n- 364 changed lines\n- 8 focused tests passed\n- Ruff clean\n- No review mutation, rendering, adapters, posting, or docs yet.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/kinocut/pr/425"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787458240&installation_model_id=20207&pr_number=425&repository=KyaniteLabs%2Fkinocut&return_to=https%3A%2F%2Fgithub.com%2FKyaniteLabs%2Fkinocut%2Fpull%2F425&signature=4f7c1f90f411ed569d453e0e53d322dfd56f671c4092b85632e1e7c2bcc69438"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added structured plans for the stream-to-shorts workflow, including intake details, review decisions, candidates, and status tracking.
  * Plans can now be saved to and loaded from JSON files with deterministic naming.
  * Added validation to ensure plan data is complete, consistent, and uniquely identified.

* **Bug Fixes**
  * Added safeguards against unsafe output paths and ambiguous plan locations.
  * Improved error reporting for missing, malformed, or invalid plan files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->