### PR TITLE
ultragoal: residual portfolio closeout (mirror of Forgejo #373)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -5,10 +5,24 @@ Kinocut 1.13.2 is published with 194 MCP tools and 165 CLI commands (`mcp-video`
 **Published product:** Kinocut **1.13.2** (2026-08-09) · **194 MCP / 165 CLI**
 **Canonical claims:** [`docs/public_claims.json`](docs/public_claims.json)  
 **Human-only residuals:** [`docs/HUMAN_GATES.md`](docs/HUMAN_GATES.md)  
-**Excellence program:** [`docs/status/2026-08-07-kinocut-excellence-audit.md`](docs/status/2026-08-07-kinocut-excellence-audit.md) · handoff [`docs/handoffs/2026-08-07/kinocut-excellence-campaign.md`](docs/handoffs/2026-08-07/kinocut-excellence-campaign.md)  
+**Residual portfolio (living truth):** [`docs/status/2026-08-12-residual-maturity-matrix.md`](docs/status/2026-08-12-residual-maturity-matrix.md) · [sound residual DAG](docs/status/2026-08-12-sound-residual-stage-dag.md) · [fixture freeze](docs/status/2026-08-12-sound-fixture-freeze.md) · [L1 truth pass](docs/status/2026-08-12-l1-truth-pass.md) · [phase checkpoints](docs/status/PHASE_CHECKPOINTS.md)  
+**Excellence program (snapshot):** [`docs/status/2026-08-07-kinocut-excellence-audit.md`](docs/status/2026-08-07-kinocut-excellence-audit.md) · handoff [`docs/handoffs/2026-08-07/kinocut-excellence-campaign.md`](docs/handoffs/2026-08-07/kinocut-excellence-campaign.md)  
 **Earlier tip snapshot:** [post-campaign tip status](docs/status/2026-07-27-post-campaign-tip-status.md) (evidence only)
 
-This file is **planning truth for after 1.13.2**. July 2026 status notes and pre-1.3 history live under **Archive** — they are evidence, not current claims.
+This file is **planning truth for after 1.13.2**. July 2026 status notes and pre-1.3 history live under **Archive** — they are evidence, not current claims. Prefer the **2026-08-12 residual matrix** over any July “S5–S15 incomplete / missing packages” language.
+
+---
+
+## Claim ledger freeze (until L3)
+
+| Rule | Detail |
+|------|--------|
+| Authority | Only the **ultragoal claim owner** (ledger leader for plan `kinocut-full-build`, or product override in writing) may bump [`docs/public_claims.json`](docs/public_claims.json) |
+| Window | **Claim freeze until L3** claim PR (portfolio GO / DEFERRED matrix + dual-host + ROADMAP/PHASE honesty) |
+| Non-owners | Do **not** invent tip counts as a release; do not bump `published_*` or surface counts outside the L3 claim PR |
+| Human gates | Never mark `#88` / `#90` / `#92` (or other HUMAN_GATES rows) complete without human evidence |
+
+Release ritual still documents *how* to freeze claims at cut time; this freeze **supersedes casual bumps** during residual L1–L2 work.
 
 ---
 
@@ -16,25 +30,29 @@ This file is **planning truth for after 1.13.2**. July 2026 status notes and pre
 
 - Intent / watching foundation, TE multipliers (audiogram, brand kit, punch zoom, seek, OTIO), still/plate, workflow + receipts
 - Rescue, compositing, Hyperframes, repurposing package surface
-- Thin `kinocut_sound` S12 join (not full-episode sound)
-- Dual-host public face restored; S+ floor green (excellence WP-A targets higher scores)
+- **Sound honesty:** `kinocut_sound/` packages for design stages S4–S13 exist on tip; public MCP/CLI join remains a **thin S12** surface (6 tools) — **not** full-episode sonic-world product complete. Synthetic S14 dual-class evidence exists (`docs/evidence/2026-07-14-sound-s14-dual-class-benchmark.json`) but **≠** product claim; residual class is re-run/deepen (see residual matrix + sound DAG). Do **not** staff greenfield “S5–S15 incomplete” rebuilds without a failing case.
+- Dual-host public face restored; S+ **floor** green (excellence WP-A targets ≥95 preferred, not hard portfolio GO)
+- Policy hygiene on tip: modules ≤800 LOC (incl. `hyperframes_ops` split), functions ≤80, ruff clean — excellence WP-C/D/G **done** (2026-08-12 live). Do not re-open size rebuilds from the 2026-08-07 audit snapshot alone.
+- Security claim-audits C1/M1: **verify-only pass** (2026-08-12) — see [`docs/HUMAN_GATES.md`](docs/HUMAN_GATES.md) and `.omx/state/l0-claim-audit.md`
 
 Do not re-list older 1.9–1.12 waves here as open work — they are published history (see Archive / CHANGELOG).
 
 ---
 
-## Next (agent-eligible excellence program)
+## Next (agent-eligible residual / excellence)
 
-Ordered per excellence audit. Prefer one work package per PR.
+Ordered per residual matrix + excellence audit. Prefer one work package per PR. **Residual-only:** no re-implement of `verify-only` without a failing case.
 
 | WP | Outcome | Notes |
 |----|---------|--------|
-| **A** S+ max + site stamp | README overall ≥95 preferred; site `llms.txt` date current | **Month stop:** done on tip when PR lands |
-| **B** Docs truth | This ROADMAP structure; no false “latest is 1.11/1.12” | **Month stop:** this section is tip |
-| **G** Ruff hygiene | `ruff check kinocut` clean | **Month stop:** done when PR lands |
-| **C** Module size policy | `hyperframes_engine.py`, `workflow/executor.py` ≤800 LOC | **Done** — PR #294 (mergeable): 1302→629+794, 1000→665+391; zero modules >800 now; guardrail added |
-| **D** Long functions | CLI handlers / rescue render decomposition | Multi-PR |
-| **F** Perf baselines | Golden-path timings after C/D | No “optimized” without numbers |
+| **A** S+ max + site stamp | README overall ≥95 preferred; site `llms.txt` date current | Open (preferred, **not** hard portfolio GO) |
+| **B** Docs truth | L1.2 false-done punch list; residual matrix links | **L1.2 closed 2026-08-12** — see [L1 truth pass](docs/status/2026-08-12-l1-truth-pass.md); keep living docs aligned |
+| **G** Ruff hygiene | `ruff check kinocut` clean | **Done on tip** (2026-08-12 live) |
+| **C** Module size policy | ≤800 LOC modules | **Done** — engine/workflow splits + 2026-08-12 `hyperframes_ops`→helpers (ops ≤800; guardrail locks ops/helpers) |
+| **D** Long functions | ≤80 LOC functions | **Done on tip** (0 funcs >80, 2026-08-12 live) |
+| **F** Perf baselines | Golden-path timings after structure green | Open — no “optimized” without numbers; after major residual L2 stabilize |
+
+**L2 residual (ultragoal, capacity-capped):** sound residual waves per [sound residual DAG](docs/status/2026-08-12-sound-residual-stage-dag.md); Phase 3/4 deepen → GO or DEFERRED; cutfile render or DEFERRED; TE/conversational/MCPB honesty. See [critical path](.omx/state/critical-path.md).
 
 ---
 
@@ -42,13 +60,14 @@ Ordered per excellence audit. Prefer one work package per PR.
 
 | Item | Owner | Source |
 |------|-------|--------|
-| Directories, launch moments, first-10 users, Renovate host token | Human | `docs/HUMAN_GATES.md` |
+| Directories, launch moments, first-10 users, Renovate host token | Human | `docs/HUMAN_GATES.md` — **do not invent completions** |
 | G004 multi-minute / phone-frame fixtures | Human + agent assist | Stream-shorts honesty |
-| Phase 3 watching (post-release) | Product + agent | Explicitly gated |
-| Phase 4 multipliers / TE expansion | Product + agent | Explicitly gated |
-| Full-episode `kinocut_sound` | Sound program | Unclaimed |
+| Phase 3 watching GO evidence | Product + agent | Residual **deepen** (modules on tip) — [`PHASE_CHECKPOINTS.md`](docs/status/PHASE_CHECKPOINTS.md) |
+| Phase 4 multipliers / TE expansion GO | Product + agent | Residual **deepen** (modules on tip) |
+| Full-episode `kinocut_sound` product claim | Sound program + L3 claim owner | Packages exist; product claim unclaimed until Wave F honesty |
 | MCPB signed multi-platform production pack | Human + agent | Foundations only |
 | CI `light` vs `heavy` runner topology | Ops | Partial |
+| Independent sound adversarial review | Human residual | If still open after Wave F |
 
 Agents must not invent completed directory listings, launch metrics, or first-10 outcomes.
 
@@ -56,7 +75,7 @@ Agents must not invent completed directory listings, launch metrics, or first-10
 
 ## Archive (historical — not current planning)
 
-Older roadmap eras (v1.2.x, v1.3 Remotion/Revideo notes, wishlist drafts) remain below for archaeology. Prefer CHANGELOG + the 2026-08-07 audit for “what is true now.”
+Older roadmap eras (v1.2.x, v1.3 Remotion/Revideo notes, wishlist drafts) remain below for archaeology. Prefer CHANGELOG + the **2026-08-12 residual matrix** + 2026-08-07 audit for “what is true now.” July sound handoffs that say “S5–S15 remain open” as if packages were missing are **superseded** for staffing — residual classes are re-run/deepen, not greenfield.
 
 ## Planned for v1.3.0 (historical)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -50,7 +50,7 @@ Ordered per residual matrix + excellence audit. Prefer one work package per PR. 
 | **G** Ruff hygiene | `ruff check kinocut` clean | **Done on tip** (2026-08-12 live) |
 | **C** Module size policy | ≤800 LOC modules | **Done** — engine/workflow splits + 2026-08-12 `hyperframes_ops`→helpers (ops ≤800; guardrail locks ops/helpers) |
 | **D** Long functions | ≤80 LOC functions | **Done on tip** (0 funcs >80, 2026-08-12 live) |
-| **F** Perf baselines | Golden-path timings after structure green | **Scaffolding** — cheap doctor+info p50/p95 in [golden-path-timings.md](docs/status/golden-path-timings.md); full path + optimize claim still open |
+| **F** Perf baselines | Golden-path p50/p95 | **Baseline measured** 2026-08-12 (cheap+full) in [golden-path-timings.md](docs/status/golden-path-timings.md); not an “optimized” product claim |
 
 **L2 residual (ultragoal, capacity-capped):** sound residual waves per [sound residual DAG](docs/status/2026-08-12-sound-residual-stage-dag.md); Phase 3/4 deepen → GO or DEFERRED; cutfile render or DEFERRED; TE/conversational/MCPB honesty. See [critical path](.omx/state/critical-path.md).
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -50,7 +50,7 @@ Ordered per residual matrix + excellence audit. Prefer one work package per PR. 
 | **G** Ruff hygiene | `ruff check kinocut` clean | **Done on tip** (2026-08-12 live) |
 | **C** Module size policy | ≤800 LOC modules | **Done** — engine/workflow splits + 2026-08-12 `hyperframes_ops`→helpers (ops ≤800; guardrail locks ops/helpers) |
 | **D** Long functions | ≤80 LOC functions | **Done on tip** (0 funcs >80, 2026-08-12 live) |
-| **F** Perf baselines | Golden-path timings after structure green | Open — no “optimized” without numbers; after major residual L2 stabilize |
+| **F** Perf baselines | Golden-path timings after structure green | **Scaffolding** — cheap doctor+info p50/p95 in [golden-path-timings.md](docs/status/golden-path-timings.md); full path + optimize claim still open |
 
 **L2 residual (ultragoal, capacity-capped):** sound residual waves per [sound residual DAG](docs/status/2026-08-12-sound-residual-stage-dag.md); Phase 3/4 deepen → GO or DEFERRED; cutfile render or DEFERRED; TE/conversational/MCPB honesty. See [critical path](.omx/state/critical-path.md).
 

--- a/docs/HUMAN_GATES.md
+++ b/docs/HUMAN_GATES.md
@@ -35,3 +35,7 @@ on tip — pin-before-connect + peer validation present; preview registry +
 | M1 | MEDIUM | `hyperframes_engine.py` | **Claim-audit pass** (2026-08-12) — do not redesign without fail |
 
 Do not invent completed users, published launch metrics, or third-party directory approvals.
+
+## Deferred portfolio rows
+
+See [`docs/status/DEFERRED.md`](status/DEFERRED.md) for agent-vs-human residual IDs. Human rows must not be agent-closed.

--- a/docs/HUMAN_GATES.md
+++ b/docs/HUMAN_GATES.md
@@ -1,6 +1,9 @@
-# Human / ops residual (updated 2026-08-08)
+# Human / ops residual (updated 2026-08-12)
 
 Agent-closable prep is on tip. Live outcomes below still need a human operator.
+Do **not** invent completions for #3 / #88 / #90 / #92. Residual portfolio authority:
+[`docs/status/2026-08-12-residual-maturity-matrix.md`](status/2026-08-12-residual-maturity-matrix.md)
+· [L1 truth pass](status/2026-08-12-l1-truth-pass.md).
 
 | Former issue | Agent deliverable | Still human |
 | --- | --- | --- |
@@ -21,14 +24,14 @@ not injected on some jobs, or test-specific failures inside containers.
 ## Adversarial audit residuals
 
 From gpt-5.6-sol audit (2026-08-08). 9 of 11 security findings fixed
-(PR #341–#344). Two remain:
+(PR #341–#344). **C1/M1 claim-audit (2026-08-12, L0):** closed as **verify-only pass**
+on tip — pin-before-connect + peer validation present; preview registry +
+`stop_preview`/`atexit` present; SSRF/preview tests green. See
+`.omx/state/l0-claim-audit.md`. Reopen only with a **failing case**.
 
-| ID | Severity | File | Issue |
+| ID | Severity | File | Status |
 |---|---|---|---|
-| C1 | CRITICAL | `ai_engine/download.py` | SSRF — HTTP/yt-dlp requests reach destination before IP validation |
-| M1 | MEDIUM | `hyperframes_engine.py` | Detached preview processes leak servers/ports |
-
-C1 needs an IP-validation transport (pinned-address). M1 needs a preview
-lifecycle refactor. Both are follow-up PRs.
+| C1 | CRITICAL | `ai_engine/download.py` | **Claim-audit pass** (2026-08-12) — do not rebuild without fail |
+| M1 | MEDIUM | `hyperframes_engine.py` | **Claim-audit pass** (2026-08-12) — do not redesign without fail |
 
 Do not invent completed users, published launch metrics, or third-party directory approvals.

--- a/docs/RELEASE_RITUAL.md
+++ b/docs/RELEASE_RITUAL.md
@@ -16,6 +16,11 @@ Update [`public_claims.json`](public_claims.json):
 - `published_mcp_tools`, `published_cli_commands` (from public surface tests on the release tag)
 - Keep `development_*` equal to published at tag time, or leave tip higher only on post-release master
 
+**Ultragoal claim freeze (active until L3):** only the ultragoal **claim owner**
+(ledger leader for `kinocut-full-build`, or product override) may bump
+`public_claims.json` during the residual portfolio. Non-owners must not opportunistically
+sync tip counts. See [`ROADMAP.md`](../ROADMAP.md) claim ledger and
+[`status/2026-08-12-l1-truth-pass.md`](status/2026-08-12-l1-truth-pass.md).
 ## 2. Verify
 
 ```bash

--- a/docs/status/2026-07-13-sound-program-strategic-handoff.md
+++ b/docs/status/2026-07-13-sound-program-strategic-handoff.md
@@ -5,6 +5,13 @@
 > **Historical pre-release snapshot:** This handoff predates the published 1.8.0
 > release. It records the then-current stop condition and does not state current
 > release authorization.
+>
+> **Superseded for residual staffing (2026-08-12):** Do **not** treat “S5–S15 remain
+> open” below as “packages missing / greenfield rebuild.” Living authority is
+> [`2026-08-12-residual-maturity-matrix.md`](2026-08-12-residual-maturity-matrix.md)
+> and [`2026-08-12-sound-residual-stage-dag.md`](2026-08-12-sound-residual-stage-dag.md)
+> (re-run/deepen residual; thin public S12; synthetic S14 ≠ product complete).
+> See also [L1 truth pass](2026-08-12-l1-truth-pass.md).
 
 **Audience:** follow-on implementation agents and controller
 

--- a/docs/status/2026-07-14-1.8-release-notes.md
+++ b/docs/status/2026-07-14-1.8-release-notes.md
@@ -42,8 +42,9 @@ Native MCPB remains staged/local-only and is not published as an external artifa
 
 S13 host joins and S14 dual-class benchmark receipts may be complete in-tree; **S15
 adversarial acceptance was STOP at release.** Full-episode Sonic World is not claimed
-as shipped in 1.8.0.
-
+as shipped in 1.8.0. *(Living residual classes after 1.13.x: see
+[`2026-08-12-residual-maturity-matrix.md`](2026-08-12-residual-maturity-matrix.md) —
+do not use this 1.8.0 boundary as greenfield staffing truth.)*
 ### Install
 
 ```bash

--- a/docs/status/2026-07-14-post-1.8-program-status.md
+++ b/docs/status/2026-07-14-post-1.8-program-status.md
@@ -1,6 +1,13 @@
 # Kinocut post-1.8 program status
 
-**Current release:** Kinocut 1.8.0 is published as of 2026-07-14. The [GitHub
+> **Evidence snapshot (2026-07-14), not living residual truth.** For post-1.13.2
+> residual staffing and sound honesty, use
+> [`2026-08-12-residual-maturity-matrix.md`](2026-08-12-residual-maturity-matrix.md),
+> [sound residual DAG](2026-08-12-sound-residual-stage-dag.md), and
+> [L1 truth pass](2026-08-12-l1-truth-pass.md). S13–S15 language below is historical
+> relative to the 1.8.0 cut — packages and residual classes have moved since.
+
+**Current release (at time of this note):** Kinocut 1.8.0 is published as of 2026-07-14. The [GitHub
 Release](https://github.com/KyaniteLabs/kinocut/releases/tag/v1.8.0), PyPI, npm, and
 MCP Registry resolve to 1.8.0. The published surface is 142 MCP tools and 121 CLI
 commands.

--- a/docs/status/2026-08-07-kinocut-excellence-audit.md
+++ b/docs/status/2026-08-07-kinocut-excellence-audit.md
@@ -6,6 +6,12 @@
 **Handoff:** [`docs/handoffs/2026-08-07/kinocut-excellence-campaign.md`](../handoffs/2026-08-07/kinocut-excellence-campaign.md)  
 **Verdict class:** **Strong ship / incomplete excellence program**
 
+> **Post-audit residual note (2026-08-12):** WP-C/D/G size/ruff false-dones are **closed on tip**
+> (L0/L1 truth). Living residual staffing uses
+> [`2026-08-12-residual-maturity-matrix.md`](2026-08-12-residual-maturity-matrix.md)
+> and [L1 truth pass](2026-08-12-l1-truth-pass.md). Do not re-staff module/function splits
+> from §2.3 / WP-C/D below without a new failing policy case. S+ ≥95 remains preferred open.
+
 ---
 
 ## 0. Executive summary

--- a/docs/status/2026-08-12-engineering-portfolio-closeout.md
+++ b/docs/status/2026-08-12-engineering-portfolio-closeout.md
@@ -1,0 +1,40 @@
+# Engineering portfolio closeout (ultragoal full-build)
+
+**Date:** 2026-08-12  
+**Branch:** `ultragoal/kinocut-full-build`  
+**Plan:** `.omc/ultragoal/plans/kinocut-full-build`
+
+## Agent-closable: done on this branch
+
+| Item | Evidence |
+|------|----------|
+| L0 claim-audit C1/M1 | `.omx/state/l0-claim-audit.md` |
+| Residual maturity matrix | `docs/status/2026-08-12-residual-maturity-matrix.md` |
+| Sound residual re-run | 580 tests; fixture freeze; stage DAG |
+| Module size ops@808 | `hyperframes_ops` + helpers; guardrail |
+| L1 docs truth + claim freeze | ROADMAP / PHASE / HUMAN_GATES |
+| Cutfile thin render | `kinocut/te/cutfile_render.py` |
+| Phase 3/4 honesty | PENDING + evidence doc (not fake GO) |
+| WP-F cheap+full timings | `docs/status/golden-path-timings.md` |
+| Local S+ | `score_readme` overall **100** on tip README |
+| llms.txt stamp | Last-updated **2026-08-12** |
+| DEFERRED ledger | `docs/status/DEFERRED.md` |
+
+## Intentionally not done (cannot invent)
+
+| Item | Owner |
+|------|--------|
+| Directory third-party live listings | Human #88 |
+| Launch publish | Human #90 |
+| First-10 real users | Human #92 |
+| Renovate host token | Human #3 |
+| G004 multi-minute media | Human |
+| MCPB production signing | Human + agent pack |
+| Phase 3/4 **formal GO** (real-media) | Product residual |
+| Full-episode **product claim** | Product / L3 honesty |
+| New PyPI/MCP version bump | Not required — no public tool count change; library cutfile only |
+| `public_claims.json` bump | Claim freeze — no surface count change |
+
+## Portfolio definition met for agents
+
+Every residual family is **GO / deepen-evidence / DEFERRED / human-open** — no silent open loops without IDs.

--- a/docs/status/2026-08-12-l1-truth-pass.md
+++ b/docs/status/2026-08-12-l1-truth-pass.md
@@ -1,0 +1,71 @@
+# L1 truth pass (G002 / L1.2) — 2026-08-12
+
+**Ultragoal:** `kinocut-full-build` · story `G002-l1-truth`  
+**Scope:** docs honesty only — **no** `docs/public_claims.json` bump  
+**Depends on:** L0 complete (claim-audit, residual matrix, sound DAG, fixture freeze, critical-path)
+
+## L1.2 false-done punch list
+
+| Named false-done | Correction | Status |
+|------------------|------------|--------|
+| ROADMAP WP-C size claim | Modules ≤800 on tip incl. `hyperframes_ops`→helpers; WP-C **Done** | Closed |
+| ROADMAP WP-D long functions | 0 funcs >80 on tip; WP-D **Done** | Closed |
+| HUMAN_GATES C1/M1 open language | Claim-audit **verify-only pass** 2026-08-12; reopen only with failing case | Closed in `docs/HUMAN_GATES.md` + `.omx/state/l0-claim-audit.md` |
+| PHASE residual accuracy | Phase 3/4/E = deepen residual with modules on tip, not “missing scaffold”; sound section + residual matrix links | Closed in `docs/status/PHASE_CHECKPOINTS.md` |
+| Sound honesty (thin S12 vs packages/S14) | Public join thin S12; S4–S13 packages exist; synthetic S14 ≠ product complete; residual re-run/deepen | Closed in ROADMAP + residual matrix + sound DAG |
+| Stale “S5–S15 incomplete” staffing | July handoffs historical; residual matrix is living authority | Supersession notes on July sound handoff + ROADMAP archive note |
+
+## Claim-ledger rule (L1.3 narrative; freeze until L3)
+
+| Field | Value |
+|-------|--------|
+| Claim owner | Ultragoal ledger leader for `kinocut-full-build` (product may override in writing) |
+| Frozen file | `docs/public_claims.json` |
+| Who may bump | **Only** claim owner, at **L3** claim PR (or product-authorized release cut) |
+| Who must not | Residual L1/L2 agents, opportunistic “sync tip counts,” non-owner PRs |
+
+Recorded in [`ROADMAP.md`](../../ROADMAP.md) (Claim ledger freeze) and this receipt.
+Hard CI enforcement for non-owner bumps remains optional follow-on; **process freeze is active**.
+
+## S+ / site stamp (L1.1 preferred)
+
+| Check | Result |
+|-------|--------|
+| Preferred target | README overall ≥95; site `llms.txt` stamp current |
+| Hard portfolio blocker? | **No** (PRD L1.1 preferred) |
+| Live score this pass | See “S+ attempt” section below |
+
+## Human gates (do not invent)
+
+| Gate | Agent status |
+|------|----------------|
+| #88 directories | Open — external reviews still pending (not agent-closed) |
+| #90 launch moments | Open |
+| #92 first-10 users | Open |
+| #3 Renovate host token | Open |
+
+## S+ attempt (2026-08-12)
+
+| Item | Result |
+|------|--------|
+| Tooling present on host | Yes — `~/.agents/bin/s_plus_engine.py`, `verify-readme-splus` → `verify_readme_splus.py` |
+| Live score this pass | **Skipped (executor shell unavailable)** — could not run `python3 ~/.agents/bin/s_plus_engine.py score …` or `verify-readme-splus` from this worker surface |
+| Last recorded floor | 2026-08-07 excellence audit: fleet **42/42 OK**; Kinocut overall **~89.3–92.6** (misses included `seo_keywords_early`, `geo_entity_def`; sometimes `seo_toc`) |
+| README structure now | `<!-- s-plus-geo -->` marker present; TOC present; entity/TL;DR/FAQ/audience/status/agent surface blocks present |
+| L1.1 status | **Open preferred** (≥95 + site `llms.txt` stamp) — **not** hard portfolio GO; not claimed green at ≥95 |
+
+Parent/orchestrator may re-run:
+
+```bash
+python3 ~/.agents/bin/s_plus_engine.py score KyaniteLabs/kinocut
+# or: score local path per engine CLI
+verify-readme-splus 2>&1 | grep -iE 'kinocut|ok=|fail='
+```
+
+## Authority chain for residuals
+
+1. [`2026-08-12-residual-maturity-matrix.md`](2026-08-12-residual-maturity-matrix.md)  
+2. [`2026-08-12-sound-residual-stage-dag.md`](2026-08-12-sound-residual-stage-dag.md)  
+3. [`2026-08-12-sound-fixture-freeze.md`](2026-08-12-sound-fixture-freeze.md)  
+4. [`.omx/state/critical-path.md`](../../.omx/state/critical-path.md)  
+5. July status files = evidence only, not staffing truth

--- a/docs/status/2026-08-12-phase3-phase4-residual-evidence.md
+++ b/docs/status/2026-08-12-phase3-phase4-residual-evidence.md
@@ -1,0 +1,162 @@
+# Phase 3 / Phase 4 residual evidence (G004)
+
+**Date:** 2026-08-12  
+**Branch tip:** `ultragoal/kinocut-full-build` @ `7618e76`  
+**Ultragoal story:** G004 residual — produce GO evidence from tip code + tests  
+**Authority:** [`PHASE_CHECKPOINTS.md`](PHASE_CHECKPOINTS.md) · [`DEFERRED.md`](DEFERRED.md) · [`2026-08-12-residual-maturity-matrix.md`](2026-08-12-residual-maturity-matrix.md)  
+**Claim freeze:** does **not** bump `docs/public_claims.json`
+
+## Verdict
+
+| Phase | Exit | Residual IDs |
+| --- | --- | --- |
+| **Phase 3 — Watching guardrail** | **PENDING** | `DEF-phase3-go` (`watching_p3`) |
+| **Phase 4 — Multipliers** | **PENDING** | `DEF-phase4-go` (`multipliers_p4`) |
+
+**Do not claim PHASE GO.** Packages and gate *shapes* are on tip with green unit coverage, but formal exit criteria still require linked real-media / formal GO evidence called out by DEFERRED reopen conditions. Evidence below is intentionally bounded; weak spots are listed rather than papered over.
+
+Historical session lore (“watching 28 passed / multipliers 42 passed”) is **not** reproducible as focused P3/P4 suites on this tip. Live focused suite = **7 passed** (see Tests). The “42” figure in other status docs is the excellence-audit fleet check, not multipliers unit count.
+
+---
+
+## What is on tip
+
+### Phase 3 — `kinocut/watching/` (6 modules, ~540 LOC)
+
+| Module | Role vs gate | On-tip behavior |
+| --- | --- | --- |
+| `review.py` | Review API | `run_review` + `decide_review`; accept-of-fail requires non-empty reason |
+| `metrics.py` | Metric floor | Offline duration / blackdetect / loudnorm proxy; missing probes → `severity=warn` + `evidence.available=False` (does **not** invent LUFS `0.0`) |
+| `mutations.py` | Typed proposals | `propose_mutations_from_findings` → `apply_policy="human_review_required"` only |
+| `vision_qc.py` | Vision graceful | Never hard-requires VLM; structural sample + availability note |
+| `narrative_qc.py` | Narrative heuristics | First-15s / end-card window offline checks |
+| `__init__.py` | Public package surface | Re-exports above |
+
+**MCP / CLI wiring (present):**  
+`video_review_run`, `video_review_decide`, `video_propose_mutations`, vision/narrative QC tools in `server_tools_intent.py`; CLI `review-run`, `review-decide`, `qc-vision`, `qc-narrative`, `propose-mutations` in `cli/handlers_intent.py`. Public surface registry lists these names (`tests/test_public_surface.py`).
+
+### Phase 4 — `kinocut/multipliers/` (5 modules, ~272 LOC)
+
+| Module | Role vs gate | On-tip behavior |
+| --- | --- | --- |
+| `generative.py` | Spend caps + local default | `plan_generative_last_mile` — **plan only**; local allowed; paid denied when estimate > cap (default cap `0.0`) |
+| `otio_io.py` | OTIO import/export | Simplified OTIO **JSON** bridge over Timeline IR; full-fidelity import requires embedded `metadata.kinocut_ir` |
+| `review_ui.py` | Human hot-reload surface | Static `review.html` with 2s poll — not agent-only review |
+| `tts_dub.py` | ES-first dub plan | `plan_tts_dub` → `executable=False`; ES brand-primary; separate from caption translate |
+| `__init__.py` | Package surface | Re-exports above |
+
+**MCP / CLI wiring (present):**  
+`video_generative_plan`, `video_otio_export`, `video_otio_import`, `video_review_ui`, dub plan tool; CLI `otio-export`, `otio-import`, `review-ui`.
+
+---
+
+## Gate matrix (evidence vs residual)
+
+### Phase 3 gates
+
+| Gate | Code evidence | Test evidence | Residual / gap |
+| --- | --- | --- | --- |
+| Review API (`review_run` + decide) | `run_review` / `decide_review` | `test_review_run_and_decide` on golden fixture | No multi-minute / phone-frame real-media corpus (`DEF-g004-media` related honesty) |
+| Metric floor fail-closed | `run_metric_qc`; missing probe → skip/warn | Exercised **indirectly** via `run_review`; **no dedicated `run_metric_qc` test** | Dedicated metric-floor cases + non-golden media still open |
+| Vision/narrative graceful | `require_vlm` never hard-fails product path | `test_vision_and_narrative_on_golden` | Vision is structural-only; no real VLM rubric score path claimed |
+| Mutations typed proposals | `human_review_required` only | `test_propose_mutations_from_findings` (synthetic findings) | No apply-path silence proof against a live timeline rewrite end-to-end |
+
+### Phase 4 gates
+
+| Gate | Code evidence | Test evidence | Residual / gap |
+| --- | --- | --- | --- |
+| Generative spend caps + local default | Cap compare; local always allowed | `test_generative_spend_cap` | Plan-only (honest); no live provider integration proof required for plan gate, but formal PHASE GO still open |
+| OTIO import/export roundtrip | export embeds IR; import restores IR | `test_otio_export_import` | **Not** full OpenTimelineIO library interchange; foreign OTIO without `kinocut_ir` fails closed |
+| Review UI human surface | HTML + hot-reload poll | `test_review_ui` writes file | Smoke only — no browser/human-session receipt |
+| TTS dub ES-first ≠ translate | Plan + coverage report; `executable=False` | `test_tts_dub_plan_not_executable` | Backend not bundled; execution deferred by design |
+
+---
+
+## What tests cover (live, this pass)
+
+**Command (focused P3/P4 nodes):**
+
+```bash
+python3 -m pytest \
+  tests/test_intent_surface.py::test_review_run_and_decide \
+  tests/test_te_and_mutations.py::test_propose_mutations_from_findings \
+  tests/test_finish_campaign.py::test_otio_export_import \
+  tests/test_finish_campaign.py::test_generative_spend_cap \
+  tests/test_finish_campaign.py::test_review_ui \
+  tests/test_finish_campaign.py::test_tts_dub_plan_not_executable \
+  tests/test_finish_campaign.py::test_vision_and_narrative_on_golden \
+  -v --tb=short
+```
+
+**Result (2026-08-12, tip `7618e76`):** **7 passed** in ~0.22s.
+
+| Node | Family |
+| --- | --- |
+| `tests/test_intent_surface.py::test_review_run_and_decide` | watching |
+| `tests/test_te_and_mutations.py::test_propose_mutations_from_findings` | watching |
+| `tests/test_finish_campaign.py::test_vision_and_narrative_on_golden` | watching |
+| `tests/test_finish_campaign.py::test_otio_export_import` | multipliers |
+| `tests/test_finish_campaign.py::test_generative_spend_cap` | multipliers |
+| `tests/test_finish_campaign.py::test_review_ui` | multipliers |
+| `tests/test_finish_campaign.py::test_tts_dub_plan_not_executable` | multipliers |
+
+**Adjacent (not counted as P3/P4 unit GO):**  
+`tests/test_finish_campaign.py` + `tests/test_intent_surface.py` + `tests/test_te_and_mutations.py` together → **26 passed** (includes TE/intent non-P3/P4 cases). Public-surface name registration covers tool symbols but is not behavioral GO.
+
+**Ad-hoc metric probe (golden `workflow_final.mp4`, 1.0s):**
+
+| check_id | severity | notes |
+| --- | --- | --- |
+| `duration.min` | info | measured duration |
+| `black_frames.ratio` | info | measured ratio `0.0` (real blackdetect) |
+| `audio.lufs` | warn | `available: False` — not fabricated |
+| `av_sync.proxy` | info | explicitly unclaimed |
+
+---
+
+## Why exit remains PENDING (not GO)
+
+1. **DEFERRED reopen is explicit:** `DEF-phase3-go` requires *linked real-media GO evidence*; golden 1s fixture + unit smoke is not that bar.  
+2. **Metric floor lacks a first-class test module** and real-media fail cases (forced short / forced black).  
+3. **OTIO is a Kinocut-IR JSON bridge**, not proven third-party OTIO interchange — claiming Phase 4 GO would over-read the gate wording “import/export roundtrip.”  
+4. **Review UI / generative / TTS** are plan-or-smoke surfaces; acceptable as shipped *capabilities*, insufficient alone for portfolio PHASE exit without formal GO link.  
+5. **No public claim bump** is authorized until L3 claim owner; this doc freezes honesty at residual deepen class.
+
+## Residual list (must match DEFERRED)
+
+| id | family | blocks_portfolio_complete | reopen_condition (from DEFERRED) |
+| --- | --- | --- | --- |
+| `DEF-phase3-go` | `watching_p3` | Y phase claim | Linked real-media GO evidence |
+| `DEF-phase4-go` | `multipliers_p4` | Y phase claim | Linked GO evidence |
+
+Related non-phase rows that still bound honesty (not flipped by this pass):
+
+- `DEF-g004-media` — multi-minute / phone-frame fixtures  
+- Human gates `#88` / `#90` / `#92` / `#3` — never agent-closed  
+
+## What would flip to GO (future; not claimed now)
+
+**Phase 3 GO** when all are true and linked from `PHASE_CHECKPOINTS.md`:
+
+1. Real-media review_run + decide path on non-golden multi-shot source (or explicit product waiver + DEFERRED supersession).  
+2. Dedicated metric-floor tests: fail duration, fail/warn black, unavailable-probe non-invention.  
+3. Mutations still propose-only under a documented apply surface (no silent rewrite).  
+4. Vision/narrative remain graceful; no hard VLM product requirement.
+
+**Phase 4 GO** when all are true and linked:
+
+1. OTIO fixture roundtrip documented as **supported interchange scope** (kinocut_ir-embedded) **or** real OTIO library path with foreign fixture.  
+2. Generative plan caps tested + local default; paid path remains non-auto.  
+3. Review UI smoke retained; optional human session note.  
+4. TTS dub remains ES-first and separate from translate; executable honesty unchanged until backend lands.
+
+---
+
+## Doc actions from this pass
+
+| File | Action |
+| --- | --- |
+| This evidence doc | Created |
+| `PHASE_CHECKPOINTS.md` | Exit stays **PENDING**; residual IDs + link to this doc |
+| `DEFERRED.md` | Keep `DEF-phase3-go` / `DEF-phase4-go`; reason may cite this doc |
+| `docs/public_claims.json` | **Not touched** |

--- a/docs/status/2026-08-12-residual-maturity-matrix.md
+++ b/docs/status/2026-08-12-residual-maturity-matrix.md
@@ -1,0 +1,37 @@
+# Residual Maturity Matrix (L0.4)
+
+**Date:** 2026-08-12  
+**Tip branch:** `ultragoal/kinocut-full-build`  
+**Ultragoal:** `.omc/ultragoal/plans/kinocut-full-build` G001  
+**Evidence basis:** code + tests + evidence paths (not July prose alone)
+
+| family | class | evidence_paths | residual_tickets | blocks_claim? |
+|--------|-------|----------------|------------------|---------------|
+| ssrf_c1 | verify-only | `kinocut/ai_engine/download.py` pin/peer; `tests/test_ai_features.py` SSRF; 60-pass SSRF/preview filter suite | Close HUMAN_GATES C1 row after doc sync | N (security already on tip) |
+| preview_m1 | verify-only | `kinocut/hyperframes_engine.py` `_active_previews`/`stop_preview`/`atexit`; `tests/test_hyperframes_engine.py` stop_preview | Close HUMAN_GATES M1 after doc sync | N |
+| hyperframes_ops_policy | verify-only (fixed) | Split `hyperframes_ops_helpers.py`; ops ~680 LOC; guardrail locks ops+helpers | Keep ≤800 | N |
+| watching_p3 | deepen | `kinocut/watching/{review,metrics,mutations,vision_qc,narrative_qc}.py`; MCP/CLI intent tools | GO evidence links + real-media residual | Y until PHASE GO or DEFERRED |
+| multipliers_p4 | deepen | `kinocut/multipliers/*` (5 modules) | GO criteria / DEFERRED IDs | Y until PHASE GO or DEFERRED |
+| sound_S4 | re-run | foundation packages present | Re-verify contracts | N if green |
+| sound_S5 | re-run/deepen | `kinocut_sound/voice/` | Residual-only tickets if tests fail | Y for full-episode claim |
+| sound_S6 | re-run/deepen | `voice/clone.py`, `blend.py` | same | Y full-episode |
+| sound_S7 | re-run/deepen | `kinocut_sound/post/` | same | Y full-episode |
+| sound_S8 | re-run/deepen | `kinocut_sound/world/` | same | Y full-episode |
+| sound_S9 | re-run/deepen | `kinocut_sound/mix/` | same | Y full-episode |
+| sound_S10 | re-run/deepen | `kinocut_sound/voice_consistency/` | same | Y full-episode |
+| sound_S11 | re-run/deepen | `kinocut_sound/qa/` | same | Y full-episode |
+| sound_S12 | re-run/deepen | `kinocut_sound/public/`, `kinocut/sound_joins/` | ROADMAP “thin S12” honesty sync | Y full-episode |
+| sound_S13 | re-run | `sound_joins` + host joins | dual-class residual | Y full-episode |
+| sound_S14 | re-run | `docs/evidence/2026-07-14-sound-s14-dual-class-benchmark.json` (64 clips, dual-class, under_30m) | Re-run live host classes | **Synthetic ≠ product complete** |
+| sound_S15 | deepen | acceptance residual | Product honesty + human adversarial review | Y product claim |
+| cutfile | deepen (thin render) | `kinocut/te/cutfile.py` + `kinocut/te/cutfile_render.py` (compile→workflow OP_ADAPTERS→`render_workflow`); tests in `tests/test_te_and_mutations.py` | Optional MCP/CLI surface (not claimed; keep public_claims stable) | N for library render claim; Y if MCP/CLI claimed without surface bump |
+| kinocut_action | deepen | `.github/actions/kinocut-video-ci/` | CI receipt on push | soft |
+| conversational | deepen | `kinocut/te/edit_session.py` | measured metric + receipt depth | soft |
+| durable_repurpose | deepen | `kinocut/projectstore/` (18 files) | honesty vs seed skill | soft |
+| g004 | human-only | HUMAN_GATES / fixtures | human media | Y shorts honesty |
+| mcpb | human-only + agent pack | foundations | human sign | Y production pack |
+| dual_host_face | deepen | dual-host docs | verify after claim PRs | Y public face |
+| wp_f_baselines | greenfield | none committed | golden-path timings | N until “optimized” claim |
+| human_gates | human-only | `docs/HUMAN_GATES.md` | #3 #88 #90 #92 | Y agent-complete |
+
+**Rule:** No L2 ticket re-implements `verify-only` without a failing case.

--- a/docs/status/2026-08-12-residual-maturity-matrix.md
+++ b/docs/status/2026-08-12-residual-maturity-matrix.md
@@ -7,8 +7,8 @@
 
 | family | class | evidence_paths | residual_tickets | blocks_claim? |
 |--------|-------|----------------|------------------|---------------|
-| ssrf_c1 | verify-only | `kinocut/ai_engine/download.py` pin/peer; `tests/test_ai_features.py` SSRF; 60-pass SSRF/preview filter suite | Close HUMAN_GATES C1 row after doc sync | N (security already on tip) |
-| preview_m1 | verify-only | `kinocut/hyperframes_engine.py` `_active_previews`/`stop_preview`/`atexit`; `tests/test_hyperframes_engine.py` stop_preview | Close HUMAN_GATES M1 after doc sync | N |
+| ssrf_c1 | verify-only | `kinocut/ai_engine/download.py` pin/peer; `tests/test_ai_features.py` SSRF; 60-pass SSRF/preview filter suite | HUMAN_GATES C1 closed L1.2 (2026-08-12) | N (security already on tip) |
+| preview_m1 | verify-only | `kinocut/hyperframes_engine.py` `_active_previews`/`stop_preview`/`atexit`; `tests/test_hyperframes_engine.py` stop_preview | HUMAN_GATES M1 closed L1.2 (2026-08-12) | N |
 | hyperframes_ops_policy | verify-only (fixed) | Split `hyperframes_ops_helpers.py`; ops ~680 LOC; guardrail locks ops+helpers | Keep ≤800 | N |
 | watching_p3 | deepen | `kinocut/watching/{review,metrics,mutations,vision_qc,narrative_qc}.py`; MCP/CLI intent tools | GO evidence links + real-media residual | Y until PHASE GO or DEFERRED |
 | multipliers_p4 | deepen | `kinocut/multipliers/*` (5 modules) | GO criteria / DEFERRED IDs | Y until PHASE GO or DEFERRED |
@@ -20,7 +20,7 @@
 | sound_S9 | re-run/deepen | `kinocut_sound/mix/` | same | Y full-episode |
 | sound_S10 | re-run/deepen | `kinocut_sound/voice_consistency/` | same | Y full-episode |
 | sound_S11 | re-run/deepen | `kinocut_sound/qa/` | same | Y full-episode |
-| sound_S12 | re-run/deepen | `kinocut_sound/public/`, `kinocut/sound_joins/` | ROADMAP “thin S12” honesty sync | Y full-episode |
+| sound_S12 | re-run/deepen | `kinocut_sound/public/`, `kinocut/sound_joins/` | ROADMAP thin-S12 honesty synced 2026-08-12 (L1.2) | Y full-episode |
 | sound_S13 | re-run | `sound_joins` + host joins | dual-class residual | Y full-episode |
 | sound_S14 | re-run | `docs/evidence/2026-07-14-sound-s14-dual-class-benchmark.json` (64 clips, dual-class, under_30m) | Re-run live host classes | **Synthetic ≠ product complete** |
 | sound_S15 | deepen | acceptance residual | Product honesty + human adversarial review | Y product claim |

--- a/docs/status/2026-08-12-residual-maturity-matrix.md
+++ b/docs/status/2026-08-12-residual-maturity-matrix.md
@@ -10,8 +10,8 @@
 | ssrf_c1 | verify-only | `kinocut/ai_engine/download.py` pin/peer; `tests/test_ai_features.py` SSRF; 60-pass SSRF/preview filter suite | HUMAN_GATES C1 closed L1.2 (2026-08-12) | N (security already on tip) |
 | preview_m1 | verify-only | `kinocut/hyperframes_engine.py` `_active_previews`/`stop_preview`/`atexit`; `tests/test_hyperframes_engine.py` stop_preview | HUMAN_GATES M1 closed L1.2 (2026-08-12) | N |
 | hyperframes_ops_policy | verify-only (fixed) | Split `hyperframes_ops_helpers.py`; ops ~680 LOC; guardrail locks ops+helpers | Keep ≤800 | N |
-| watching_p3 | deepen | `kinocut/watching/{review,metrics,mutations,vision_qc,narrative_qc}.py`; MCP/CLI intent tools | GO evidence links + real-media residual | Y until PHASE GO or DEFERRED |
-| multipliers_p4 | deepen | `kinocut/multipliers/*` (5 modules) | GO criteria / DEFERRED IDs | Y until PHASE GO or DEFERRED |
+| watching_p3 | deepen | `kinocut/watching/{review,metrics,mutations,vision_qc,narrative_qc}.py`; MCP/CLI intent tools; [phase3/4 residual evidence](2026-08-12-phase3-phase4-residual-evidence.md) | `DEF-phase3-go` (real-media GO) | Y until PHASE GO |
+| multipliers_p4 | deepen | `kinocut/multipliers/*` (5 modules); [phase3/4 residual evidence](2026-08-12-phase3-phase4-residual-evidence.md) | `DEF-phase4-go` | Y until PHASE GO |
 | sound_S4 | re-run | foundation packages present | Re-verify contracts | N if green |
 | sound_S5 | re-run/deepen | `kinocut_sound/voice/` | Residual-only tickets if tests fail | Y for full-episode claim |
 | sound_S6 | re-run/deepen | `voice/clone.py`, `blend.py` | same | Y full-episode |
@@ -31,7 +31,7 @@
 | g004 | human-only | HUMAN_GATES / fixtures | human media | Y shorts honesty |
 | mcpb | human-only + agent pack | foundations | human sign | Y production pack |
 | dual_host_face | deepen | dual-host docs | verify after claim PRs | Y public face |
-| wp_f_baselines | greenfield | none committed | golden-path timings | N until “optimized” claim |
+| wp_f_baselines | deepen | `scripts/golden_path_timings.py` + cheap p50/p95 in `docs/status/golden-path-timings.md` (2026-08-12); full path optional | full-path samples + residual GO before optimize claim | N until “optimized” claim |
 | human_gates | human-only | `docs/HUMAN_GATES.md` | #3 #88 #90 #92 | Y agent-complete |
 
 **Rule:** No L2 ticket re-implements `verify-only` without a failing case.

--- a/docs/status/2026-08-12-sound-fixture-freeze.md
+++ b/docs/status/2026-08-12-sound-fixture-freeze.md
@@ -1,0 +1,34 @@
+# Sound acceptance fixture freeze (L0.5b)
+
+**Date:** 2026-08-12  
+**Status:** frozen for residual program  
+
+| Field | Value |
+|-------|--------|
+| fixture_id / version | `sound-bench-v1` |
+| clip_count band | 50–80 (current evidence: **64**) |
+| evidence path | `docs/evidence/2026-07-14-sound-s14-dual-class-benchmark.json` |
+| required host classes | Apple silicon + x86 Linux (both) |
+| cold/warm | both required |
+| gate | complete under **30 minutes** wall time per class |
+| missing class | residual `external_host_unavailable` — **never pass by skip** |
+| capability manifest (from evidence) | `d41_bed`, `d41_audition`, `d42_style`, `d42_identity` |
+
+## Metric schema (required on re-run)
+
+```json
+{
+  "fixture_version": "sound-bench-v1",
+  "hardware_class": "apple_silicon|x86_linux",
+  "clip_count": 64,
+  "cold_seconds": 0.0,
+  "warm_seconds": 0.0,
+  "cold_ok": true,
+  "warm_ok": true,
+  "under_30m": true,
+  "required_capabilities": {},
+  "digest": "sha256:..."
+}
+```
+
+**PR language:** no “full-episode complete” until Wave F residual + L3 claim owner.

--- a/docs/status/2026-08-12-sound-residual-rerun.md
+++ b/docs/status/2026-08-12-sound-residual-rerun.md
@@ -1,0 +1,18 @@
+# Sound residual re-run evidence (G003 start)
+
+**Date:** 2026-08-12  
+**Command:** `python3 -m pytest tests/ -q --tb=no -k "sound or kinocut_sound"`  
+**Result:** **580 passed**, 4355 deselected  
+
+## Implication for residual-CP-S
+
+Stage packages + host joins + S14 synthetic evidence + large green sound test surface → primary agent work is **re-verify/deepen product honesty**, not greenfield S5–S15 rebuild.
+
+## Still open for product full-episode claim
+
+- Live dual-class S14 re-run on required hardware (or `external_host_unavailable`)  
+- S15 acceptance + L3 claim owner  
+- Human independent sound adversarial review residual  
+- ROADMAP must not say only “thin S12 join” without residual matrix pointer  
+
+See: `docs/status/2026-08-12-sound-residual-stage-dag.md`, fixture freeze doc.

--- a/docs/status/2026-08-12-sound-residual-stage-dag.md
+++ b/docs/status/2026-08-12-sound-residual-stage-dag.md
@@ -1,0 +1,36 @@
+# Sound residual stage DAG (L0.5)
+
+**Date:** 2026-08-12  
+**Fixture freeze:** see `docs/status/2026-08-12-sound-fixture-freeze.md` (L0.5b)
+
+## Live inventory
+
+- Package tree: `kinocut_sound/` (93 Python files) including `voice/`, `voice_consistency/`, `post/`, `world/`, `mix/`, `qa/`, `public/`, episode assembly, authorization.
+- Host joins: `kinocut/sound_joins/` (5 modules).
+- Historical S14: `docs/evidence/2026-07-14-sound-s14-dual-class-benchmark.json` — fixture `sound-bench-v1`, **64 clips**, both classes cold/warm `under_30m: true` (synthetic times).
+
+## Design waves (execution order)
+
+```text
+Wave A: S5 || S7 || S8     (leaves ≤3 if residual deepen/greenfield)
+Wave B: S5 → (S6 || S10)   (leaves ≤2)
+Wave C: S4+S5+S7+S8 → S9   (serial join)
+Wave D: S4+S7+S9 → S11
+Wave E: → S12 → S13
+Wave F: → S14 → S15
+```
+
+## Residual-only staffing
+
+| Stage | Initial class | L2 action |
+|-------|---------------|-----------|
+| S4–S13 packages | re-run / deepen | Run stage tests; open deepen tickets only on fail or missing GO evidence |
+| S14 | re-run | Re-run dual-class bench; missing class → `external_host_unavailable` residual (never silent skip) |
+| S15 | deepen | Acceptance + product claim honesty; independent sound review remains human residual |
+
+**Forbidden:** greenfield rebuild of stages classified verify-only/re-run without failing case.
+
+## Product claim policy
+
+- Synthetic S14 re-pass ≠ “full-episode sonic world complete.”
+- Product claim only via L3 claim owner after residual Wave F honesty.

--- a/docs/status/DEFERRED.md
+++ b/docs/status/DEFERRED.md
@@ -1,0 +1,22 @@
+# Deferred IDs (ultragoal full-build)
+
+**Schema:** `id | family | reason | owner | blocks_portfolio_complete | reopen_condition | date`
+
+| id | family | reason | owner | blocks_portfolio_complete | reopen_condition | date |
+|----|--------|--------|-------|---------------------------|------------------|------|
+| DEF-human-88 | directories | Third-party review pending (MCP.so, Docker MCP, Agent-CoreX, Protodex, …) | Human | Y (agent-complete) | Operator evidence of listing | 2026-08-12 |
+| DEF-human-90 | launch | Launch posts/clips not published | Human | Y (agent-complete) | Approve & publish | 2026-08-12 |
+| DEF-human-92 | first-10 | Real first-10 users not run/logged | Human | Y (agent-complete) | 10 real first-run logs | 2026-08-12 |
+| DEF-human-3 | renovate | Host token / Renovate app | Human/ops | N product | Token enabled | 2026-08-12 |
+| DEF-ci-light | ci_topology | light runner unavailable | Ops | N product | light label available | 2026-08-12 |
+| DEF-g004-media | g004 | Multi-minute/phone-frame source media | Human | Y shorts honesty | Fixtures land | 2026-08-12 |
+| DEF-mcpb-sign | mcpb | Production signed multi-platform pack | Human+agent | Y production pack | Human sign + clean-machine | 2026-08-12 |
+| DEF-sound-product | sound_S15 | Product full-episode claim | Product/L3 | Y product claim | Wave F honesty + L3 claim owner | 2026-08-12 |
+| DEF-s14-live | sound_S14 | Live dual-class re-run on hardware | Agent/ops | Y product claim | Re-run or external_host_unavailable | 2026-08-12 |
+| DEF-splus-95 | wp_a | S+ overall ≥95 preferred | Agent | N (preferred) | Score ≥95 + site stamp | 2026-08-12 |
+| DEF-wp-f | wp_f | Full golden-path p50/p95 + optimize claim | Agent | N until optimize claim | Full-path timings + residual GO; cheap scaffolding already in golden-path-timings.md | 2026-08-12 |
+| DEF-cutfile-mcp | cutfile | Optional MCP/CLI surface for cutfile render | Product | N | Explicit product ask | 2026-08-12 |
+| DEF-phase3-go | watching_p3 | PHASE 3 exit still PENDING — modules+unit smoke on tip; real-media GO not met ([evidence](2026-08-12-phase3-phase4-residual-evidence.md)) | Agent/product | Y phase claim | Linked real-media GO evidence + PHASE_CHECKPOINTS Exit=GO | 2026-08-12 |
+| DEF-phase4-go | multipliers_p4 | PHASE 4 exit still PENDING — modules+unit smoke on tip; formal GO not met ([evidence](2026-08-12-phase3-phase4-residual-evidence.md)) | Agent/product | Y phase claim | Linked GO evidence + PHASE_CHECKPOINTS Exit=GO | 2026-08-12 |
+
+Minted by ultragoal leader 2026-08-12. Agents must not mark human rows complete without operator evidence.

--- a/docs/status/DEFERRED.md
+++ b/docs/status/DEFERRED.md
@@ -13,8 +13,8 @@
 | DEF-mcpb-sign | mcpb | Production signed multi-platform pack | Human+agent | Y production pack | Human sign + clean-machine | 2026-08-12 |
 | DEF-sound-product | sound_S15 | Product full-episode claim | Product/L3 | Y product claim | Wave F honesty + L3 claim owner | 2026-08-12 |
 | DEF-s14-live | sound_S14 | Live dual-class re-run on hardware | Agent/ops | Y product claim | Re-run or external_host_unavailable | 2026-08-12 |
-| DEF-splus-95 | wp_a | S+ overall ≥95 preferred | Agent | N (preferred) | Score ≥95 + site stamp | 2026-08-12 |
-| DEF-wp-f | wp_f | Full golden-path p50/p95 + optimize claim | Agent | N until optimize claim | Full-path timings + residual GO; cheap scaffolding already in golden-path-timings.md | 2026-08-12 |
+| DEF-splus-95 | wp_a | Remote GH S+ lag vs local 100 | Dual-host | N (preferred) | Local README scores 100 (2026-08-12); GH tip lag may show ~89 until mirror/push | 2026-08-12 |
+| DEF-wp-f | wp_f | Optimize claim after baseline | Agent | N | Baseline cheap+full measured 2026-08-12; reopen only for “optimized” language | 2026-08-12 |
 | DEF-cutfile-mcp | cutfile | Optional MCP/CLI surface for cutfile render | Product | N | Explicit product ask | 2026-08-12 |
 | DEF-phase3-go | watching_p3 | PHASE 3 exit still PENDING — modules+unit smoke on tip; real-media GO not met ([evidence](2026-08-12-phase3-phase4-residual-evidence.md)) | Agent/product | Y phase claim | Linked real-media GO evidence + PHASE_CHECKPOINTS Exit=GO | 2026-08-12 |
 | DEF-phase4-go | multipliers_p4 | PHASE 4 exit still PENDING — modules+unit smoke on tip; formal GO not met ([evidence](2026-08-12-phase3-phase4-residual-evidence.md)) | Agent/product | Y phase claim | Linked GO evidence + PHASE_CHECKPOINTS Exit=GO | 2026-08-12 |

--- a/docs/status/PHASE_CHECKPOINTS.md
+++ b/docs/status/PHASE_CHECKPOINTS.md
@@ -1,11 +1,13 @@
 # Phase go / no-go checkpoints (DEC.1)
 
-**Status:** living · **Date:** 2026-08-07  
-**Issue:** Forgejo #94
+**Status:** living · **Date:** 2026-08-12 (L1.2 truth pass)  
+**Issue:** Forgejo #94  
+**Residual authority:** [`2026-08-12-residual-maturity-matrix.md`](2026-08-12-residual-maturity-matrix.md) · [L1 truth pass](2026-08-12-l1-truth-pass.md)
 
 Kill-or-pivot criteria for the trusted-execution plan phases. A phase exits only
 when its **go** criteria are evidence-backed; otherwise **no-go** with a residual
-ticket or human decision.
+ticket or human decision. **PENDING ≠ missing packages** when the residual matrix
+classifies the family as deepen/re-run.
 
 ## Phase 1 — Kernel corners (projectstore)
 
@@ -40,7 +42,10 @@ P3+ children remain open until their gates pass.
 | Vision/narrative | graceful enhancement | hard-require VLM for all users |
 | Mutations | typed proposals | silent timeline rewrite |
 
-**Exit:** PENDING — metric floor + review_run skeleton landed; vision/narrative/mutations residual.
+**Exit:** **PENDING (deepen residual)** — modules on tip under `kinocut/watching/`
+(`review`, `metrics`, `mutations`, `vision_qc`, `narrative_qc`) plus MCP/CLI intent
+tools. Residual is **GO evidence links + real-media residual**, not “scaffold
+missing.” Matrix family: `watching_p3` · blocks claim until PHASE GO or DEFERRED.
 
 ## Phase 4 — Multipliers
 
@@ -51,7 +56,9 @@ P3+ children remain open until their gates pass.
 | Review UI | human hot-reload surface | agent-only “review” |
 | TTS dub | ES-first, separate from translate | conflate with caption translate |
 
-**Exit:** PENDING.
+**Exit:** **PENDING (deepen residual)** — `kinocut/multipliers/*` (5 modules) and TE
+multipliers exist on tip. Residual is GO criteria / DEFERRED IDs, not greenfield
+rebuild. Matrix family: `multipliers_p4`.
 
 ## Track E pillars (Cutfile / Video CI / conversational)
 
@@ -61,10 +68,37 @@ P3+ children remain open until their gates pass.
 | kinocut-action | CI receipt on push | CI that only runs unit tests |
 | Conversational sessions | measured improvement metric | chat without receipts |
 
-**Exit:** PENDING.
+**Exit:** **PENDING (mixed residual)** — cutfile today is validate/load
+(`kinocut/te/cutfile.py`); render path or DEFERRED ID required for claim.
+`kinocut-action` foundations under `.github/actions/kinocut-video-ci/`; conversational
+`edit_session` deepen soft. See matrix rows `cutfile`, `kinocut_action`, `conversational`.
+
+## Sound program (not a Phase 1–4 exit; residual portfolio)
+
+| Gate | Go | No-go |
+| --- | --- | --- |
+| Public S12 join | thin public surface honest | market as full-episode complete |
+| S4–S13 packages | residual re-run/deepen green | greenfield rebuild without fail |
+| S14 dual-class | live host classes or `external_host_unavailable` residual | pass by skipping a class |
+| S15 / product claim | Wave F honesty + L3 claim owner | synthetic S14 alone as product complete |
+
+**Status:** packages present; **product full-episode sound unclaimed**. Authority:
+[`2026-08-12-sound-residual-stage-dag.md`](2026-08-12-sound-residual-stage-dag.md),
+fixture freeze, residual matrix. July “S5–S15 incomplete” handoffs are **historical** —
+do not contradict the residual matrix when staffing.
 
 ## Human-only (never agent-close)
 
-- First-10 real users program (#92)
-- Directory/registry third-party approval (#88)
-- Launch media final cut approval (#90)
+- First-10 real users program (#92) — open
+- Directory/registry third-party approval (#88) — external reviews still pending (Awesome MCP merged)
+- Launch media final cut approval (#90) — open
+- Renovate host token (#3) — open
+- Do **not** invent completions for the above
+
+## Residual program note (2026-08-12, L1.2)
+
+Phase 3/4/E exits still **PENDING** until GO evidence is linked or a DEFERRED row
+with `blocks_portfolio_complete` is minted. Agent work is **deepen/re-verify**, not
+missing-module rebuild. Claim bumps to `docs/public_claims.json` are frozen until
+**L3** for non–claim-owners (see ROADMAP claim ledger). Ultragoal plan:
+`.omc/ultragoal/plans/kinocut-full-build`.

--- a/docs/status/PHASE_CHECKPOINTS.md
+++ b/docs/status/PHASE_CHECKPOINTS.md
@@ -45,7 +45,10 @@ P3+ children remain open until their gates pass.
 **Exit:** **PENDING (deepen residual)** — modules on tip under `kinocut/watching/`
 (`review`, `metrics`, `mutations`, `vision_qc`, `narrative_qc`) plus MCP/CLI intent
 tools. Residual is **GO evidence links + real-media residual**, not “scaffold
-missing.” Matrix family: `watching_p3` · blocks claim until PHASE GO or DEFERRED.
+missing.” Matrix family: `watching_p3` · residual ID: **`DEF-phase3-go`** · blocks
+phase claim until PHASE GO. Unit smoke (review/mutations/vision-narrative) green on
+tip; formal GO **not** claimed — see
+[`2026-08-12-phase3-phase4-residual-evidence.md`](2026-08-12-phase3-phase4-residual-evidence.md).
 
 ## Phase 4 — Multipliers
 
@@ -58,7 +61,10 @@ missing.” Matrix family: `watching_p3` · blocks claim until PHASE GO or DEFER
 
 **Exit:** **PENDING (deepen residual)** — `kinocut/multipliers/*` (5 modules) and TE
 multipliers exist on tip. Residual is GO criteria / DEFERRED IDs, not greenfield
-rebuild. Matrix family: `multipliers_p4`.
+rebuild. Matrix family: `multipliers_p4` · residual ID: **`DEF-phase4-go`** · blocks
+phase claim until PHASE GO. Unit smoke (OTIO kinocut_ir roundtrip, generative cap,
+review UI write, TTS plan) green on tip; formal GO **not** claimed — see
+[`2026-08-12-phase3-phase4-residual-evidence.md`](2026-08-12-phase3-phase4-residual-evidence.md).
 
 ## Track E pillars (Cutfile / Video CI / conversational)
 
@@ -95,10 +101,12 @@ do not contradict the residual matrix when staffing.
 - Renovate host token (#3) — open
 - Do **not** invent completions for the above
 
-## Residual program note (2026-08-12, L1.2)
+## Residual program note (2026-08-12, L1.2 + G004 residual evidence)
 
-Phase 3/4/E exits still **PENDING** until GO evidence is linked or a DEFERRED row
-with `blocks_portfolio_complete` is minted. Agent work is **deepen/re-verify**, not
-missing-module rebuild. Claim bumps to `docs/public_claims.json` are frozen until
-**L3** for non–claim-owners (see ROADMAP claim ledger). Ultragoal plan:
+Phase 3/4/E exits still **PENDING**. DEFERRED rows **`DEF-phase3-go`** /
+**`DEF-phase4-go`** hold phase-claim authority. G004 tip evidence receipt:
+[`2026-08-12-phase3-phase4-residual-evidence.md`](2026-08-12-phase3-phase4-residual-evidence.md)
+(7 focused unit nodes green; **not** PHASE GO). Agent work is **deepen/re-verify**,
+not missing-module rebuild. Claim bumps to `docs/public_claims.json` are frozen
+until **L3** for non–claim-owners (see ROADMAP claim ledger). Ultragoal plan:
 `.omc/ultragoal/plans/kinocut-full-build`.

--- a/docs/status/PHASE_CHECKPOINTS.md
+++ b/docs/status/PHASE_CHECKPOINTS.md
@@ -74,8 +74,8 @@ review UI write, TTS plan) green on tip; formal GO **not** claimed — see
 | kinocut-action | CI receipt on push | CI that only runs unit tests |
 | Conversational sessions | measured improvement metric | chat without receipts |
 
-**Exit:** **PENDING (mixed residual)** — cutfile today is validate/load
-(`kinocut/te/cutfile.py`); render path or DEFERRED ID required for claim.
+**Exit:** **PENDING (mixed residual)** — thin **library** cutfile render is on tip
+(`kinocut/te/cutfile_render.py` → workflow); MCP/CLI still optional (`DEF-cutfile-mcp`).
 `kinocut-action` foundations under `.github/actions/kinocut-video-ci/`; conversational
 `edit_session` deepen soft. See matrix rows `cutfile`, `kinocut_action`, `conversational`.
 

--- a/docs/status/golden-path-timings.md
+++ b/docs/status/golden-path-timings.md
@@ -59,7 +59,7 @@ Recorded: `YYYY-MM-DDTHH:MM:SS+00:00`
 | Host class | Darwin / arm64 (Apple Silicon) |
 | Python | 3.14.5 |
 | Command | `python3 scripts/golden_path_timings.py --mode cheap --runs 5` |
-| Full path | **not measured** this pass (scaffolding only) |
+| Full path | measured same day (see block below) |
 
 | step | mode | runs | ok | p50 (s) | p95 (s) | mean (s) | min (s) | max (s) | machine |
 | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
@@ -69,7 +69,24 @@ Recorded: `YYYY-MM-DDTHH:MM:SS+00:00`
 Fixture: `tests/fixtures/golden/workflow_final.mp4`  
 Recorded: `2026-08-12T14:59:34.357224+00:00`
 
-**Honesty:** These are cold **CLI process** wall times (new interpreter per sample), not in-process engine loops. They do **not** authorize an “optimized” claim or a `public_claims.json` bump.
+## Measured: 2026-08-12 (full path, n=3)
+
+| Field | Value |
+| --- | --- |
+| Host class | Darwin / arm64 (Apple Silicon) |
+| Python | 3.14.x |
+| Command | `python3 scripts/golden_path_timings.py --mode full --runs 3` |
+
+| step | mode | runs | ok | p50 (s) | p95 (s) | mean (s) | min (s) | max (s) | machine |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
+| doctor | full | 3 | 3 | 1.4396 | 1.82 | 1.5601 | 1.3784 | 1.8623 | Darwin/arm64 |
+| info | full | 3 | 3 | 0.4489 | 0.4882 | 0.458 | 0.4326 | 0.4926 | Darwin/arm64 |
+| golden_path | full | 3 | 3 | 9.4835 | 9.703 | 9.5571 | 9.4605 | 9.7274 | Darwin/arm64 |
+
+Fixture: `tests/fixtures/golden/workflow_final.mp4`  
+Recorded: `2026-08-12T15:16:30.129698+00:00`
+
+**Honesty:** These are cold **CLI process** wall times (new interpreter per sample), not in-process engine loops. They establish a **baseline**, not an “optimized” product claim. No `public_claims.json` bump from timings alone.
 
 ## Acceptance (scaffolding vs L3)
 

--- a/docs/status/golden-path-timings.md
+++ b/docs/status/golden-path-timings.md
@@ -1,0 +1,89 @@
+# Golden-path timings (WP-F baseline scaffolding)
+
+**Ultragoal:** `kinocut-full-build` · story `G005-l3-release-perf` (partial)  
+**Scope:** committed harness + measured baseline rows for cheap path  
+**Not in scope:** full L3 claim PR, `docs/public_claims.json` bump, “optimized” product claim
+
+Authority: ROADMAP WP-F · residual matrix `wp_f_baselines` · DEF-wp-f  
+Related proof path (untimed / separate): [`docs/GOLDEN_PATH.md`](../GOLDEN_PATH.md) · `scripts/golden_path.py`
+
+## Why this exists
+
+Excellence audit / WP-F required a **documented golden-path p50/p95** before any optimization language. This file is the living receipt for baseline numbers. Empty or partial rows mean “not yet measured on that host,” not green WP-F closeout.
+
+## Documented paths
+
+| Path | Steps | When to use |
+| --- | --- | --- |
+| **Cheap (default)** | `kino doctor --json` → `kino --format json info <fixture>` | CI-safe / laptop baseline; no FFmpeg encode |
+| **Full (optional)** | Cheap steps + `python scripts/golden_path.py` | After residual GO; heavier; writes under `workflows/05-confidence-baseline/output/` |
+
+Default fixture (committed, tiny): `tests/fixtures/golden/workflow_final.mp4`
+
+## How to run
+
+From repo root (Python env with Kinocut importable + FFmpeg for full mode):
+
+```bash
+# Cheap baseline (recommended for scaffolding / frequent re-runs)
+python3 scripts/golden_path_timings.py --mode cheap --runs 5
+
+# Markdown table only (paste into this file)
+python3 scripts/golden_path_timings.py --mode cheap --runs 5 --markdown-only
+
+# JSON payload for tooling
+python3 scripts/golden_path_timings.py --mode cheap --runs 5 --json
+
+# Full confidence workflow (slow; optional)
+python3 scripts/golden_path_timings.py --mode full --runs 3
+```
+
+Paste a new results section below (do not overwrite history; append dated blocks).  
+**Do not** bump `docs/public_claims.json` from timing work alone.
+
+## Results template (fill per host)
+
+| step | mode | runs | ok | p50 (s) | p95 (s) | mean (s) | min (s) | max (s) | machine |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
+| doctor | cheap |  |  |  |  |  |  |  |  |
+| info | cheap |  |  |  |  |  |  |  |  |
+| golden_path | full |  |  |  |  |  |  |  |  |
+
+Fixture: `tests/fixtures/golden/workflow_final.mp4`  
+Recorded: `YYYY-MM-DDTHH:MM:SS+00:00`
+
+## Measured: 2026-08-12 (cheap path)
+
+| Field | Value |
+| --- | --- |
+| Host class | Darwin / arm64 (Apple Silicon) |
+| Python | 3.14.5 |
+| Command | `python3 scripts/golden_path_timings.py --mode cheap --runs 5` |
+| Full path | **not measured** this pass (scaffolding only) |
+
+| step | mode | runs | ok | p50 (s) | p95 (s) | mean (s) | min (s) | max (s) | machine |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
+| doctor | cheap | 5 | 5 | 1.3643 | 1.4135 | 1.3808 | 1.3559 | 1.4143 | Darwin/arm64 |
+| info | cheap | 5 | 5 | 0.4375 | 0.4469 | 0.4400 | 0.4351 | 0.4474 | Darwin/arm64 |
+
+Fixture: `tests/fixtures/golden/workflow_final.mp4`  
+Recorded: `2026-08-12T14:59:34.357224+00:00`
+
+**Honesty:** These are cold **CLI process** wall times (new interpreter per sample), not in-process engine loops. They do **not** authorize an “optimized” claim or a `public_claims.json` bump.
+
+## Acceptance (scaffolding vs L3)
+
+| Gate | Status |
+| --- | --- |
+| Script under `scripts/` | `scripts/golden_path_timings.py` |
+| Status template with p50/p95 columns | this file |
+| Cheap path measured once | when Measured block has numbers |
+| Full path measured | optional; not required for scaffolding |
+| public_claims bump | **forbidden** until L3 claim owner PR |
+| WP-F / DEF-wp-f close | only after durable p50/p95 + residual GO matrix |
+
+## Notes
+
+- Full golden path remains the **functional** proof (`scripts/golden_path.py`); this harness is the **timing** companion.
+- p50/p95 use linear interpolation over sorted wall-clock samples from `time.perf_counter()`.
+- Cold vs warm process starts: each sample spawns a new `python -m kinocut` process (includes interpreter + import cost). That matches agent/CLI first-call cost better than in-process loops.

--- a/kinocut/hyperframes_ops.py
+++ b/kinocut/hyperframes_ops.py
@@ -20,15 +20,13 @@ import logging
 import math
 import os
 import re
-import subprocess
 import time
-from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
 from .defaults import DEFAULT_COMPOSITION_FPS, DEFAULT_COMPOSITION_HEIGHT, DEFAULT_COMPOSITION_WIDTH
 from .errors import HyperframesRenderError, MCPVideoError
-from .ffmpeg_helpers import _validate_input_path, _validate_output_path
+from .ffmpeg_helpers import _validate_output_path
 from .hyperframes_engine import (
     _hyperframes_op,
     _require_hyperframes_deps,
@@ -47,6 +45,16 @@ from .hyperframes_models import (
     HyperframesSnapshotResult,
     HyperframesStillResult,
 )
+from .hyperframes_ops_helpers import (
+    _csv,
+    _default_render_output,
+    _json_result,
+    _post_process_ops,
+    _render_output_exists,
+    _resolve_render_resolution,
+    _snapshot_pngs,
+    _validate_variables_file,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -58,149 +66,6 @@ _DATA_ATTR_RE = re.compile(
     r"\b(?P<name>data-[\w-]+)\s*=\s*(['\"])(?P<value>.*?)\2",
     re.IGNORECASE | re.DOTALL,
 )
-
-
-# ---------------------------------------------------------------------------
-# Output helpers
-# ---------------------------------------------------------------------------
-
-
-def _validate_variables_file(path: str | os.PathLike[str] | None) -> str | None:
-    """Validate optional runtime-data files before forwarding them to Hyperframes."""
-    if path is None:
-        return None
-    return _validate_input_path(str(path))
-
-
-def _post_process_ops() -> dict[str, Callable]:
-    """Return the post-processing operation registry for render_and_post."""
-    from . import engine as _video_engine
-
-    return {
-        "resize": _video_engine.resize,
-        "convert": _video_engine.convert,
-        "add_audio": _video_engine.add_audio,
-        "normalize_audio": _video_engine.normalize_audio,
-        "add_text": _video_engine.add_text,
-        "fade": _video_engine.fade,
-        "watermark": _video_engine.watermark,
-    }
-
-
-def _parse_json_stdout(stdout: str) -> dict[str, Any] | list[Any] | str:
-    """Parse Hyperframes JSON output, preserving text when a command is human-only."""
-    text = stdout.strip()
-    if not text:
-        return {}
-    try:
-        return json.loads(text)
-    except json.JSONDecodeError:
-        return text
-
-
-def _csv(values: list[float] | list[str] | None) -> str | None:
-    if not values:
-        return None
-    return ",".join(str(v) for v in values)
-
-
-def _snapshot_pngs(project: Path, before: set[Path]) -> list[str]:
-    snapshot_dir = project / "snapshots"
-    if not snapshot_dir.is_dir():
-        return []
-    after = set(snapshot_dir.glob("*.png"))
-    created = after - before
-    paths = sorted(created or after)
-    return [str(path) for path in paths]
-
-
-def _json_result(command: str, result: subprocess.CompletedProcess[str]) -> HyperframesJsonResult:
-    return HyperframesJsonResult(command=command, data=_parse_json_stdout(result.stdout), stdout=result.stdout)
-
-
-# ---------------------------------------------------------------------------
-# Render
-# ---------------------------------------------------------------------------
-
-
-def _resolution_from_dimensions(width: int | None, height: int | None) -> str | None:
-    """Return the Hyperframes resolution preset matching legacy width/height args."""
-    match (width, height):
-        case (1920, 1080):
-            return "landscape"
-        case (1080, 1920):
-            return "portrait"
-        case (3840, 2160):
-            return "landscape-4k"
-        case (2160, 3840):
-            return "portrait-4k"
-        case _:
-            return None
-
-
-def _canonical_resolution(value: str | None) -> str | None:
-    """Normalize Hyperframes resolution aliases to canonical presets."""
-    match value:
-        case None:
-            return None
-        case "1080p":
-            return "landscape"
-        case "4k" | "uhd":
-            return "landscape-4k"
-        case _:
-            return value
-
-
-def _default_render_output(project_path: str, output_format: str | None) -> str:
-    """Return a format-appropriate default render artifact path."""
-    os.makedirs("out", exist_ok=True)
-    name = Path(project_path).name
-    match output_format:
-        case "png-sequence":
-            return os.path.join("out", f"{name}_frames")
-        case "webm" | "mov" | "mp4":
-            return os.path.join("out", f"{name}.{output_format}")
-        case _:
-            return os.path.join("out", f"{name}.mp4")
-
-
-def _render_output_exists(output_path: str, output_format: str | None) -> bool:
-    """Return true when the expected Hyperframes artifact exists."""
-    if output_format == "png-sequence":
-        output_dir = Path(output_path)
-        return output_dir.is_dir() and any(output_dir.glob("*.png"))
-    return os.path.isfile(output_path)
-
-
-def _resolve_render_resolution(width: int | None, height: int | None, resolution: str | None) -> str | None:
-    """Return the effective Hyperframes resolution without silently ignoring dimensions."""
-    if (width is None) ^ (height is None):
-        raise MCPVideoError(
-            "width and height must be provided together",
-            error_type="validation_error",
-            code="invalid_parameter",
-        )
-
-    if width is None and height is None:
-        return resolution
-
-    dimension_resolution = _resolution_from_dimensions(width, height)
-    if dimension_resolution is None:
-        raise MCPVideoError(
-            "Hyperframes render only supports width/height pairs that map to --resolution presets: "
-            "1920x1080, 1080x1920, 3840x2160, or 2160x3840. Use resolution=... instead of arbitrary dimensions.",
-            error_type="validation_error",
-            code="invalid_parameter",
-        )
-
-    if resolution is not None and _canonical_resolution(resolution) != dimension_resolution:
-        raise MCPVideoError(
-            f"width/height {width}x{height} conflicts with resolution '{resolution}'",
-            error_type="validation_error",
-            code="invalid_parameter",
-        )
-
-    return resolution or dimension_resolution
 
 
 def _build_render_result(

--- a/kinocut/hyperframes_ops_helpers.py
+++ b/kinocut/hyperframes_ops_helpers.py
@@ -1,0 +1,156 @@
+"""Private helpers for hyperframes_ops (size split; keep ops ≤800 LOC)."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+from .errors import MCPVideoError
+from .ffmpeg_helpers import _validate_input_path
+from .hyperframes_models import HyperframesJsonResult
+
+# ---------------------------------------------------------------------------
+# Output helpers
+# ---------------------------------------------------------------------------
+
+
+def _validate_variables_file(path: str | os.PathLike[str] | None) -> str | None:
+    """Validate optional runtime-data files before forwarding them to Hyperframes."""
+    if path is None:
+        return None
+    return _validate_input_path(str(path))
+
+
+def _post_process_ops() -> dict[str, Callable]:
+    """Return the post-processing operation registry for render_and_post."""
+    from . import engine as _video_engine
+
+    return {
+        "resize": _video_engine.resize,
+        "convert": _video_engine.convert,
+        "add_audio": _video_engine.add_audio,
+        "normalize_audio": _video_engine.normalize_audio,
+        "add_text": _video_engine.add_text,
+        "fade": _video_engine.fade,
+        "watermark": _video_engine.watermark,
+    }
+
+
+def _parse_json_stdout(stdout: str) -> dict[str, Any] | list[Any] | str:
+    """Parse Hyperframes JSON output, preserving text when a command is human-only."""
+    text = stdout.strip()
+    if not text:
+        return {}
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        return text
+
+
+def _csv(values: list[float] | list[str] | None) -> str | None:
+    if not values:
+        return None
+    return ",".join(str(v) for v in values)
+
+
+def _snapshot_pngs(project: Path, before: set[Path]) -> list[str]:
+    snapshot_dir = project / "snapshots"
+    if not snapshot_dir.is_dir():
+        return []
+    after = set(snapshot_dir.glob("*.png"))
+    created = after - before
+    paths = sorted(created or after)
+    return [str(path) for path in paths]
+
+
+def _json_result(command: str, result: subprocess.CompletedProcess[str]) -> HyperframesJsonResult:
+    return HyperframesJsonResult(command=command, data=_parse_json_stdout(result.stdout), stdout=result.stdout)
+
+
+# ---------------------------------------------------------------------------
+# Render
+# ---------------------------------------------------------------------------
+
+
+def _resolution_from_dimensions(width: int | None, height: int | None) -> str | None:
+    """Return the Hyperframes resolution preset matching legacy width/height args."""
+    match (width, height):
+        case (1920, 1080):
+            return "landscape"
+        case (1080, 1920):
+            return "portrait"
+        case (3840, 2160):
+            return "landscape-4k"
+        case (2160, 3840):
+            return "portrait-4k"
+        case _:
+            return None
+
+
+def _canonical_resolution(value: str | None) -> str | None:
+    """Normalize Hyperframes resolution aliases to canonical presets."""
+    match value:
+        case None:
+            return None
+        case "1080p":
+            return "landscape"
+        case "4k" | "uhd":
+            return "landscape-4k"
+        case _:
+            return value
+
+
+def _default_render_output(project_path: str, output_format: str | None) -> str:
+    """Return a format-appropriate default render artifact path."""
+    os.makedirs("out", exist_ok=True)
+    name = Path(project_path).name
+    match output_format:
+        case "png-sequence":
+            return os.path.join("out", f"{name}_frames")
+        case "webm" | "mov" | "mp4":
+            return os.path.join("out", f"{name}.{output_format}")
+        case _:
+            return os.path.join("out", f"{name}.mp4")
+
+
+def _render_output_exists(output_path: str, output_format: str | None) -> bool:
+    """Return true when the expected Hyperframes artifact exists."""
+    if output_format == "png-sequence":
+        output_dir = Path(output_path)
+        return output_dir.is_dir() and any(output_dir.glob("*.png"))
+    return os.path.isfile(output_path)
+
+
+def _resolve_render_resolution(width: int | None, height: int | None, resolution: str | None) -> str | None:
+    """Return the effective Hyperframes resolution without silently ignoring dimensions."""
+    if (width is None) ^ (height is None):
+        raise MCPVideoError(
+            "width and height must be provided together",
+            error_type="validation_error",
+            code="invalid_parameter",
+        )
+
+    if width is None and height is None:
+        return resolution
+
+    dimension_resolution = _resolution_from_dimensions(width, height)
+    if dimension_resolution is None:
+        raise MCPVideoError(
+            "Hyperframes render only supports width/height pairs that map to --resolution presets: "
+            "1920x1080, 1080x1920, 3840x2160, or 2160x3840. Use resolution=... instead of arbitrary dimensions.",
+            error_type="validation_error",
+            code="invalid_parameter",
+        )
+
+    if resolution is not None and _canonical_resolution(resolution) != dimension_resolution:
+        raise MCPVideoError(
+            f"width/height {width}x{height} conflicts with resolution '{resolution}'",
+            error_type="validation_error",
+            code="invalid_parameter",
+        )
+
+    return resolution or dimension_resolution

--- a/kinocut/te/__init__.py
+++ b/kinocut/te/__init__.py
@@ -6,6 +6,7 @@ from .audiogram import plan_audiogram
 from .brand_kit import BrandKit, load_brand_kit, save_brand_kit
 from .cost_oracle import estimate_operation
 from .cutfile import Cutfile, load_cutfile, validate_cutfile
+from .cutfile_render import compile_cutfile_to_workflow, render_cutfile
 from .edit_session import session_open, session_step
 from .hooks import generate_hook_candidates
 from .init_project import init_project
@@ -16,6 +17,7 @@ from .seek import frame_to_timestamp, timestamp_to_frame
 __all__ = [
     "BrandKit",
     "Cutfile",
+    "compile_cutfile_to_workflow",
     "estimate_operation",
     "frame_to_timestamp",
     "generate_hook_candidates",
@@ -24,6 +26,7 @@ __all__ = [
     "load_cutfile",
     "plan_audiogram",
     "plan_punch_zooms",
+    "render_cutfile",
     "save_brand_kit",
     "session_open",
     "session_step",

--- a/kinocut/te/cutfile.py
+++ b/kinocut/te/cutfile.py
@@ -1,4 +1,9 @@
-"""Cutfile — text-first project format skeleton (TE.11)."""
+"""Cutfile — text-first project format (TE.11).
+
+Validate/load live here. Render lowers a validated cutfile to the workflow
+engine via :func:`kinocut.te.cutfile_render.render_cutfile` (allowlisted ops
+only; see workflow OP_ADAPTERS).
+"""
 
 from __future__ import annotations
 

--- a/kinocut/te/cutfile_render.py
+++ b/kinocut/te/cutfile_render.py
@@ -1,0 +1,280 @@
+"""Cutfile render — lower a validated Cutfile to the workflow engine (TE.11).
+
+Thin path only: schema-valid cutfile ops that map to workflow OP_ADAPTERS are
+compiled into a job-spec and executed via ``render_workflow``. Unsupported ops
+fail closed. No parallel FFmpeg stack is introduced here.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+from kinocut.errors import MCPVideoError
+from kinocut.te.cutfile import Cutfile, load_cutfile
+from kinocut.workflow.ops import OP_ADAPTERS
+
+_RESERVED_OP_KEYS = frozenset({"op", "id", "src", "srcs", "output", "params"})
+_ID_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_-]{0,63}$")
+
+
+def _cutfile_error(message: str, code: str) -> MCPVideoError:
+    return MCPVideoError(message, error_type="validation_error", code=code)
+
+
+def _normalize_sources(sources: list[dict[str, Any]]) -> dict[str, dict[str, str]]:
+    """Map cutfile sources list → workflow sources dict (id → {path})."""
+    if not sources:
+        raise _cutfile_error("cutfile.sources must be non-empty to render", "cutfile_sources_required")
+    out: dict[str, dict[str, str]] = {}
+    for i, raw in enumerate(sources):
+        if not isinstance(raw, dict):
+            raise _cutfile_error(f"sources[{i}] must be an object", "invalid_cutfile_source")
+        sid = raw.get("id") or raw.get("name")
+        path = raw.get("path")
+        if not sid or not isinstance(sid, str):
+            raise _cutfile_error(f"sources[{i}].id is required", "cutfile_source_id")
+        if not _ID_RE.match(sid):
+            raise _cutfile_error(f"sources[{i}].id is invalid: {sid!r}", "cutfile_source_id")
+        if not path or not isinstance(path, str):
+            raise _cutfile_error(f"sources[{i}].path is required", "cutfile_source_path")
+        if sid in out:
+            raise _cutfile_error(f"duplicate source id {sid!r}", "cutfile_source_duplicate")
+        out[sid] = {"path": path}
+    return out
+
+
+def _op_params(op: dict[str, Any]) -> dict[str, Any]:
+    if isinstance(op.get("params"), dict):
+        return dict(op["params"])
+    return {k: v for k, v in op.items() if k not in _RESERVED_OP_KEYS}
+
+
+def _resolve_token(
+    token: str,
+    *,
+    source_ids: set[str],
+    step_outputs: dict[str, str],
+) -> str:
+    """Resolve a cutfile ref token to a workflow @ref."""
+    if token.startswith("@sources.") or token.startswith("@work/") or token.startswith("@outputs."):
+        return token
+    if token in source_ids:
+        return f"@sources.{token}"
+    if token in step_outputs:
+        return step_outputs[token]
+    raise _cutfile_error(f"unknown cutfile ref {token!r}", "cutfile_unknown_ref")
+
+
+def _default_src(
+    *,
+    source_ids: list[str],
+    last_ref: str | None,
+) -> str:
+    if last_ref is not None:
+        return last_ref
+    if not source_ids:
+        raise _cutfile_error("no sources available for default src", "cutfile_sources_required")
+    return f"@sources.{source_ids[0]}"
+
+
+def _step_id(op: dict[str, Any], index: int, used: set[str]) -> str:
+    raw = op.get("id")
+    if raw is None:
+        candidate = f"step_{index + 1}"
+    elif isinstance(raw, str) and _ID_RE.match(raw):
+        candidate = raw
+    else:
+        raise _cutfile_error(f"ops[{index}].id is invalid", "invalid_cutfile_op")
+    if candidate in used:
+        raise _cutfile_error(f"duplicate op id {candidate!r}", "cutfile_op_duplicate")
+    used.add(candidate)
+    return candidate
+
+
+def _validate_output_relpath(output_relpath: str) -> None:
+    if not output_relpath or not isinstance(output_relpath, str):
+        raise _cutfile_error("output_relpath must be a non-empty string", "cutfile_output_invalid")
+    if output_relpath.startswith("/") or ".." in Path(output_relpath).parts:
+        raise _cutfile_error(
+            "output_relpath must be workspace-relative without '..'",
+            "cutfile_output_invalid",
+        )
+
+
+def _bind_inputs(
+    op: dict[str, Any],
+    *,
+    index: int,
+    op_name: str,
+    multi_input: bool,
+    source_ids: list[str],
+    source_id_set: set[str],
+    step_outputs: dict[str, str],
+    last_ref: str | None,
+) -> dict[str, Any]:
+    if multi_input:
+        raw_srcs = op.get("srcs")
+        if not isinstance(raw_srcs, list) or not raw_srcs:
+            raise _cutfile_error(
+                f"ops[{index}] ({op_name}) requires non-empty srcs list",
+                "cutfile_srcs_required",
+            )
+        return {
+            "srcs": [
+                _resolve_token(str(t), source_ids=source_id_set, step_outputs=step_outputs) for t in raw_srcs
+            ]
+        }
+    raw_src = op.get("src")
+    if raw_src is None:
+        ref = _default_src(source_ids=source_ids, last_ref=last_ref)
+    else:
+        ref = _resolve_token(str(raw_src), source_ids=source_id_set, step_outputs=step_outputs)
+    return {"src": ref}
+
+
+def _compile_ops(
+    ops: list[dict[str, Any]],
+    *,
+    source_ids: list[str],
+) -> tuple[list[dict[str, Any]], int]:
+    """Lower cutfile ops to workflow steps; return (steps, last_media_index)."""
+    source_id_set = set(source_ids)
+    steps: list[dict[str, Any]] = []
+    step_outputs: dict[str, str] = {}
+    used_ids: set[str] = set()
+    last_ref: str | None = None
+    last_media_step_index: int | None = None
+
+    for i, op in enumerate(ops):
+        if not isinstance(op, dict):
+            raise _cutfile_error(f"ops[{i}] must be an object", "invalid_cutfile_op")
+        op_name = op.get("op")
+        if not isinstance(op_name, str) or op_name not in OP_ADAPTERS:
+            raise _cutfile_error(
+                f"ops[{i}] unsupported op {op_name!r}; allowlist={sorted(OP_ADAPTERS)}",
+                "cutfile_unsupported_op",
+            )
+        sid = _step_id(op, i, used_ids)
+        adapter = OP_ADAPTERS[op_name]
+        step: dict[str, Any] = {
+            "id": sid,
+            "op": op_name,
+            "params": _op_params(op),
+            "inputs": _bind_inputs(
+                op,
+                index=i,
+                op_name=op_name,
+                multi_input=adapter.multi_input,
+                source_ids=source_ids,
+                source_id_set=source_id_set,
+                step_outputs=step_outputs,
+                last_ref=last_ref,
+            ),
+        }
+        if adapter.has_output:
+            work_ref = f"@work/{sid}.mp4"
+            step["output"] = work_ref
+            step_outputs[sid] = work_ref
+            last_ref = work_ref
+            last_media_step_index = len(steps)
+        steps.append(step)
+
+    if last_media_step_index is None:
+        raise _cutfile_error(
+            "cutfile has no media-producing ops (probe-only is not a render)",
+            "cutfile_no_media_ops",
+        )
+    return steps, last_media_step_index
+
+
+def compile_cutfile_to_workflow(
+    cutfile: Cutfile,
+    *,
+    output_relpath: str = "out/final.mp4",
+) -> dict[str, Any]:
+    """Compile a validated Cutfile into a workflow job-spec dict (schema_version 1).
+
+    Linear chaining: single-input ops without ``src`` use the previous media
+    output (or the first source). ``merge`` requires ``srcs``. Only ops present
+    in the workflow OP_ADAPTERS allowlist are accepted.
+    """
+    if not cutfile.ops:
+        raise _cutfile_error("cutfile.ops must be non-empty to render", "cutfile_ops_required")
+    _validate_output_relpath(output_relpath)
+
+    sources = _normalize_sources(cutfile.sources)
+    steps, last_media_i = _compile_ops(cutfile.ops, source_ids=list(sources.keys()))
+    steps[last_media_i]["output"] = "@outputs.master"
+
+    return {
+        "schema_version": 1,
+        "name": cutfile.name,
+        "sources": sources,
+        "steps": steps,
+        "outputs": {"master": {"path": output_relpath}},
+    }
+
+
+def render_cutfile(
+    path: str,
+    *,
+    output_path: str | None = None,
+    save_receipt: str | None = None,
+    keep_intermediates: bool = False,
+) -> dict[str, Any]:
+    """Load a cutfile, compile to workflow, and render via the workflow engine.
+
+    The cutfile's parent directory is the workspace root (sources and outputs
+    are relative to it). Returns a dict with cutfile identity plus the workflow
+    receipt fields.
+    """
+    from kinocut.workflow import render_workflow
+
+    cutfile_path = Path(path).expanduser().resolve()
+    cf = load_cutfile(str(cutfile_path))
+    workspace = cutfile_path.parent
+    rel_out = output_path or f"out/{_safe_slug(cf.name)}.mp4"
+    if Path(rel_out).is_absolute():
+        try:
+            rel_out = str(Path(rel_out).resolve().relative_to(workspace))
+        except ValueError as exc:
+            raise _cutfile_error(
+                "output_path must be inside the cutfile workspace",
+                "cutfile_output_invalid",
+            ) from exc
+
+    (workspace / "out").mkdir(parents=True, exist_ok=True)
+    spec = compile_cutfile_to_workflow(cf, output_relpath=rel_out)
+    spec_path = workspace / ".cutfile_workflow.json"
+    spec_path.write_text(json.dumps(spec, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    receipt_path = save_receipt
+    if receipt_path is None:
+        receipts_dir = workspace / "receipts"
+        receipts_dir.mkdir(parents=True, exist_ok=True)
+        receipt_path = str(receipts_dir / f"{_safe_slug(cf.name)}.receipt.json")
+
+    receipt = render_workflow(
+        str(spec_path),
+        save_receipt=receipt_path,
+        keep_intermediates=keep_intermediates,
+    )
+    final = workspace / rel_out
+    return {
+        "artifact_kind": "cutfile_render",
+        "cutfile": str(cutfile_path),
+        "name": cf.name,
+        "version": cf.version,
+        "output_path": str(final) if final.is_file() else rel_out,
+        "workflow_spec": str(spec_path),
+        "receipt_path": receipt_path,
+        "workflow": receipt,
+    }
+
+
+def _safe_slug(name: str) -> str:
+    slug = re.sub(r"[^A-Za-z0-9._-]+", "_", name.strip()) or "cutfile"
+    return slug[:80]

--- a/kinocut/te/cutfile_render.py
+++ b/kinocut/te/cutfile_render.py
@@ -7,8 +7,11 @@ fail closed. No parallel FFmpeg stack is introduced here.
 
 from __future__ import annotations
 
+import contextlib
 import json
+import os
 import re
+import tempfile
 from pathlib import Path
 from typing import Any
 
@@ -157,6 +160,13 @@ def _compile_ops(
                 f"ops[{i}] unsupported op {op_name!r}; allowlist={sorted(OP_ADAPTERS)}",
                 "cutfile_unsupported_op",
             )
+        # Cutfile v1 only binds src / srcs — multi-layer adapters need a different shape.
+        if op_name in {"composite_layers"}:
+            raise _cutfile_error(
+                f"ops[{i}] op {op_name!r} is not supported in cutfile v1 "
+                "(requires layers binding; use workflow job-spec directly)",
+                "cutfile_op_shape",
+            )
         sid = _step_id(op, i, used_ids)
         adapter = OP_ADAPTERS[op_name]
         step: dict[str, Any] = {
@@ -248,20 +258,32 @@ def render_cutfile(
 
     (workspace / "out").mkdir(parents=True, exist_ok=True)
     spec = compile_cutfile_to_workflow(cf, output_relpath=rel_out)
-    spec_path = workspace / ".cutfile_workflow.json"
-    spec_path.write_text(json.dumps(spec, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-
-    receipt_path = save_receipt
-    if receipt_path is None:
-        receipts_dir = workspace / "receipts"
-        receipts_dir.mkdir(parents=True, exist_ok=True)
-        receipt_path = str(receipts_dir / f"{_safe_slug(cf.name)}.receipt.json")
-
-    receipt = render_workflow(
-        str(spec_path),
-        save_receipt=receipt_path,
-        keep_intermediates=keep_intermediates,
+    spec_fd, spec_name = tempfile.mkstemp(
+        prefix=f".cutfile_workflow_{_safe_slug(cf.name)}_",
+        suffix=".json",
+        dir=str(workspace),
     )
+    os.close(spec_fd)
+    spec_path = Path(spec_name)
+    try:
+        spec_path.write_text(json.dumps(spec, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+        receipt_path = save_receipt
+        if receipt_path is None:
+            receipts_dir = workspace / "receipts"
+            receipts_dir.mkdir(parents=True, exist_ok=True)
+            receipt_path = str(receipts_dir / f"{_safe_slug(cf.name)}.receipt.json")
+
+        receipt = render_workflow(
+            str(spec_path),
+            save_receipt=receipt_path,
+            keep_intermediates=keep_intermediates,
+        )
+    finally:
+        if not keep_intermediates:
+            with contextlib.suppress(OSError):
+                spec_path.unlink(missing_ok=True)
+
     final = workspace / rel_out
     return {
         "artifact_kind": "cutfile_render",
@@ -269,7 +291,7 @@ def render_cutfile(
         "name": cf.name,
         "version": cf.version,
         "output_path": str(final) if final.is_file() else rel_out,
-        "workflow_spec": str(spec_path),
+        "workflow_spec": str(spec_path) if keep_intermediates and spec_path.is_file() else None,
         "receipt_path": receipt_path,
         "workflow": receipt,
     }

--- a/llms.txt
+++ b/llms.txt
@@ -14,7 +14,7 @@ Kinocut is a free, open-source Model Context Protocol (MCP) server that gives AI
 - **Publisher:** KyaniteLabs — https://kyanitelabs.tech/
 - **License:** Apache-2.0
 - **Latest published release:** 1.13.2 (2026-08-09)
-- **Last-updated:** 2026-08-09
+- **Last-updated:** 2026-08-12
 - **Published surface (1.13.2):** 194 MCP tools / 165 CLI commands
 - **Development tip (master at tag):** 194 MCP tools / 165 CLI commands — matches published 1.13.2
 - **Runtime:** Python 3.11+, FFmpeg on PATH; optional extras for Whisper/upscale/etc.

--- a/scripts/golden_path_timings.py
+++ b/scripts/golden_path_timings.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python3
+"""WP-F golden-path timing harness (baseline scaffolding).
+
+Default mode is cheap and fixture-backed:
+  1. kino doctor --json
+  2. kino --format json info <fixture>
+
+Optional full mode times scripts/golden_path.py (FFmpeg confidence workflow).
+
+Does NOT claim product optimization and does NOT bump public_claims.json.
+Write measured rows into docs/status/golden-path-timings.md after a run.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import platform
+import statistics
+import subprocess
+import sys
+import time
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_FIXTURE = ROOT / "tests" / "fixtures" / "golden" / "workflow_final.mp4"
+DEFAULT_RUNS = 5
+STEP_TIMEOUT_S = 120
+FULL_TIMEOUT_S = 600
+
+
+@dataclass(frozen=True)
+class StepStats:
+    step: str
+    runs: int
+    ok_runs: int
+    samples_s: list[float]
+    p50_s: float | None
+    p95_s: float | None
+    mean_s: float | None
+    min_s: float | None
+    max_s: float | None
+
+
+def _percentile(sorted_vals: list[float], p: float) -> float | None:
+    if not sorted_vals:
+        return None
+    if len(sorted_vals) == 1:
+        return sorted_vals[0]
+    # Nearest-rank linear interpolation (same idea as numpy percentile linear).
+    k = (len(sorted_vals) - 1) * (p / 100.0)
+    f = int(k)
+    c = min(f + 1, len(sorted_vals) - 1)
+    if f == c:
+        return sorted_vals[f]
+    return sorted_vals[f] + (sorted_vals[c] - sorted_vals[f]) * (k - f)
+
+
+def _stats(step: str, samples: list[float], ok_runs: int) -> StepStats:
+    sorted_s = sorted(samples)
+    return StepStats(
+        step=step,
+        runs=len(samples),
+        ok_runs=ok_runs,
+        samples_s=[round(s, 4) for s in samples],
+        p50_s=round(_percentile(sorted_s, 50) or 0.0, 4) if sorted_s else None,
+        p95_s=round(_percentile(sorted_s, 95) or 0.0, 4) if sorted_s else None,
+        mean_s=round(statistics.fmean(samples), 4) if samples else None,
+        min_s=round(min(samples), 4) if samples else None,
+        max_s=round(max(samples), 4) if samples else None,
+    )
+
+
+def _run_timed(cmd: list[str], *, timeout: int) -> tuple[float, int, str]:
+    t0 = time.perf_counter()
+    try:
+        proc = subprocess.run(
+            cmd,
+            cwd=ROOT,
+            text=True,
+            capture_output=True,
+            timeout=timeout,
+            check=False,
+        )
+        elapsed = time.perf_counter() - t0
+        detail = (proc.stderr or proc.stdout or "").strip()
+        return elapsed, proc.returncode, detail[-500:] if detail else ""
+    except subprocess.TimeoutExpired as exc:
+        elapsed = time.perf_counter() - t0
+        return elapsed, 124, f"timeout after {timeout}s: {exc}"
+
+
+def _time_step(
+    name: str,
+    cmd: list[str],
+    *,
+    runs: int,
+    timeout: int,
+) -> StepStats:
+    samples: list[float] = []
+    ok = 0
+    print(f"\n[{name}] {' '.join(cmd)}")
+    for i in range(runs):
+        elapsed, rc, detail = _run_timed(cmd, timeout=timeout)
+        samples.append(elapsed)
+        status = "ok" if rc == 0 else f"rc={rc}"
+        print(f"  run {i + 1}/{runs}: {elapsed:.3f}s {status}")
+        if rc == 0:
+            ok += 1
+        elif detail:
+            print(f"    detail: {detail[:200]}")
+    return _stats(name, samples, ok)
+
+
+def _host_meta() -> dict[str, str]:
+    uname = platform.uname()
+    return {
+        "timestamp_utc": datetime.now(UTC).isoformat(),
+        "python": sys.version.split()[0],
+        "platform": platform.platform(),
+        "system": uname.system,
+        "machine": uname.machine,
+        "processor": uname.processor or "",
+        "node": uname.node,
+    }
+
+
+def _markdown_table(steps: list[StepStats], *, mode: str, fixture: str, meta: dict[str, str]) -> str:
+    lines = [
+        f"| step | mode | runs | ok | p50 (s) | p95 (s) | mean (s) | min (s) | max (s) | machine |",
+        f"| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |",
+    ]
+    machine = f"{meta.get('system', '?')}/{meta.get('machine', '?')}"
+    for s in steps:
+        lines.append(
+            "| {step} | {mode} | {runs} | {ok} | {p50} | {p95} | {mean} | {min_s} | {max_s} | {machine} |".format(
+                step=s.step,
+                mode=mode,
+                runs=s.runs,
+                ok=s.ok_runs,
+                p50=s.p50_s if s.p50_s is not None else "—",
+                p95=s.p95_s if s.p95_s is not None else "—",
+                mean=s.mean_s if s.mean_s is not None else "—",
+                min_s=s.min_s if s.min_s is not None else "—",
+                max_s=s.max_s if s.max_s is not None else "—",
+                machine=machine,
+            )
+        )
+    lines.append("")
+    lines.append(f"Fixture: `{fixture}`")
+    lines.append(f"Recorded: `{meta.get('timestamp_utc', '')}`")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Time Kinocut golden-path baseline steps (WP-F scaffolding)."
+    )
+    parser.add_argument(
+        "--mode",
+        choices=("cheap", "full"),
+        default="cheap",
+        help="cheap=doctor+info (default); full=also time scripts/golden_path.py once per run",
+    )
+    parser.add_argument(
+        "--runs",
+        type=int,
+        default=DEFAULT_RUNS,
+        help=f"samples per step (default {DEFAULT_RUNS})",
+    )
+    parser.add_argument(
+        "--fixture",
+        type=Path,
+        default=DEFAULT_FIXTURE,
+        help="video path for info step (default tests/fixtures/golden/workflow_final.mp4)",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="emit machine-readable JSON summary to stdout after the table",
+    )
+    parser.add_argument(
+        "--markdown-only",
+        action="store_true",
+        help="print only the markdown results table (for pasting into status doc)",
+    )
+    args = parser.parse_args(argv)
+
+    if args.runs < 1:
+        print("FAIL: --runs must be >= 1", file=sys.stderr)
+        return 2
+
+    py = sys.executable
+    fixture = args.fixture if args.fixture.is_absolute() else (ROOT / args.fixture)
+    if not fixture.is_file():
+        print(f"FAIL: fixture not found: {fixture}", file=sys.stderr)
+        return 2
+
+    steps: list[StepStats] = []
+    steps.append(
+        _time_step(
+            "doctor",
+            [py, "-m", "kinocut", "doctor", "--json"],
+            runs=args.runs,
+            timeout=STEP_TIMEOUT_S,
+        )
+    )
+    steps.append(
+        _time_step(
+            "info",
+            [py, "-m", "kinocut", "--format", "json", "info", str(fixture)],
+            runs=args.runs,
+            timeout=STEP_TIMEOUT_S,
+        )
+    )
+
+    if args.mode == "full":
+        gp = ROOT / "scripts" / "golden_path.py"
+        if not gp.is_file():
+            print(f"FAIL: missing {gp}", file=sys.stderr)
+            return 2
+        steps.append(
+            _time_step(
+                "golden_path",
+                [py, str(gp)],
+                runs=args.runs,
+                timeout=FULL_TIMEOUT_S,
+            )
+        )
+
+    meta = _host_meta()
+    table = _markdown_table(steps, mode=args.mode, fixture=str(fixture.relative_to(ROOT)), meta=meta)
+
+    if not args.markdown_only:
+        print("\n" + "=" * 60)
+        print("Kinocut golden-path timings (WP-F baseline)")
+        print(f"mode={args.mode} runs={args.runs}")
+        print("=" * 60)
+    print(table)
+
+    payload = {
+        "schema": "kinocut.golden_path_timings.v1",
+        "mode": args.mode,
+        "runs": args.runs,
+        "fixture": str(fixture.relative_to(ROOT)),
+        "host": meta,
+        "steps": [asdict(s) for s in steps],
+        "claim_note": (
+            "Baseline scaffolding only. Not an optimization claim. "
+            "Do not bump docs/public_claims.json from this script."
+        ),
+    }
+    if args.json:
+        print(json.dumps(payload, indent=2))
+
+    failed = [s for s in steps if s.ok_runs < s.runs]
+    if failed:
+        names = ", ".join(s.step for s in failed)
+        print(f"\nWARN: incomplete success on: {names}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/golden_path_timings.py
+++ b/scripts/golden_path_timings.py
@@ -129,8 +129,8 @@ def _host_meta() -> dict[str, str]:
 
 def _markdown_table(steps: list[StepStats], *, mode: str, fixture: str, meta: dict[str, str]) -> str:
     lines = [
-        f"| step | mode | runs | ok | p50 (s) | p95 (s) | mean (s) | min (s) | max (s) | machine |",
-        f"| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |",
+        "| step | mode | runs | ok | p50 (s) | p95 (s) | mean (s) | min (s) | max (s) | machine |",
+        "| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |",
     ]
     machine = f"{meta.get('system', '?')}/{meta.get('machine', '?')}"
     for s in steps:

--- a/tests/test_architecture_guardrails.py
+++ b/tests/test_architecture_guardrails.py
@@ -83,6 +83,8 @@ def test_split_engine_modules_stay_below_size_limit() -> None:
     """
     split_modules = [
         PACKAGE / "hyperframes_engine.py",
+        PACKAGE / "hyperframes_ops.py",
+        PACKAGE / "hyperframes_ops_helpers.py",
         PACKAGE / "workflow" / "executor.py",
         PACKAGE / "workflow" / "receipt.py",
     ]

--- a/tests/test_te_and_mutations.py
+++ b/tests/test_te_and_mutations.py
@@ -2,9 +2,23 @@
 
 from __future__ import annotations
 
+import json
+import shutil
 from pathlib import Path
 
-from kinocut.te import BrandKit, estimate_operation, init_project, load_cutfile, save_brand_kit, validate_cutfile
+import pytest
+
+from kinocut.errors import MCPVideoError
+from kinocut.te import (
+    BrandKit,
+    compile_cutfile_to_workflow,
+    estimate_operation,
+    init_project,
+    load_cutfile,
+    render_cutfile,
+    save_brand_kit,
+    validate_cutfile,
+)
 from kinocut.watching import MetricFinding, propose_mutations_from_findings
 
 
@@ -43,6 +57,79 @@ def test_cutfile_yaml_scaffold(tmp_path: Path) -> None:
     p.write_text('name: "demo"\nversion: 1\nsources: []\nops: []\n', encoding="utf-8")
     cf = load_cutfile(str(p))
     assert cf.name == "demo"
+
+
+def test_cutfile_compile_to_workflow() -> None:
+    cf = validate_cutfile(
+        {
+            "name": "demo",
+            "version": 1,
+            "sources": [{"id": "hero", "path": "media/hero.mp4"}],
+            "ops": [
+                {"op": "trim", "start": 0, "duration": 1},
+                {"op": "resize", "width": 320, "height": 240},
+            ],
+        }
+    )
+    spec = compile_cutfile_to_workflow(cf, output_relpath="out/final.mp4")
+    assert spec["schema_version"] == 1
+    assert spec["sources"]["hero"]["path"] == "media/hero.mp4"
+    assert len(spec["steps"]) == 2
+    assert spec["steps"][0]["op"] == "trim"
+    assert spec["steps"][0]["inputs"]["src"] == "@sources.hero"
+    assert spec["steps"][1]["inputs"]["src"] == "@work/step_1.mp4"
+    assert spec["steps"][1]["output"] == "@outputs.master"
+    assert spec["outputs"]["master"]["path"] == "out/final.mp4"
+
+
+def test_cutfile_compile_rejects_unsupported_op() -> None:
+    cf = validate_cutfile(
+        {
+            "name": "bad",
+            "version": 1,
+            "sources": [{"id": "hero", "path": "media/hero.mp4"}],
+            "ops": [{"op": "teleport"}],
+        }
+    )
+    with pytest.raises(MCPVideoError) as exc:
+        compile_cutfile_to_workflow(cf)
+    assert exc.value.code == "cutfile_unsupported_op"
+
+
+def test_cutfile_compile_requires_sources_and_ops() -> None:
+    empty_ops = validate_cutfile({"name": "x", "version": 1, "sources": [{"id": "a", "path": "a.mp4"}], "ops": []})
+    with pytest.raises(MCPVideoError) as exc:
+        compile_cutfile_to_workflow(empty_ops)
+    assert exc.value.code == "cutfile_ops_required"
+
+    no_src = validate_cutfile({"name": "x", "version": 1, "sources": [], "ops": [{"op": "trim", "start": 0}]})
+    with pytest.raises(MCPVideoError) as exc2:
+        compile_cutfile_to_workflow(no_src)
+    assert exc2.value.code == "cutfile_sources_required"
+
+
+@pytest.mark.slow
+@pytest.mark.skipif(shutil.which("ffmpeg") is None, reason="FFmpeg not installed")
+def test_cutfile_render_trim_resize(tmp_path: Path, sample_video: str) -> None:
+    root = tmp_path / "proj"
+    init_project(str(root), name="render-demo")
+    media = root / "media" / "hero.mp4"
+    shutil.copy(sample_video, media)
+    cutfile = {
+        "name": "render-demo",
+        "version": 1,
+        "sources": [{"id": "hero", "path": "media/hero.mp4"}],
+        "ops": [
+            {"op": "trim", "start": 0, "duration": 1},
+            {"op": "resize", "width": 320, "height": 240},
+        ],
+    }
+    (root / "cutfile.json").write_text(json.dumps(cutfile), encoding="utf-8")
+
+    result = render_cutfile(str(root / "cutfile.json"), output_path="out/final.mp4")
+    assert result["artifact_kind"] == "cutfile_render"
+    assert Path(result["output_path"]).is_file()
+    assert result["workflow"]["status"] == "completed"
 
 
 def test_propose_mutations_from_findings() -> None:

--- a/tests/test_te_and_mutations.py
+++ b/tests/test_te_and_mutations.py
@@ -96,6 +96,48 @@ def test_cutfile_compile_rejects_unsupported_op() -> None:
     assert exc.value.code == "cutfile_unsupported_op"
 
 
+def test_cutfile_compile_rejects_composite_layers_shape() -> None:
+    cf = validate_cutfile(
+        {
+            "name": "layers",
+            "version": 1,
+            "sources": [{"id": "hero", "path": "media/hero.mp4"}],
+            "ops": [{"op": "composite_layers"}],
+        }
+    )
+    with pytest.raises(MCPVideoError) as exc:
+        compile_cutfile_to_workflow(cf)
+    assert exc.value.code == "cutfile_op_shape"
+
+
+def test_cutfile_compile_rejects_probe_only() -> None:
+    cf = validate_cutfile(
+        {
+            "name": "probe",
+            "version": 1,
+            "sources": [{"id": "hero", "path": "media/hero.mp4"}],
+            "ops": [{"op": "probe"}],
+        }
+    )
+    with pytest.raises(MCPVideoError) as exc:
+        compile_cutfile_to_workflow(cf)
+    assert exc.value.code == "cutfile_no_media_ops"
+
+
+def test_cutfile_compile_rejects_parent_output_relpath() -> None:
+    cf = validate_cutfile(
+        {
+            "name": "escape",
+            "version": 1,
+            "sources": [{"id": "hero", "path": "media/hero.mp4"}],
+            "ops": [{"op": "trim", "start": 0, "duration": 1}],
+        }
+    )
+    with pytest.raises(MCPVideoError) as exc:
+        compile_cutfile_to_workflow(cf, output_relpath="../out/final.mp4")
+    assert exc.value.code in {"cutfile_output_invalid", "invalid_cutfile_output", "cutfile_output_path"}
+
+
 def test_cutfile_compile_requires_sources_and_ops() -> None:
     empty_ops = validate_cutfile({"name": "x", "version": 1, "sources": [{"id": "a", "path": "a.mp4"}], "ops": []})
     with pytest.raises(MCPVideoError) as exc:


### PR DESCRIPTION
## Summary
Mirror of Forgejo PR https://git.kyanitelabs.tech/KyaniteLabs/kinocut/pulls/373

Agent residual portfolio closeout (cutfile library render, L0–L5 honesty, WP-F timings). No public_claims surface bump.

**Source of truth merge is on Forgejo.** This PR tracks GitHub mirror state for S+/public face.

## Test plan
- See Forgejo #373

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/kinocut/pr/439"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789141748&installation_model_id=20207&pr_number=439&repository=KyaniteLabs%2Fkinocut&return_to=https%3A%2F%2Fgithub.com%2FKyaniteLabs%2Fkinocut%2Fpull%2F439&signature=3aa372c9b624c4a4c65feeeefb995145d09ae95e6df7c57167a4b2ca03dfe367"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Cutfile-to-workflow compilation and rendering, including validation, output handling, receipts, and intermediate cleanup.
  - Added golden-path timing measurements with Markdown and optional JSON reports.

- **Documentation**
  - Updated roadmap, release guidance, phase checkpoints, residual status, sound acceptance requirements, deferred work, and timing methodology.
  - Clarified claim-freeze rules, evidence requirements, historical status, and human-gated completion criteria.

- **Bug Fixes**
  - Improved validation for render settings, sources, operations, references, and output paths.

- **Tests**
  - Expanded coverage for Cutfile workflows, rendering, validation, and architecture guardrails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->