### PR TITLE
feat: package approved shorts renders with fail-closed provenance

### DIFF
--- a/kinocut/product/__init__.py
+++ b/kinocut/product/__init__.py
@@ -7,6 +7,7 @@ and the persisted human-review contract.
 
 from .package import package_approved_clip
 from .package_models import *  # noqa: F403
+from .shorts_package import package_approved_candidate
 from .shorts_plan import (
     IntakeReport,
     RenderRecord,
@@ -38,6 +39,7 @@ __all__ = [  # noqa: F405
     "canonical_manifest_bytes",
     "load_shorts_plan",
     "manifest_artifact_digest",
+    "package_approved_candidate",
     "package_approved_clip",
     "package_kind",
     "parse_package_manifest",

--- a/kinocut/product/__init__.py
+++ b/kinocut/product/__init__.py
@@ -18,6 +18,7 @@ from .shorts_plan import (
     save_shorts_plan,
 )
 from .shorts_review import resolve_approved_candidate, review_shorts_plan
+from .shorts_render import render_approved_candidate
 
 __all__ = [  # noqa: F405
     "IntakeReport",
@@ -40,6 +41,7 @@ __all__ = [  # noqa: F405
     "package_approved_clip",
     "package_kind",
     "parse_package_manifest",
+    "render_approved_candidate",
     "resolve_approved_candidate",
     "review_shorts_plan",
     "save_shorts_plan",

--- a/kinocut/product/shorts_package.py
+++ b/kinocut/product/shorts_package.py
@@ -1,0 +1,131 @@
+"""Review-gated packaging of approved shorts renders.
+
+Packages each platform draft only after a current approve decision. Reads
+render receipts from the plan; never posts or opens network connections.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+from ..errors import MCPVideoError
+from .captions import CaptionArtifact
+from .package import package_approved_clip
+from .package_models import PackageConfig, PackageLineage, ThumbnailSpec
+from .shorts_plan import RenderRecord, ShortsPlan, load_shorts_plan, save_shorts_plan
+from .shorts_review import resolve_approved_candidate
+
+__all__ = ["package_approved_candidate"]
+
+
+def _package_error(problem: str, *, code: str, cause: str, recovery: str) -> MCPVideoError:
+    return MCPVideoError(
+        f"Problem: {problem} Likely cause: {cause} Recovery: {recovery}",
+        error_type="validation_error",
+        code=code,
+        suggested_action={"auto_fix": False, "description": recovery},
+    )
+
+
+def _caption_from_srt(path: str) -> CaptionArtifact:
+    try:
+        body = Path(path).read_text(encoding="utf-8")
+    except OSError as exc:
+        raise _package_error(
+            "Editable captions from the render stage could not be read.",
+            code="shorts_package_caption_missing",
+            cause=str(exc),
+            recovery="Re-run render_approved_candidate for this candidate, then package again.",
+        ) from exc
+    if not body.strip():
+        raise _package_error(
+            "Editable captions from the render stage are empty.",
+            code="shorts_package_caption_empty",
+            cause=f"file {path!r} has no caption text.",
+            recovery="Re-run render_approved_candidate so captions.srt is regenerated.",
+        )
+    if not body.endswith("\n"):
+        body = body + "\n"
+    return CaptionArtifact(
+        cues=(),
+        srt_body=body,
+        warnings=(),
+        low_confidence_token_count=0,
+        omitted_token_count=0,
+    )
+
+
+def _renders_for(plan: ShortsPlan, candidate_id: str) -> tuple[RenderRecord, ...]:
+    return tuple(record for record in plan.renders if record.candidate_id == candidate_id)
+
+
+def package_approved_candidate(
+    plan_path_or_dir: str,
+    *,
+    candidate_id: str,
+    package_root: str | None = None,
+    overwrite: bool = False,
+) -> dict[str, Any]:
+    """Package every platform draft for an approved candidate and persist the plan."""
+    plan = load_shorts_plan(plan_path_or_dir)
+    candidate = resolve_approved_candidate(plan, candidate_id)
+    records = _renders_for(plan, candidate.candidate_id)
+    if not records:
+        raise _package_error(
+            "No platform renders exist for this approved candidate.",
+            code="shorts_package_render_required",
+            cause=f"candidate {candidate.candidate_id!r} has no RenderRecord entries.",
+            recovery="Call render_approved_candidate(...) first, then package.",
+        )
+
+    base = os.path.realpath(
+        package_root or os.path.join(plan.output_dir, candidate.candidate_id, "packages")
+    )
+    os.makedirs(base, exist_ok=True)
+    config = PackageConfig(overwrite_package=overwrite)
+    emitted: list[dict[str, Any]] = []
+    manifests: list[str] = list(plan.package_manifests)
+
+    for record in records:
+        package_dir = os.path.join(base, record.platform)
+        result = package_approved_clip(
+            package_dir=package_dir,
+            vertical_video_path=record.output_path,
+            caption_artifact=_caption_from_srt(record.editable_subtitles),
+            candidate=candidate,
+            thumbnail=ThumbnailSpec(image_path=record.thumbnail_path, timestamp=candidate.start),
+            lineage=PackageLineage(
+                candidate_id=candidate.candidate_id,
+                review_decision_ref=plan.job_id,
+                generation_lineage_ref=record.render_digest,
+            ),
+            config=config,
+        )
+        if result.manifest_path not in manifests:
+            manifests.append(result.manifest_path)
+        emitted.append(
+            {
+                "platform": record.platform,
+                "package_root": result.package_root,
+                "manifest_path": result.manifest_path,
+                "asset_paths": list(result.asset_paths),
+                "external_posting": False,
+            }
+        )
+
+    revised = plan.model_copy(
+        update={
+            "package_manifests": tuple(manifests),
+            "status": "packaged",
+        }
+    )
+    save_shorts_plan(revised)
+    return {
+        "job_id": plan.job_id,
+        "candidate_id": candidate.candidate_id,
+        "status": "packaged",
+        "packages": emitted,
+        "external_posting": False,
+    }

--- a/kinocut/product/shorts_render.py
+++ b/kinocut/product/shorts_render.py
@@ -1,0 +1,282 @@
+"""Review-gated render orchestration for shorts plans.
+
+Fails closed without a current approve decision. Uses existing trim/resize/
+audio/caption/thumbnail engines only. No network or posting.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+from ..engine_audio_normalize import normalize_audio
+from ..engine_edit import trim
+from ..engine_resize import resize
+from ..engine_thumbnail import thumbnail
+from ..ffmpeg_helpers import _build_ffmpeg_cmd, _run_ffmpeg, _validate_input_path
+from .captions import CaptionConfig, WordTiming, build_caption_artifact
+from .clip_pipeline import clip_moment
+from .config import normalise_platform
+from .models import CandidateMoment, canonical_dedup_key
+from .shorts_plan import RenderRecord, ShortsPlan, load_shorts_plan, save_shorts_plan
+from .shorts_review import resolve_approved_candidate
+
+__all__ = ["render_approved_candidate"]
+
+
+def _candidate_digest(candidate: CandidateMoment) -> str:
+    payload = json.dumps(candidate.model_dump(mode="json"), sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(payload.encode()).hexdigest()[:16]
+
+
+def _render_digest(
+    *,
+    source_sha256: str,
+    candidate_digest: str,
+    platform: str,
+    start: float,
+    end: float,
+    config: dict[str, Any],
+) -> str:
+    material = (
+        f"render-v5:{source_sha256}:{candidate_digest}:{platform}:"
+        f"{start}:{end}:{json.dumps(config, sort_keys=True, separators=(',', ':'), default=str)}"
+    )
+    return hashlib.sha256(material.encode()).hexdigest()[:16]
+
+
+def _words_for(plan: ShortsPlan, candidate: CandidateMoment) -> list[WordTiming]:
+    """Prefer real word timings; fall back to even segment splits."""
+    segment_ids = {
+        seg.segment_id for seg in plan.transcript if seg.end > candidate.start and seg.start < candidate.end
+    }
+    words: list[WordTiming] = []
+    if plan.transcript_words:
+        for item in plan.transcript_words:
+            if item.segment_id not in segment_ids or item.end <= candidate.start or item.start >= candidate.end:
+                continue
+            start = max(item.start, candidate.start) - candidate.start
+            end = min(item.end, candidate.end) - candidate.start
+            if end <= start:
+                end = start + 0.001
+            words.append(WordTiming(word=item.word, start=start, end=end, probability=item.probability))
+        if words:
+            return words
+    for segment in plan.transcript:
+        if segment.segment_id not in segment_ids:
+            continue
+        tokens = segment.text.split()
+        if not tokens:
+            continue
+        step = (segment.end - segment.start) / len(tokens)
+        for index, token in enumerate(tokens):
+            global_start = segment.start + index * step
+            global_end = segment.start + (index + 1) * step
+            if global_end <= candidate.start or global_start >= candidate.end:
+                continue
+            start = max(global_start, candidate.start) - candidate.start
+            end = min(global_end, candidate.end) - candidate.start
+            words.append(
+                WordTiming(word=token, start=start, end=max(end, start + 0.001), probability=segment.confidence)
+            )
+    return words
+
+
+def _clip_bounds(candidate: CandidateMoment, platform: str):
+    internal = normalise_platform(platform)
+    clipped = clip_moment(candidate, platform=internal)
+    rendered = candidate.model_copy(
+        update={
+            "start": clipped.start_seconds,
+            "end": clipped.end_seconds,
+            "dedup_key": canonical_dedup_key(
+                start=clipped.start_seconds,
+                end=clipped.end_seconds,
+                excerpt=candidate.transcript_excerpt,
+                sensitivity=candidate.sensitivity,
+            ),
+        }
+    )
+    warning = None
+    if clipped.was_clipped or clipped.review_warning is not None:
+        warning = clipped.review_warning or (
+            f"moment {candidate.candidate_id!r} clipped for {internal}"
+        )
+    return clipped, rendered, warning
+
+
+def _payload_for(record: RenderRecord, clipped, *, cache_hit: bool) -> dict[str, Any]:
+    payload = record.model_copy(update={"cache_hit": cache_hit}).model_dump(mode="json")
+    payload.update(
+        {
+            "effective_start_seconds": clipped.start_seconds,
+            "effective_end_seconds": clipped.end_seconds,
+            "original_start_seconds": clipped.original_start_seconds,
+            "original_end_seconds": clipped.original_end_seconds,
+            "was_clipped": clipped.was_clipped,
+            "review_warning": clipped.review_warning,
+        }
+    )
+    return payload
+
+
+def _render_media(
+    *,
+    source_path: str,
+    platform_dir: str,
+    final_path: str,
+    start: float,
+    end: float,
+    audio_cfg: dict[str, Any],
+) -> str:
+    duration = end - start
+    fade = float(audio_cfg.get("fade_seconds", 0.05))
+    trimmed = trim(
+        source_path,
+        start=start,
+        duration=duration,
+        output_path=os.path.join(platform_dir, "trimmed.mp4"),
+    )
+    vertical = resize(
+        trimmed.output_path,
+        aspect_ratio="9:16",
+        output_path=os.path.join(platform_dir, "vertical-raw.mp4"),
+    )
+    faded = os.path.join(platform_dir, "vertical-faded.mp4")
+    fade_out = max(0.0, duration - fade)
+    _run_ffmpeg(
+        _build_ffmpeg_cmd(
+            vertical.output_path,
+            output_path=faded,
+            video_codec="copy",
+            audio_filter=(
+                f"afade=t=in:st=0:d={fade:.3f},afade=t=out:st={fade_out:.3f}:d={fade:.3f}"
+            ),
+        )
+    )
+    return normalize_audio(
+        faded,
+        target_lufs=float(audio_cfg.get("lufs", -14.0)),
+        output_path=final_path,
+    ).output_path
+
+
+def _render_one_platform(
+    plan: ShortsPlan,
+    candidate: CandidateMoment,
+    *,
+    platform: str,
+    base_dir: str,
+    source_path: str,
+    cand_digest: str,
+    audio_cfg: dict[str, Any],
+    records: list[RenderRecord],
+) -> tuple[dict[str, Any], RenderRecord | None, str | None]:
+    platform_dir = os.path.join(base_dir, platform)
+    os.makedirs(platform_dir, exist_ok=True)
+    final_path = os.path.join(platform_dir, "vertical.mp4")
+    clipped, rendered, warning = _clip_bounds(candidate, platform)
+    digest = _render_digest(
+        source_sha256=plan.intake.source_sha256,
+        candidate_digest=cand_digest,
+        platform=platform,
+        start=clipped.start_seconds,
+        end=clipped.end_seconds,
+        config=plan.config if isinstance(plan.config, dict) else {},
+    )
+    previous = next(
+        (
+            record
+            for record in records
+            if record.candidate_id == candidate.candidate_id
+            and record.platform == platform
+            and record.render_digest == digest
+            and os.path.isfile(record.output_path)
+        ),
+        None,
+    )
+    if previous is not None:
+        return _payload_for(previous, clipped, cache_hit=True), None, warning
+
+    finished = _render_media(
+        source_path=source_path,
+        platform_dir=platform_dir,
+        final_path=final_path,
+        start=clipped.start_seconds,
+        end=clipped.end_seconds,
+        audio_cfg=audio_cfg,
+    )
+    srt_path = os.path.join(platform_dir, "captions.srt")
+    body = build_caption_artifact(_words_for(plan, rendered), config=CaptionConfig()).srt_body
+    Path(srt_path).write_text(body + ("" if body.endswith("\n") else "\n"), encoding="utf-8")
+    thumb = thumbnail(finished, output_path=os.path.join(platform_dir, "thumbnail.jpg")).output_path
+    record = RenderRecord(
+        candidate_id=candidate.candidate_id,
+        platform=platform,  # type: ignore[arg-type]
+        output_path=finished,
+        render_digest=digest,
+        editable_subtitles=srt_path,
+        thumbnail_path=thumb,
+        cache_hit=False,
+    )
+    return _payload_for(record, clipped, cache_hit=False), record, warning
+
+
+def render_approved_candidate(
+    plan_path_or_dir: str,
+    *,
+    candidate_id: str,
+    output_path: str | None = None,
+) -> dict[str, Any]:
+    """Render platform drafts for an approved candidate and persist the plan."""
+    plan = load_shorts_plan(plan_path_or_dir)
+    candidate = resolve_approved_candidate(plan, candidate_id)
+    source_path = _validate_input_path(plan.intake.source_path)
+    base_dir = os.path.realpath(output_path or os.path.join(plan.output_dir, candidate.candidate_id))
+    if os.path.splitext(base_dir)[1]:
+        base_dir = os.path.dirname(base_dir)
+    os.makedirs(base_dir, exist_ok=True)
+
+    records: list[RenderRecord] = list(plan.renders)
+    emitted: list[dict[str, Any]] = []
+    warnings: list[str] = []
+    cand_digest = _candidate_digest(candidate)
+    render_cfg = plan.config.get("render", {}) if isinstance(plan.config, dict) else {}
+    audio_cfg = render_cfg.get("audio", {}) if isinstance(render_cfg, dict) else {}
+    if not isinstance(audio_cfg, dict):
+        audio_cfg = {}
+
+    for platform in plan.platforms:
+        payload, new_record, warning = _render_one_platform(
+            plan,
+            candidate,
+            platform=platform,
+            base_dir=base_dir,
+            source_path=source_path,
+            cand_digest=cand_digest,
+            audio_cfg=audio_cfg,
+            records=records,
+        )
+        if warning is not None:
+            warnings.append(warning)
+        if new_record is not None:
+            records = [
+                item
+                for item in records
+                if not (item.candidate_id == candidate.candidate_id and item.platform == platform)
+            ] + [new_record]
+        emitted.append(payload)
+
+    revised = plan.model_copy(update={"renders": tuple(records), "status": "rendered"})
+    save_shorts_plan(revised)
+    return {
+        "job_id": plan.job_id,
+        "candidate_id": candidate.candidate_id,
+        "status": "rendered",
+        "renders": emitted,
+        "external_posting": False,
+        "review_warnings": tuple(dict.fromkeys(warnings)),
+    }

--- a/tests/test_shorts_package.py
+++ b/tests/test_shorts_package.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from kinocut.errors import MCPVideoError
+from kinocut.product.models import CandidateMoment, canonical_dedup_key
+from kinocut.product.shorts_package import package_approved_candidate
+from kinocut.product.shorts_plan import RenderRecord, ShortsPlan, save_shorts_plan
+from kinocut.product.shorts_review import review_shorts_plan
+
+
+def _candidate() -> CandidateMoment:
+    excerpt = "A complete candidate thought."
+    return CandidateMoment(
+        candidate_id="candidate_01",
+        start=10.0,
+        end=25.0,
+        transcript_excerpt=excerpt,
+        suggested_title="A useful clip",
+        suggested_hook="Start here",
+        rationale="Complete thought",
+        confidence=0.9,
+        dedup_key=canonical_dedup_key(start=10.0, end=25.0, excerpt=excerpt, sensitivity="none"),
+    )
+
+
+def _plan_with_renders(tmp_path: Path) -> str:
+    source = tmp_path / "source.mp4"
+    source.write_bytes(b"source")
+    plan_dir = tmp_path / "plans"
+    candidate = _candidate()
+    renders = []
+    for platform in ("youtube-shorts", "instagram-reel"):
+        platform_dir = tmp_path / "renders" / platform
+        platform_dir.mkdir(parents=True)
+        video = platform_dir / "vertical.mp4"
+        thumb = platform_dir / "thumbnail.jpg"
+        srt = platform_dir / "captions.srt"
+        video.write_bytes(f"video-{platform}".encode())
+        thumb.write_bytes(f"thumb-{platform}".encode())
+        srt.write_text("1\n00:00:00,000 --> 00:00:01,000\nHello\n", encoding="utf-8")
+        renders.append(
+            RenderRecord(
+                candidate_id=candidate.candidate_id,
+                platform=platform,
+                output_path=str(video),
+                render_digest="a" * 16,
+                editable_subtitles=str(srt),
+                thumbnail_path=str(thumb),
+            )
+        )
+    save_shorts_plan(
+        ShortsPlan.model_validate(
+            {
+                "job_id": "shorts_0123456789abcdef",
+                "project_dir": str(tmp_path),
+                "output_dir": str(plan_dir),
+                "intake": {
+                    "source_path": str(source),
+                    "source_sha256": "b" * 64,
+                    "duration": 60.0,
+                    "width": 1920,
+                    "height": 1080,
+                    "audio_available": True,
+                },
+                "platforms": ("youtube-shorts", "instagram-reel"),
+                "config": {},
+                "transcript": (
+                    {"segment_id": "segment_01", "start": 10.0, "end": 25.0, "text": "A complete candidate thought."},
+                ),
+                "proposals": (candidate.model_dump(mode="json"),),
+                "renders": [item.model_dump(mode="json") for item in renders],
+            }
+        )
+    )
+    return str(plan_dir)
+
+
+def test_package_fails_closed_without_approve(tmp_path):
+    plan = _plan_with_renders(tmp_path)
+    with pytest.raises(MCPVideoError) as exc:
+        package_approved_candidate(plan, candidate_id="candidate_01")
+    assert exc.value.code == "shorts_review_required"
+
+
+def test_package_writes_both_platform_packages(tmp_path):
+    plan = _plan_with_renders(tmp_path)
+    review_shorts_plan(plan, candidate_id="candidate_01", decision="approve")
+    result = package_approved_candidate(plan, candidate_id="candidate_01")
+    assert result["status"] == "packaged"
+    assert result["external_posting"] is False
+    assert len(result["packages"]) == 2
+    platforms = {item["platform"] for item in result["packages"]}
+    assert platforms == {"youtube-shorts", "instagram-reel"}
+    for item in result["packages"]:
+        root = Path(item["package_root"])
+        assert (root / "vertical.mp4").is_file()
+        assert (root / "captions.srt").is_file()
+        assert (root / "thumbnail.jpg").is_file()
+        assert (root / "metadata.json").is_file()
+        assert Path(item["manifest_path"]).is_file()

--- a/tests/test_shorts_render.py
+++ b/tests/test_shorts_render.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from kinocut.errors import MCPVideoError
+from kinocut.product.models import CandidateMoment, canonical_dedup_key
+from kinocut.product.shorts_plan import ShortsPlan, save_shorts_plan
+from kinocut.product.shorts_render import render_approved_candidate
+from kinocut.product.shorts_review import review_shorts_plan
+
+
+def _plan(tmp_path: Path, source: Path) -> str:
+    excerpt = "A complete candidate thought."
+    candidate = CandidateMoment(
+        candidate_id="candidate_01",
+        start=10.0,
+        end=25.0,
+        transcript_excerpt=excerpt,
+        suggested_title="A useful clip",
+        suggested_hook="Start here",
+        rationale="Complete thought",
+        confidence=0.9,
+        dedup_key=canonical_dedup_key(start=10.0, end=25.0, excerpt=excerpt, sensitivity="none"),
+    )
+    plan_dir = tmp_path / "plans"
+    save_shorts_plan(
+        ShortsPlan.model_validate(
+            {
+                "job_id": "shorts_0123456789abcdef",
+                "project_dir": str(tmp_path),
+                "output_dir": str(plan_dir),
+                "intake": {
+                    "source_path": str(source),
+                    "source_sha256": "a" * 64,
+                    "duration": 60.0,
+                    "width": 1920,
+                    "height": 1080,
+                    "audio_available": True,
+                },
+                "platforms": ("youtube-shorts", "instagram-reel"),
+                "config": {"render": {"audio": {"lufs": -14.0, "fade_seconds": 0.05}}},
+                "transcript": (
+                    {"segment_id": "segment_01", "start": 10.0, "end": 25.0, "text": excerpt},
+                ),
+                "proposals": (candidate.model_dump(mode="json"),),
+            }
+        )
+    )
+    return str(plan_dir)
+
+
+def _stub(monkeypatch, source: Path) -> None:
+    def out(path, data=b"x"):
+        Path(path).write_bytes(data)
+        return SimpleNamespace(output_path=path)
+
+    monkeypatch.setattr(
+        "kinocut.product.shorts_render.trim",
+        lambda *a, output_path=None, **k: out(output_path, b"trim"),
+    )
+    monkeypatch.setattr(
+        "kinocut.product.shorts_render.resize",
+        lambda *a, output_path=None, **k: out(output_path, b"resize"),
+    )
+    monkeypatch.setattr(
+        "kinocut.product.shorts_render.normalize_audio",
+        lambda *a, output_path=None, **k: out(output_path, b"norm"),
+    )
+    monkeypatch.setattr(
+        "kinocut.product.shorts_render.thumbnail",
+        lambda *a, output_path=None, **k: out(output_path, b"thumb"),
+    )
+
+    def run(cmd, **k):
+        for item in reversed(cmd):
+            if isinstance(item, str) and item.endswith(".mp4"):
+                Path(item).write_bytes(b"ffmpeg")
+                break
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr("kinocut.product.shorts_render._run_ffmpeg", run)
+    monkeypatch.setattr("kinocut.product.shorts_render._validate_input_path", lambda p: str(source))
+
+
+def test_render_fails_closed_without_approve(tmp_path):
+    source = tmp_path / "source.mp4"
+    source.write_bytes(b"fake")
+    with pytest.raises(MCPVideoError) as exc:
+        render_approved_candidate(_plan(tmp_path, source), candidate_id="candidate_01")
+    assert exc.value.code == "shorts_review_required"
+
+
+def test_render_pipeline_records_both_platforms(tmp_path, monkeypatch):
+    source = tmp_path / "source.mp4"
+    source.write_bytes(b"fake-video")
+    plan = _plan(tmp_path, source)
+    review_shorts_plan(plan, candidate_id="candidate_01", decision="approve")
+    _stub(monkeypatch, source)
+    result = render_approved_candidate(plan, candidate_id="candidate_01")
+    assert result["status"] == "rendered"
+    assert result["external_posting"] is False
+    assert len(result["renders"]) == 2
+    assert {r["platform"] for r in result["renders"]} == {"youtube-shorts", "instagram-reel"}
+    again = render_approved_candidate(plan, candidate_id="candidate_01")
+    assert all(item.get("cache_hit") for item in again["renders"])


### PR DESCRIPTION
Mirrors Forgejo package orchestrator PR for #405.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/kinocut/pr/429"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787461587&installation_model_id=20207&pr_number=429&repository=KyaniteLabs%2Fkinocut&return_to=https%3A%2F%2Fgithub.com%2FKyaniteLabs%2Fkinocut%2Fpull%2F429&signature=44141a4de6bbfd8a28bb5a0a244047b05d68b9bc6ae7acc1bbddf7e3049c25b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->