### PR TITLE
feat: wishlist residuals + optional depth + Renovate/light CI ops

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -4,5 +4,10 @@
     "config:recommended"
   ],
   "automerge": true,
-  "platformAutomerge": true
+  "platformAutomerge": true,
+  "labels": [
+    "dependencies"
+  ],
+  "prHourlyLimit": 4,
+  "prConcurrentLimit": 5
 }

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -52,7 +52,7 @@ Ordered per residual matrix + excellence audit. Prefer one work package per PR. 
 | **D** Long functions | ≤80 LOC functions | **Done on tip** (0 funcs >80, 2026-08-12 live) |
 | **F** Perf baselines | Golden-path p50/p95 | **Baseline measured** 2026-08-12 (cheap+full) in [golden-path-timings.md](docs/status/golden-path-timings.md); not an “optimized” product claim |
 
-**L2 residual (ultragoal, capacity-capped):** sound residual waves per [sound residual DAG](docs/status/2026-08-12-sound-residual-stage-dag.md); Phase 3/4 deepen → GO or DEFERRED; cutfile render or DEFERRED; TE/conversational/MCPB honesty. See [critical path](.omx/state/critical-path.md).
+**L2 residual (ultragoal, capacity-capped):** sound residual waves per [sound residual DAG](docs/status/2026-08-12-sound-residual-stage-dag.md); Phase 3/4 deepen → GO or DEFERRED; cutfile render or DEFERRED; TE/conversational/MCPB honesty. See [product pipeline complete](docs/status/2026-08-12-product-pipeline-complete.md) and residual matrix.
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -242,7 +242,7 @@ v1.2.0 shipped. 82 MCP tools, 832 tests, security hardened. Here's what's next.
 
 - [x] **Progress callbacks** — Long operations (merge, convert, export) give no feedback. A progress percentage in the MCP response would let agents tell users "50% done..." instead of silence. FFmpeg outputs progress to stderr — parse it.
 - [x] **Output file cleanup** — `video_cleanup` MCP tool removes intermediate files, with a `keep` list to preserve finals.
-- [ ] **Smarter GIF output** — 3-second GIF at "low" quality = 28MB. The two-pass palette approach is good but `scale=480:-1` is too large for "low". Scale by quality preset: low=320, medium=480, high=640.
+- [x] **Smarter GIF output** — 3-second GIF at "low" quality = 28MB. The two-pass palette approach is good but `scale=480:-1` is too large for "low". Scale by quality preset: low=320, medium=480, high=640. *(Shipped; quality scales low=320..ultra=800 in engine_convert)*
 - [x] **Visual verification** — After an operation, return a thumbnail of the first frame of the output. *(Shipped in v1.0.0)*
 
 ## Medium Impact (Makes the API less frustrating)
@@ -265,16 +265,16 @@ v1.2.0 shipped. 82 MCP tools, 832 tests, security hardened. Here's what's next.
 ## Low Impact (Nice to have)
 
 - [x] **Custom font upload** — `font_manager.py` downloads and caches Google Fonts by name for use in text overlays. *(Shipped in v1.3.0)*
-- [ ] **Video concatenation with transitions per-clip** — Already supported in `merge` via `transitions` parameter, but add a `video_edit` shortcut for simple "clip A -> fade -> clip B -> dissolve -> clip C" patterns.
-- [ ] **Audio waveform extraction** — Return a text-based waveform representation so agents can "see" the audio without playing it. Useful for finding silence or loud sections.
+- [x] **Video concatenation with transitions per-clip** — Already supported in `merge` via `transitions` parameter; `video_edit` sequence shortcut accepts `clips` + `transitions` + `transition_duration` (expanded via `expand_sequence_shortcut`).
+- [x] **Audio waveform extraction** — Return a text-based waveform representation so agents can "see" the audio without playing it. Useful for finding silence or loud sections. *(WaveformResult.text ASCII via _render_ascii_waveform)*
 - [x] **Subtitle generation from text** — Given a list of `[(start, end, text)]` tuples, generate an SRT file and burn it in one step. *(Shipped as `video_generate_subtitles`)*
-- [ ] **Frame-accurate seeking** — Use `-ss` before `-i` (input seeking) for speed, but fall back to output seeking for frame accuracy when the user specifies exact timestamps.
+- [x] **Frame-accurate seeking** — Use `-ss` before `-i` (input seeking) for speed, but fall back to output seeking for frame accuracy when the user specifies exact timestamps. *(trim accurate=True + te/seek helpers)*
 - [x] **Output directory option** — Currently outputs go next to the input file. Add a global `output_dir` option so all intermediates go to a temp folder. *(Shipped in v0.3.0 as `video_batch --output-dir` / `output_dir` param)*
 
 ## Observability (For you as the maintainer)
 
 - [~] **Usage analytics** — Dropped 2026-06-12. A v1.3.0 agent commit shipped a ping module pointing at a Vercel endpoint that was never deployed or owned; removed because an unowned, claimable domain receiving install IDs is a liability, not observability. If telemetry ever returns it needs an endpoint we actually control, decided first.
-- [ ] **Structured logging** — Currently silent on success. Add a `--verbose` flag and optional log file. Helps users debug their own issues before filing them.
+- [x] **Structured logging** — Currently silent on success. Add a `--verbose` flag and optional log file. Helps users debug their own issues before filing them. *(`-v/--verbose` + `--log-file PATH`)*
 - [x] **GitHub Actions CI** — Run the full test suite on push. Catch regressions before they ship. Currently manual. *(Shipped in v0.2.x)*
 
 ## Not Doing (Intentionally out of scope)
@@ -303,5 +303,5 @@ Features that FFmpeg supports but Kinocut doesn't expose yet. Ordered by impact.
 ### Low Impact
 - [x] **Ken Burns / zoom pan** — Animated zoom/pan effects via `zoompan` filter
 - [x] **Advanced masking** — New `luma_key()` (brightness-based masking) and `shape_mask()` (circle, rounded_rect, oval) tools. *(Shipped in v1.3.0)*
-- [ ] **Frame-accurate seeking** — Input seeking for speed, output seeking for accuracy
+- [x] **Frame-accurate seeking** — Input seeking for speed, output seeking for accuracy *(trim accurate=True)*
 - [x] **Two-pass encoding** — More efficient compression for target file sizes

--- a/docs/CI_RUNNER_TOPOLOGY.md
+++ b/docs/CI_RUNNER_TOPOLOGY.md
@@ -3,14 +3,41 @@
 This document records the repository contract for Kinocut's Forgejo runners.
 It is not evidence that a Forgejo administrator has applied the configuration.
 
+**Last agent review:** 2026-08-12 · light routing verified in `.forgejo/workflows/ci.yml`
+
 ## Workload routing
 
 | Label | Intended workload | Host rule |
 | --- | --- | --- |
 | `light` | lint, metadata, and other low-CPU checks | May run at capacity 1; must not carry real-media tests |
-| `heavy` | Legacy shared heavy-work label | Do not use for Kinocut jobs; other registered runners may claim it |
+| `heavy` | Legacy shared heavy-work label (also Renovate / mirror sync today) | Prefer not for Kinocut test suites; keep for short ops jobs until `light` capacity is proven for them |
 | `arm64-heavy` | Python tests, FFmpeg renders, Hyperframes, and FFmpeg matrices | Dedicated ARM64 runner away from the Forgejo application host |
 | `kinocut-ci` | Same workload class as `arm64-heavy`, using the prebuilt Kinocut image | Map only after the immutable image digest is published and smoke-tested |
+
+## Light runner topology (contract)
+
+**Goal:** cheap checks never queue behind multi-minute FFmpeg/pytest shards.
+
+| Workflow job | File | `runs-on` | Notes |
+| --- | --- | --- | --- |
+| Lint / ruff | `.forgejo/workflows/ci.yml` | **`light`** | Must stay on `light`; do not move lint onto `arm64-heavy` |
+| Unit / integration / FFmpeg matrix | `.forgejo/workflows/ci.yml` | `arm64-heavy` | Real media + pytest only |
+| Renovate | `.forgejo/workflows/renovate.yml` | `heavy` | Containerized; ops job (not pytest) |
+| Mirror sync | `.forgejo/workflows/sync-github.yml` | `heavy` | Ops job |
+
+### Admin checklist for light capacity
+
+1. Runner registers labels: `light`, `heavy`, `arm64-heavy` (and optionally `default`).
+2. At least one runner claims **`light`** without also being the sole host for concurrent `arm64-heavy` starvation (capacity ≥1 is fine if heavy work is on another label).
+3. Spot-check: open a PR that only touches docs → lint job starts without waiting for a long test shard.
+4. Do **not** schedule real-media pytest on `light`.
+5. If `light` has zero online runners, lint fails fast — that is preferred to silent routing onto an overloaded heavy host.
+
+### Anti-patterns
+
+- Routing FFmpeg matrix or full pytest onto `light`
+- Using bare `ubuntu-latest` on Forgejo (self-hosted labels only)
+- Mapping `arm64-heavy` onto the Forgejo application VM under load
 
 The 2026-07-10 incident audit observed `vps-runner-01` on the Forgejo host at
 capacity 1 and `nucbox-ci` at capacity 4. Those observations are historical,

--- a/docs/HUMAN_GATES.md
+++ b/docs/HUMAN_GATES.md
@@ -8,7 +8,7 @@ where noted. Residual portfolio authority:
 
 | Former issue | Agent deliverable | Status |
 | --- | --- | --- |
-| #3 Renovate dashboard | `.github/dependabot.yml` + `.renovaterc.json` + note that Forgejo Renovate needs `GITHUB_COM_TOKEN`/hostRules | **Still human/ops** — enable token / Renovate app on host (Forgejo admin) |
+| #3 Renovate dashboard | `.github/dependabot.yml` + `.renovaterc.json` + `.forgejo/workflows/renovate.yml` + runbook [`docs/ops/RENOVATE_HOST_TOKEN.md`](ops/RENOVATE_HOST_TOKEN.md) | **Still human/ops** — set `RENOVATE_TOKEN` + `MIRROR_GITHUB_TOKEN` on Forgejo; agent runbook complete |
 | #88 Directory submissions | `docs/DIRECTORY_REBRAND_STATUS.md` + `docs/status/DIRECTORY_SUBMISSION_OPS.md` | Awesome MCP Servers PR **merged** (2026-08-08). MCP.so, Docker MCP, Agent-CoreX, Protodex still pending external review |
 | #90 Launch moments | `docs/status/LAUNCH_MOMENTS.md` drafts + checklists | Approve & publish posts/clips (marketing ops, not product maturity) |
 | #92 First-10 users | `docs/status/USER_PROGRAM_RUNBOOK.md` | **CLOSED as obsolete (2026-08-12)** — adoption already past a “first 10” gate (see live signals below) |

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -163,7 +163,7 @@ download models, contact providers, or submit jobs. See
 | `video_overlay` | Picture-in-picture overlay with opacity and timing guardrails |
 | `video_composite_layers` | Spec-driven ordered image/video layer compositing with explicit straight/premultiplied input alpha, transforms, timing windows, masks/mattes, full-canvas and allowlisted positioned blend modes, rotation/pivot, named layer/mask/mask-edge `effect-noise` routes, dry-run plans, and deterministic `layer_plan` v2 receipts (video-only output) |
 | `video_split_screen` | Side-by-side or top/bottom layout with duration/FPS/audio mismatch warnings |
-| `video_edit` | Full timeline-based edit from JSON DSL |
+| `video_edit` | Full timeline-based edit from JSON DSL, or sequence shortcut (`clips` + optional `transitions` / `transition_duration`) |
 | `video_create_from_images` | Create video from image sequence |
 | `video_export_frames` | Export video as individual image frames |
 | `video_extract_frame` | Extract a single frame at a given timestamp for visual verification |

--- a/docs/ops/RENOVATE_HOST_TOKEN.md
+++ b/docs/ops/RENOVATE_HOST_TOKEN.md
@@ -1,0 +1,65 @@
+# Renovate host token (#3)
+
+**Status:** agent-prep complete · live enablement is **human/Forgejo admin**  
+**Related:** `docs/HUMAN_GATES.md` · `.renovaterc.json` · `.forgejo/workflows/renovate.yml` · `.github/dependabot.yml`
+
+## What is already in-repo
+
+| Artifact | Role |
+| --- | --- |
+| `.renovaterc.json` | Recommended Renovate config (`config:recommended`, automerge on) |
+| `.forgejo/workflows/renovate.yml` | Scheduled Renovate job (every 6h + `workflow_dispatch`) on Forgejo |
+| `.github/dependabot.yml` | GitHub-side dependency PRs (mirror host) |
+
+The workflow expects these **secrets on the Forgejo repo or org**:
+
+| Secret | Purpose |
+| --- | --- |
+| `RENOVATE_TOKEN` | Forgejo personal access token (or app token) with repo write for PR creation |
+| `MIRROR_GITHUB_TOKEN` | Mapped to `GITHUB_COM_TOKEN` so Renovate can read release notes / changelogs on github.com |
+
+## Human ops steps (Forgejo admin)
+
+1. **Create a bot account or use a machine user** with access to `KyaniteLabs/kinocut`.
+2. **Mint `RENOVATE_TOKEN`** with scopes that allow:
+   - repository contents read
+   - pull/PR create + write
+   - issues write (labels/comments as needed by Renovate)
+3. **Mint or reuse a GitHub PAT** (`MIRROR_GITHUB_TOKEN`) with `public_repo` (or fine-grained read on public deps) so github.com rate limits do not starve changelog lookups.
+4. In Forgejo: **Settings → Actions → Secrets** (repo or org) set:
+   - `RENOVATE_TOKEN`
+   - `MIRROR_GITHUB_TOKEN`
+5. Confirm the runner label used by `.forgejo/workflows/renovate.yml` (`heavy` today) is online.
+6. Trigger once: Actions → **Renovate** → `workflow_dispatch`, or wait for the cron.
+7. Verify a dependency PR opens (or logs show “no updates”).
+
+## Optional hostRules (when github.com is blocked or needs a different token)
+
+If the runner cannot reach github.com anonymously, extend `.renovaterc.json`:
+
+```json
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "automerge": true,
+  "platformAutomerge": true,
+  "hostRules": [
+    {
+      "hostType": "github",
+      "matchHost": "github.com",
+      "token": "{{ secrets.GITHUB_COM_TOKEN }}"
+    }
+  ]
+}
+```
+
+Secrets must be injected via the workflow env (already sets `GITHUB_COM_TOKEN` from `MIRROR_GITHUB_TOKEN`). Do **not** commit real tokens.
+
+## Done criteria for #3
+
+- [ ] `RENOVATE_TOKEN` present on Forgejo host
+- [ ] `MIRROR_GITHUB_TOKEN` present (for github.com)
+- [ ] At least one successful Renovate workflow run (green or “no updates”)
+- [ ] Optional: first dependency PR reviewed/merged
+
+This file is the agent-closable runbook. Checking the boxes above is human/ops only.

--- a/docs/status/2026-08-12-l1-truth-pass.md
+++ b/docs/status/2026-08-12-l1-truth-pass.md
@@ -67,5 +67,5 @@ verify-readme-splus 2>&1 | grep -iE 'kinocut|ok=|fail='
 1. [`2026-08-12-residual-maturity-matrix.md`](2026-08-12-residual-maturity-matrix.md)  
 2. [`2026-08-12-sound-residual-stage-dag.md`](2026-08-12-sound-residual-stage-dag.md)  
 3. [`2026-08-12-sound-fixture-freeze.md`](2026-08-12-sound-fixture-freeze.md)  
-4. [`.omx/state/critical-path.md`](../../.omx/state/critical-path.md)  
+4. [`2026-08-12-product-pipeline-complete.md`](2026-08-12-product-pipeline-complete.md)  
 5. July status files = evidence only, not staffing truth

--- a/docs/status/2026-08-12-wishlist-depth-ops-closeout.md
+++ b/docs/status/2026-08-12-wishlist-depth-ops-closeout.md
@@ -1,0 +1,35 @@
+# Wishlist + optional depth + ops closeout (2026-08-12)
+
+## Scope (user-approved)
+
+1. **All ROADMAP wishlist open checkboxes** (High/Medium/Low/Observability residual)
+2. **All optional product depth** (TTS probe, VLM keyframes, foreign OTIO, generative paid rigor, perf baseline sample, sound dual-class honesty)
+3. **Ops from residual matrix:** Renovate host token (#3) runbook + CI light runner topology
+
+## Delivered
+
+| Item | Result |
+| --- | --- |
+| Smarter GIF | Already shipped (low=320…ultra=800); ROADMAP unchecked row closed |
+| `video_edit` sequence shortcut | `expand_sequence_shortcut` + docs; `clips`/`transitions`/`transition_duration` |
+| Waveform text | Already shipped (`WaveformResult.text`); ROADMAP closed |
+| Frame-accurate seek | Already shipped (`trim accurate=True` + TE seek); ROADMAP closed |
+| Structured logging | `-v/--verbose` + **`--log-file PATH`** |
+| TTS depth | Doctor-visible `detect_tts_backend`; plan `executable` tracks probe |
+| VLM depth | Structural keyframe extract; VLM package = deferred explicit call (no fake scores) |
+| Foreign OTIO | Local `file://`/path media → `foreign_otio_import` + sequence shortcut; remote rejected |
+| Generative paid rigor | `executable`/`paid_path` + `assert_generative_executable` fail-closed |
+| Perf | Cheap golden-path timings re-measured (doctor/info p50) |
+| Sound dual-class | Evidence retained; second class remains host residual (`external_host_unavailable` when absent) |
+| Renovate #3 | `docs/ops/RENOVATE_HOST_TOKEN.md` + HUMAN_GATES link; secrets still human |
+| CI light topology | `docs/CI_RUNNER_TOPOLOGY.md` light contract table; lint stays on `light` |
+
+## Tests
+
+- `tests/test_wishlist_depth_closeout.py` (new)
+- Related suites green: phase4 multipliers, finish_campaign, phase3 watching, engine/client/cli sample (319+)
+
+## Human residual
+
+- Install/set `RENOVATE_TOKEN` + `MIRROR_GITHUB_TOKEN` on Forgejo (see Renovate runbook)
+- Live dual-class sound re-run when second host exists

--- a/docs/status/golden-path-timings.md
+++ b/docs/status/golden-path-timings.md
@@ -104,3 +104,15 @@ Recorded: `2026-08-12T15:16:30.129698+00:00`
 - Full golden path remains the **functional** proof (`scripts/golden_path.py`); this harness is the **timing** companion.
 - p50/p95 use linear interpolation over sorted wall-clock samples from `time.perf_counter()`.
 - Cold vs warm process starts: each sample spawns a new `python -m kinocut` process (includes interpreter + import cost). That matches agent/CLI first-call cost better than in-process loops.
+
+## Latest cheap baseline (agent)
+
+**Recorded:** 2026-08-12T21:08:45Z · host Darwin/arm64 · fixture `tests/fixtures/golden/workflow_final.mp4`
+
+| step | mode | runs | ok | p50 (s) | p95 (s) | mean (s) |
+| --- | --- | ---: | ---: | ---: | ---: | ---: |
+| doctor | cheap | 3 | 3 | 5.26 | 5.33 | 5.16 |
+| info | cheap | 3 | 3 | 1.63 | 2.30 | 1.87 |
+
+Not an “optimized” product claim — baseline receipt only (WP-F scaffolding).
+

--- a/kinocut/__main__.py
+++ b/kinocut/__main__.py
@@ -48,6 +48,7 @@ def _rewrite_namespaced_argv(argv: list[str]) -> list[str]:
     from .cli.namespaces import resolve_namespaced
 
     boolean_globals = {"-v", "--verbose", "--mcp", "--version"}
+    value_globals = {"--format", "--log-file"}
     i = 0
     n = len(argv)
     while i < n:
@@ -55,12 +56,12 @@ def _rewrite_namespaced_argv(argv: list[str]) -> list[str]:
         if arg in boolean_globals:
             i += 1
             continue
-        if arg == "--format":
+        if arg in value_globals:
             if i + 1 >= n:
-                return argv  # malformed --format; defer to argparse
+                return argv  # malformed flag; defer to argparse
             i += 2
             continue
-        if arg.startswith("--format="):
+        if arg.startswith("--format=") or arg.startswith("--log-file="):
             i += 1
             continue
         if arg.startswith("-"):
@@ -75,16 +76,34 @@ def _rewrite_namespaced_argv(argv: list[str]) -> list[str]:
     return argv
 
 
+def _configure_logging(*, verbose: bool, log_file: str | None) -> None:
+    """Attach structured DEBUG logging to stderr and/or a file."""
+    if not verbose and not log_file:
+        return
+    fmt = logging.Formatter(
+        "%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+        datefmt="%H:%M:%S",
+    )
+    root = logging.getLogger()
+    root.setLevel(logging.DEBUG)
+    if verbose:
+        sh = logging.StreamHandler(sys.stderr)
+        sh.setLevel(logging.DEBUG)
+        sh.setFormatter(fmt)
+        root.addHandler(sh)
+    if log_file:
+        fh = logging.FileHandler(log_file, encoding="utf-8")
+        fh.setLevel(logging.DEBUG)
+        fh.setFormatter(fmt)
+        root.addHandler(fh)
+        logger.debug("Structured logging enabled; file=%s verbose_stderr=%s", log_file, verbose)
+
+
 def main() -> None:
     parser = build_parser()
     args = parser.parse_args(_rewrite_namespaced_argv(sys.argv[1:]))
 
-    if args.verbose:
-        logging.basicConfig(
-            level=logging.DEBUG,
-            format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
-            datefmt="%H:%M:%S",
-        )
+    _configure_logging(verbose=bool(getattr(args, "verbose", False)), log_file=getattr(args, "log_file", None))
 
     # --version
     if args.version:

--- a/kinocut/ai_engine/download.py
+++ b/kinocut/ai_engine/download.py
@@ -108,7 +108,7 @@ def _split_host_port(host_str: str, default_port: int) -> tuple[str, int]:
     if host_str.startswith("["):
         bracket_end = host_str.index("]")
         hostname = host_str[1:bracket_end]
-        rest = host_str[bracket_end + 1:]
+        rest = host_str[bracket_end + 1 :]
         port = int(rest[1:]) if rest.startswith(":") else default_port
         return hostname, port
     parts = host_str.rsplit(":", 1)
@@ -146,6 +146,8 @@ class _SafeRedirectHandler(urllib.request.HTTPRedirectHandler):
                 code="ssrf_blocked",
             )
         return super().redirect_request(req, fp, code, msg, headers, newurl)
+
+
 def _is_blocked_ip(ip_str: str) -> bool:
     addr = _ipaddress.ip_address(ip_str)
     return addr.is_private or addr.is_loopback or addr.is_link_local or addr.is_reserved

--- a/kinocut/cli/handlers_intent.py
+++ b/kinocut/cli/handlers_intent.py
@@ -110,8 +110,8 @@ def _register_review_commands(runner: CommandRunner) -> None:
     runner.register("qc-narrative", _qc_narrative)
 
 
-def _register_te_commands(runner: CommandRunner) -> None:
-    """Register init, estimate, brand-kit, cutfile, mutations, publish, hooks, seek commands."""
+def _register_te_project_commands(runner: CommandRunner) -> None:
+    """Register init / estimate / brand / cutfile TE commands."""
 
     def _init(a: Any, j: bool) -> None:
         from kinocut.te import init_project
@@ -153,6 +153,16 @@ def _register_te_commands(runner: CommandRunner) -> None:
             keep_intermediates=bool(a.keep_intermediates),
         )
         _out(r, j, lambda res: f"cutfile render → {res.get('output_path')}")
+
+    runner.register("init", _init)
+    runner.register("estimate", _estimate)
+    runner.register("brand-kit", _brand)
+    runner.register("cutfile-validate", _cutfile)
+    runner.register("cutfile-render", _cutfile_render)
+
+
+def _register_te_review_commands(runner: CommandRunner) -> None:
+    """Register metric-qc / mutations / publish / hooks / seek TE commands."""
 
     def _metric_qc(a: Any, j: bool) -> None:
         from kinocut.watching import run_metric_qc
@@ -204,16 +214,17 @@ def _register_te_commands(runner: CommandRunner) -> None:
             r = timestamp_to_frame(float(a.seconds or 0), a.fps)
         _out(r, j, lambda res: f"frame={res['frame']} t={res['seconds']}")
 
-    runner.register("init", _init)
-    runner.register("estimate", _estimate)
-    runner.register("brand-kit", _brand)
-    runner.register("cutfile-validate", _cutfile)
-    runner.register("cutfile-render", _cutfile_render)
     runner.register("metric-qc", _metric_qc)
     runner.register("propose-mutations", _mutations)
     runner.register("publish-validate", _publish)
     runner.register("hook-candidates", _hooks)
     runner.register("seek-frame", _seek)
+
+
+def _register_te_commands(runner: CommandRunner) -> None:
+    """Register TE QoL CLI commands (project + review surfaces)."""
+    _register_te_project_commands(runner)
+    _register_te_review_commands(runner)
 
 
 def _register_multiplier_commands(runner: CommandRunner) -> None:

--- a/kinocut/cli/parser/__init__.py
+++ b/kinocut/cli/parser/__init__.py
@@ -58,6 +58,12 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Enable verbose logging to stderr",
     )
+    parser.add_argument(
+        "--log-file",
+        default=None,
+        metavar="PATH",
+        help="Write structured DEBUG logs to PATH (implies verbose to file; combine with -v for stderr too)",
+    )
     subparsers = parser.add_subparsers(dest="command", help="CLI commands")
 
     core.add_parsers(subparsers)

--- a/kinocut/client/media.py
+++ b/kinocut/client/media.py
@@ -449,7 +449,16 @@ class ClientMediaMixin:
         )
 
     def edit(self, timeline: dict[str, Any], output: str | None = None) -> EditResult:
-        """Execute a full timeline-based edit from JSON."""
+        """Execute a full timeline-based edit from JSON.
+
+        Full Timeline form uses ``tracks`` / ``export``. Sequence shortcut::
+
+            client.edit({
+                "clips": ["a.mp4", "b.mp4", "c.mp4"],
+                "transitions": ["fade", "dissolve"],
+                "transition_duration": 0.5,
+            })
+        """
         return _edit_timeline(timeline, output_path=output)
 
     def extract_audio(

--- a/kinocut/engine_batch.py
+++ b/kinocut/engine_batch.py
@@ -110,6 +110,7 @@ def video_batch(
         "results": results,
     }
 
+
 def _batch_output_name(input_path: str, operation: str, ext: str) -> str:
     """Build a collision-resistant output basename for a batch input.
 
@@ -121,6 +122,7 @@ def _batch_output_name(input_path: str, operation: str, ext: str) -> str:
     parent = os.path.dirname(os.path.abspath(input_path))
     digest = hashlib.sha1(parent.encode(), usedforsecurity=False).hexdigest()[:8]
     return f"{name}_{operation}_{digest}{ext}"
+
 
 def _run_batch_operation(
     input_path: str,

--- a/kinocut/engine_hls.py
+++ b/kinocut/engine_hls.py
@@ -56,9 +56,7 @@ def _validate_playlist_path(playlist_path: str, output_dir: str, playlist_name: 
     """
     resolved_output_dir = os.path.realpath(output_dir)
     resolved_playlist = os.path.realpath(playlist_path)
-    if resolved_playlist != resolved_output_dir and not resolved_playlist.startswith(
-        resolved_output_dir + os.sep
-    ):
+    if resolved_playlist != resolved_output_dir and not resolved_playlist.startswith(resolved_output_dir + os.sep):
         raise MCPVideoError(
             f"playlist_name must not escape output_dir: {playlist_name!r}",
             error_type="validation_error",

--- a/kinocut/engine_timeline.py
+++ b/kinocut/engine_timeline.py
@@ -35,9 +35,120 @@ from .ffmpeg_helpers import _escape_ffmpeg_filter_value, _validate_input_path, _
 from .models import EditResult, NamedPosition, Timeline, TimelineClip, TimelineImageOverlay
 
 
+def expand_sequence_shortcut(timeline: dict) -> dict:
+    """Expand a simple multi-clip sequence into a full Timeline dict.
+
+    Shortcut form (wishlist: ``clip A -> fade -> clip B -> dissolve -> clip C``)::
+
+        {
+          "clips": ["a.mp4", "b.mp4", "c.mp4"],
+          "transitions": ["fade", "dissolve"],  # optional; one per boundary
+          "transition_duration": 0.5,           # optional default 1.0
+          "width": 1920, "height": 1080,        # optional
+          "export": {"format": "mp4", "quality": "high"},  # optional
+        }
+
+    Clips may also be dicts with ``source`` and optional trim fields. When the
+    payload already has ``tracks``, it is returned unchanged (full Timeline).
+    """
+    if not isinstance(timeline, dict):
+        return timeline
+    if timeline.get("tracks"):
+        return timeline
+    if "clips" not in timeline:
+        return timeline
+    clips_raw = timeline["clips"]
+    if not isinstance(clips_raw, list) or not clips_raw:
+        raise MCPVideoError(
+            "sequence shortcut requires non-empty clips list",
+            error_type="validation_error",
+            code="empty_sequence_clips",
+        )
+
+    clip_models: list[dict] = []
+    for i, item in enumerate(clips_raw):
+        if isinstance(item, str):
+            clip_models.append({"source": item})
+        elif isinstance(item, dict) and item.get("source"):
+            clip_models.append(
+                {
+                    "source": item["source"],
+                    "start": item.get("start", 0.0),
+                    "duration": item.get("duration"),
+                    "trim_start": item.get("trim_start", 0.0),
+                    "trim_end": item.get("trim_end"),
+                    "volume": item.get("volume", 1.0),
+                    "fade_in": item.get("fade_in", 0.0),
+                    "fade_out": item.get("fade_out", 0.0),
+                }
+            )
+        else:
+            raise MCPVideoError(
+                f"clips[{i}] must be a path string or dict with source",
+                error_type="validation_error",
+                code="invalid_sequence_clip",
+            )
+
+    n_bounds = len(clip_models) - 1
+    transitions_in = timeline.get("transitions") or []
+    if not isinstance(transitions_in, list):
+        raise MCPVideoError(
+            "transitions must be a list of transition type strings",
+            error_type="validation_error",
+            code="invalid_sequence_transitions",
+        )
+    trans_duration = float(timeline.get("transition_duration", 1.0))
+    if trans_duration < 0:
+        raise MCPVideoError(
+            "transition_duration must be >= 0",
+            error_type="validation_error",
+            code="invalid_transition_duration",
+        )
+
+    transition_models: list[dict] = []
+    if n_bounds > 0 and transitions_in:
+        for i in range(n_bounds):
+            ttype = transitions_in[i] if i < len(transitions_in) else transitions_in[-1]
+            if not isinstance(ttype, str) or not ttype.strip():
+                raise MCPVideoError(
+                    f"transitions[{min(i, len(transitions_in) - 1)}] must be a non-empty string",
+                    error_type="validation_error",
+                    code="invalid_transition_type",
+                )
+            transition_models.append(
+                {
+                    "after_clip": i,
+                    "type": ttype.strip(),
+                    "duration": trans_duration,
+                }
+            )
+
+    expanded: dict = {
+        "width": int(timeline.get("width", 1920)),
+        "height": int(timeline.get("height", 1080)),
+        "tracks": [
+            {
+                "type": "video",
+                "clips": clip_models,
+                "transitions": transition_models,
+            }
+        ],
+    }
+    if timeline.get("export") is not None:
+        expanded["export"] = timeline["export"]
+    if timeline.get("duration") is not None:
+        expanded["duration"] = timeline["duration"]
+    return expanded
+
+
 def edit_timeline(timeline: Timeline | dict, output_path: str | None = None) -> EditResult:
-    """Execute a full timeline-based edit described in JSON."""
+    """Execute a full timeline-based edit described in JSON.
+
+    Accepts either a full :class:`Timeline` (``tracks`` …) or the sequence
+    shortcut form documented in :func:`expand_sequence_shortcut`.
+    """
     if isinstance(timeline, dict):
+        timeline = expand_sequence_shortcut(timeline)
         timeline = Timeline.model_validate(timeline)
     _validate_timeline_positions(timeline)
     tmpdir = tempfile.mkdtemp(prefix="mcp_video_timeline_")

--- a/kinocut/engine_timeline.py
+++ b/kinocut/engine_timeline.py
@@ -35,6 +35,72 @@ from .ffmpeg_helpers import _escape_ffmpeg_filter_value, _validate_input_path, _
 from .models import EditResult, NamedPosition, Timeline, TimelineClip, TimelineImageOverlay
 
 
+def _sequence_clip_models(clips_raw: list) -> list[dict]:
+    """Normalize sequence-shortcut clips into TimelineClip dicts."""
+    clip_models: list[dict] = []
+    for i, item in enumerate(clips_raw):
+        if isinstance(item, str):
+            clip_models.append({"source": item})
+        elif isinstance(item, dict) and item.get("source"):
+            clip_models.append(
+                {
+                    "source": item["source"],
+                    "start": item.get("start", 0.0),
+                    "duration": item.get("duration"),
+                    "trim_start": item.get("trim_start", 0.0),
+                    "trim_end": item.get("trim_end"),
+                    "volume": item.get("volume", 1.0),
+                    "fade_in": item.get("fade_in", 0.0),
+                    "fade_out": item.get("fade_out", 0.0),
+                }
+            )
+        else:
+            raise MCPVideoError(
+                f"clips[{i}] must be a path string or dict with source",
+                error_type="validation_error",
+                code="invalid_sequence_clip",
+            )
+    return clip_models
+
+
+def _sequence_transition_models(timeline: dict, n_clips: int) -> list[dict]:
+    """Build per-boundary transition models for a sequence shortcut."""
+    transitions_in = timeline.get("transitions") or []
+    if not isinstance(transitions_in, list):
+        raise MCPVideoError(
+            "transitions must be a list of transition type strings",
+            error_type="validation_error",
+            code="invalid_sequence_transitions",
+        )
+    trans_duration = float(timeline.get("transition_duration", 1.0))
+    if trans_duration < 0:
+        raise MCPVideoError(
+            "transition_duration must be >= 0",
+            error_type="validation_error",
+            code="invalid_transition_duration",
+        )
+    n_bounds = n_clips - 1
+    transition_models: list[dict] = []
+    if n_bounds <= 0 or not transitions_in:
+        return transition_models
+    for i in range(n_bounds):
+        ttype = transitions_in[i] if i < len(transitions_in) else transitions_in[-1]
+        if not isinstance(ttype, str) or not ttype.strip():
+            raise MCPVideoError(
+                f"transitions[{min(i, len(transitions_in) - 1)}] must be a non-empty string",
+                error_type="validation_error",
+                code="invalid_transition_type",
+            )
+        transition_models.append(
+            {
+                "after_clip": i,
+                "type": ttype.strip(),
+                "duration": trans_duration,
+            }
+        )
+    return transition_models
+
+
 def expand_sequence_shortcut(timeline: dict) -> dict:
     """Expand a simple multi-clip sequence into a full Timeline dict.
 
@@ -65,64 +131,8 @@ def expand_sequence_shortcut(timeline: dict) -> dict:
             code="empty_sequence_clips",
         )
 
-    clip_models: list[dict] = []
-    for i, item in enumerate(clips_raw):
-        if isinstance(item, str):
-            clip_models.append({"source": item})
-        elif isinstance(item, dict) and item.get("source"):
-            clip_models.append(
-                {
-                    "source": item["source"],
-                    "start": item.get("start", 0.0),
-                    "duration": item.get("duration"),
-                    "trim_start": item.get("trim_start", 0.0),
-                    "trim_end": item.get("trim_end"),
-                    "volume": item.get("volume", 1.0),
-                    "fade_in": item.get("fade_in", 0.0),
-                    "fade_out": item.get("fade_out", 0.0),
-                }
-            )
-        else:
-            raise MCPVideoError(
-                f"clips[{i}] must be a path string or dict with source",
-                error_type="validation_error",
-                code="invalid_sequence_clip",
-            )
-
-    n_bounds = len(clip_models) - 1
-    transitions_in = timeline.get("transitions") or []
-    if not isinstance(transitions_in, list):
-        raise MCPVideoError(
-            "transitions must be a list of transition type strings",
-            error_type="validation_error",
-            code="invalid_sequence_transitions",
-        )
-    trans_duration = float(timeline.get("transition_duration", 1.0))
-    if trans_duration < 0:
-        raise MCPVideoError(
-            "transition_duration must be >= 0",
-            error_type="validation_error",
-            code="invalid_transition_duration",
-        )
-
-    transition_models: list[dict] = []
-    if n_bounds > 0 and transitions_in:
-        for i in range(n_bounds):
-            ttype = transitions_in[i] if i < len(transitions_in) else transitions_in[-1]
-            if not isinstance(ttype, str) or not ttype.strip():
-                raise MCPVideoError(
-                    f"transitions[{min(i, len(transitions_in) - 1)}] must be a non-empty string",
-                    error_type="validation_error",
-                    code="invalid_transition_type",
-                )
-            transition_models.append(
-                {
-                    "after_clip": i,
-                    "type": ttype.strip(),
-                    "duration": trans_duration,
-                }
-            )
-
+    clip_models = _sequence_clip_models(clips_raw)
+    transition_models = _sequence_transition_models(timeline, len(clip_models))
     expanded: dict = {
         "width": int(timeline.get("width", 1920)),
         "height": int(timeline.get("height", 1080)),

--- a/kinocut/hyperframes_engine.py
+++ b/kinocut/hyperframes_engine.py
@@ -570,7 +570,6 @@ def preview(
         start_new_session=True,
     )
 
-
     time.sleep(min(startup_timeout, 2))
     if proc.poll() is not None:
         raise HyperframesProjectError(str(project), "Hyperframes preview exited immediately")

--- a/kinocut/multipliers/__init__.py
+++ b/kinocut/multipliers/__init__.py
@@ -2,13 +2,15 @@
 
 from __future__ import annotations
 
-from .generative import GenerativePlan, plan_generative_last_mile
+from .generative import GenerativePlan, assert_generative_executable, plan_generative_last_mile
 from .otio_io import export_otio_json, import_otio_json
 from .review_ui import write_review_surface
-from .tts_dub import plan_tts_dub
+from .tts_dub import detect_tts_backend, plan_tts_dub
 
 __all__ = [
     "GenerativePlan",
+    "assert_generative_executable",
+    "detect_tts_backend",
     "export_otio_json",
     "import_otio_json",
     "plan_generative_last_mile",

--- a/kinocut/multipliers/generative.py
+++ b/kinocut/multipliers/generative.py
@@ -19,6 +19,8 @@ class GenerativePlan:
     allowed: bool
     reason: str
     params: dict[str, Any] = field(default_factory=dict)
+    executable: bool = False
+    paid_path: bool = False
 
     def to_dict(self) -> dict[str, Any]:
         return {"artifact_kind": "generative_plan", **asdict(self)}
@@ -38,6 +40,10 @@ def plan_generative_last_mile(
         raise MCPVideoError("prompt required", error_type="validation_error", code="prompt_required")
     if max_spend_usd < 0:
         raise MCPVideoError("max_spend_usd must be >= 0", error_type="validation_error", code="bad_spend_cap")
+    if estimated_spend_usd < 0:
+        raise MCPVideoError(
+            "estimated_spend_usd must be >= 0", error_type="validation_error", code="bad_spend_estimate"
+        )
     prov = (provider or "local").strip().lower()
     local_only = prov in {"local", "none", "offline"}
     if local_only:
@@ -51,9 +57,18 @@ def plan_generative_last_mile(
             allowed=True,
             reason="local/open-weights path; no cloud spend",
             params=dict(params or {}),
+            executable=True,
+            paid_path=False,
         )
     allowed = estimated_spend_usd <= max_spend_usd
-    reason = "within spend cap" if allowed else f"estimated ${estimated_spend_usd:.4f} exceeds cap ${max_spend_usd:.4f}"
+    # Paid paths require an explicit positive cap — zero cap always denies.
+    if max_spend_usd <= 0:
+        allowed = False
+        reason = "paid path denied: max_spend_usd must be > 0 for non-local providers"
+    elif allowed:
+        reason = "within spend cap"
+    else:
+        reason = f"estimated ${estimated_spend_usd:.4f} exceeds cap ${max_spend_usd:.4f}"
     return GenerativePlan(
         provider=prov,
         model=model,
@@ -64,4 +79,31 @@ def plan_generative_last_mile(
         allowed=allowed,
         reason=reason,
         params=dict(params or {}),
+        executable=allowed,
+        paid_path=True,
     )
+
+
+def assert_generative_executable(plan: GenerativePlan | dict[str, Any]) -> dict[str, Any]:
+    """Fail closed before any paid or local generative call.
+
+    Returns a normalized plan dict when executable; raises when not allowed.
+    This is the paid-path rigor gate — plan surfaces must call this before
+    any provider I/O.
+    """
+    data = plan.to_dict() if isinstance(plan, GenerativePlan) else dict(plan)
+    allowed = bool(data.get("allowed"))
+    executable = bool(data.get("executable", allowed))
+    if not allowed or not executable:
+        raise MCPVideoError(
+            f"generative path not executable: {data.get('reason', 'denied')}",
+            error_type="validation_error",
+            code="generative_not_executable",
+        )
+    if data.get("paid_path") and float(data.get("max_spend_usd") or 0) <= 0:
+        raise MCPVideoError(
+            "paid generative path requires max_spend_usd > 0",
+            error_type="validation_error",
+            code="generative_paid_cap_required",
+        )
+    return data

--- a/kinocut/multipliers/otio_io.py
+++ b/kinocut/multipliers/otio_io.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 from typing import Any
+from urllib.parse import unquote, urlparse
 
 from kinocut.errors import MCPVideoError
 from kinocut.ffmpeg_helpers import _validate_artifact_path, _validate_input_path
@@ -58,31 +59,184 @@ def export_otio_json(timeline: dict[str, Any], output_path: str) -> dict[str, An
     }
 
 
+def _media_path_from_clip(clip: dict[str, Any]) -> str | None:
+    """Extract a local filesystem path from a foreign OTIO Clip media reference."""
+    if not isinstance(clip, dict):
+        return None
+    # Common shapes: media_reference.target_url, media.media_reference.target_url
+    for key in ("media_reference", "media"):
+        ref = clip.get(key)
+        if isinstance(ref, dict):
+            nested = ref.get("media_reference") if key == "media" else ref
+            if isinstance(nested, dict):
+                url = nested.get("target_url") or nested.get("target_url_or_path")
+                if isinstance(url, str) and url.strip():
+                    return _url_to_local_path(url.strip())
+            url = ref.get("target_url") if isinstance(ref, dict) else None
+            if isinstance(url, str) and url.strip():
+                return _url_to_local_path(url.strip())
+    meta = clip.get("metadata") or {}
+    if isinstance(meta, dict):
+        for key in ("source", "path", "media_path"):
+            val = meta.get(key)
+            if isinstance(val, str) and val.strip():
+                return val.strip()
+    return None
+
+
+def _url_to_local_path(url: str) -> str | None:
+    if url.startswith("file://"):
+        parsed = urlparse(url)
+        return unquote(parsed.path)
+    if "://" in url and not url.startswith("file:"):
+        # Remote URLs are never auto-fetched — fail closed at import time.
+        return None
+    return url
+
+
+def _collect_track_children(doc: dict[str, Any]) -> list[dict[str, Any]]:
+    children: list[dict[str, Any]] = []
+    tracks = doc.get("tracks")
+    if isinstance(tracks, dict):
+        for track in tracks.get("children") or []:
+            if isinstance(track, dict):
+                for child in track.get("children") or []:
+                    if isinstance(child, dict):
+                        children.append(child)
+    elif isinstance(tracks, list):
+        for track in tracks:
+            if isinstance(track, dict):
+                for child in track.get("children") or []:
+                    if isinstance(child, dict):
+                        children.append(child)
+    return children
+
+
+def _is_confined_relpath(value: str) -> bool:
+    """Match Timeline IR path rules: relative, no traversal, no absolute."""
+    if not value or "\\" in value or "\x00" in value or value.startswith("/"):
+        return False
+    if any(part in {"", ".", ".."} for part in value.split("/")):
+        return False
+    return True
+
+
+def _import_foreign_otio(doc: dict[str, Any], path: Path) -> dict[str, Any]:
+    """Import foreign OTIO JSON when clips resolve to local media paths.
+
+    Does not invent missing sources. Remote media references and missing files
+    raise validation errors.
+
+    - Absolute/local validated paths → ``foreign_otio_import`` + sequence shortcut
+      (Timeline IR forbids absolute sources).
+    - Already-confined relative paths → full ``timeline_ir``.
+    """
+    children = _collect_track_children(doc)
+    if not children:
+        raise MCPVideoError(
+            "otio has no clips and no kinocut_ir",
+            error_type="validation_error",
+            code="empty_otio",
+        )
+
+    resolved: list[dict[str, str]] = []
+    for idx, clip in enumerate(children):
+        media_path = _media_path_from_clip(clip)
+        if not media_path:
+            raise MCPVideoError(
+                f"foreign otio clip[{idx}] has no local media_reference path "
+                "(remote URLs are not fetched; embed metadata.kinocut_ir or file:// paths)",
+                error_type="validation_error",
+                code="otio_foreign_no_local_media",
+            )
+        try:
+            validated = _validate_input_path(media_path)
+        except Exception as exc:
+            raise MCPVideoError(
+                f"foreign otio clip[{idx}] media path rejected: {media_path}",
+                error_type="validation_error",
+                code="otio_foreign_media_invalid",
+            ) from exc
+        node_id = str(clip.get("name") or f"c{idx + 1}")
+        resolved.append({"id": node_id, "source": validated, "raw": media_path})
+
+    name = str(doc.get("name") or path.stem or "foreign_otio")
+    all_confined = all(_is_confined_relpath(c["raw"]) for c in resolved)
+    if all_confined:
+        sources: dict[str, dict[str, str]] = {}
+        nodes: list[dict[str, Any]] = []
+        for idx, clip in enumerate(resolved):
+            src_id = f"s{idx + 1}"
+            sources[src_id] = {"path": clip["raw"]}
+            nodes.append(
+                {
+                    "id": clip["id"],
+                    "kind": "clip",
+                    "depends_on": [],
+                    "inputs": {"src": f"@sources.{src_id}"},
+                    "params": {
+                        "start": {"numerator": 0, "denominator": 1},
+                        "duration": {"numerator": 1, "denominator": 1},
+                    },
+                    "output": f"@outputs.clip_{idx + 1}",
+                }
+            )
+        timeline = {
+            "ir_schema_version": 1,
+            "name": name,
+            "timebase": {"numerator": 1, "denominator": 30},
+            "sources": sources,
+            "nodes": nodes,
+            "outputs": {"final": {"path": "out/final.mp4"}},
+        }
+        ir = parse_timeline_ir(timeline)
+        return {
+            "artifact_kind": "timeline_ir",
+            **ir.model_dump(mode="json"),
+            "identity": None,
+            "import_mode": "foreign_local_media_confined",
+            "clip_count": len(nodes),
+        }
+
+    # Absolute (but validated) local media: sequence shortcut for video_edit/merge
+    clip_paths = [c["source"] for c in resolved]
+    return {
+        "artifact_kind": "foreign_otio_import",
+        "import_mode": "foreign_local_media",
+        "name": name,
+        "clip_count": len(resolved),
+        "clips": resolved,
+        "sequence_shortcut": {
+            "clips": clip_paths,
+            "transitions": [],
+            "transition_duration": 1.0,
+        },
+        "next_action": "video_edit_sequence_shortcut_or_merge",
+    }
+
+
 def import_otio_json(path: str) -> dict[str, Any]:
-    """Import OTIO JSON that embeds kinocut_ir, or rebuild a minimal IR."""
+    """Import OTIO JSON that embeds kinocut_ir, or foreign clips with local media.
+
+    Priority:
+    1. ``metadata.kinocut_ir`` — full-fidelity Kinocut Timeline IR
+    2. Foreign OTIO clips whose ``media_reference.target_url`` resolves to a
+       confined local path (``file://`` or bare path). Remote URLs are rejected.
+    """
     p = Path(_validate_input_path(path))
     try:
         doc = json.loads(p.read_text(encoding="utf-8"))
     except json.JSONDecodeError as exc:
         raise MCPVideoError(f"invalid otio json: {exc}", error_type="validation_error", code="invalid_otio") from exc
+    if not isinstance(doc, dict):
+        raise MCPVideoError("otio root must be an object", error_type="validation_error", code="invalid_otio")
     meta = doc.get("metadata") or {}
-    if isinstance(meta.get("kinocut_ir"), dict):
+    if isinstance(meta, dict) and isinstance(meta.get("kinocut_ir"), dict):
         ir = parse_timeline_ir(meta["kinocut_ir"])
         return {
             "artifact_kind": "timeline_ir",
             **ir.model_dump(mode="json"),
             "identity": None,
+            "import_mode": "kinocut_ir",
         }
-    # Minimal rebuild from clip names
-    children = []
-    tracks = doc.get("tracks") or {}
-    for track in tracks.get("children") or []:
-        children.extend(track.get("children") or [])
-    if not children:
-        raise MCPVideoError("otio has no clips and no kinocut_ir", error_type="validation_error", code="empty_otio")
-    # Cannot invent confined sources — require embedded IR for full fidelity.
-    raise MCPVideoError(
-        "otio import requires metadata.kinocut_ir for confined sources",
-        error_type="validation_error",
-        code="otio_needs_kinocut_ir",
-    )
+    return _import_foreign_otio(doc, p)

--- a/kinocut/multipliers/otio_io.py
+++ b/kinocut/multipliers/otio_io.py
@@ -119,24 +119,8 @@ def _is_confined_relpath(value: str) -> bool:
     return not any(part in {"", ".", ".."} for part in value.split("/"))
 
 
-def _import_foreign_otio(doc: dict[str, Any], path: Path) -> dict[str, Any]:
-    """Import foreign OTIO JSON when clips resolve to local media paths.
-
-    Does not invent missing sources. Remote media references and missing files
-    raise validation errors.
-
-    - Absolute/local validated paths → ``foreign_otio_import`` + sequence shortcut
-      (Timeline IR forbids absolute sources).
-    - Already-confined relative paths → full ``timeline_ir``.
-    """
-    children = _collect_track_children(doc)
-    if not children:
-        raise MCPVideoError(
-            "otio has no clips and no kinocut_ir",
-            error_type="validation_error",
-            code="empty_otio",
-        )
-
+def _resolve_foreign_clips(children: list[dict[str, Any]]) -> list[dict[str, str]]:
+    """Validate local media paths for foreign OTIO clips."""
     resolved: list[dict[str, str]] = []
     for idx, clip in enumerate(children):
         media_path = _media_path_from_clip(clip)
@@ -157,47 +141,64 @@ def _import_foreign_otio(doc: dict[str, Any], path: Path) -> dict[str, Any]:
             ) from exc
         node_id = str(clip.get("name") or f"c{idx + 1}")
         resolved.append({"id": node_id, "source": validated, "raw": media_path})
+    return resolved
 
+
+def _timeline_ir_from_confined(resolved: list[dict[str, str]], name: str) -> dict[str, Any]:
+    """Build Timeline IR when all foreign sources are confined relative paths."""
+    sources: dict[str, dict[str, str]] = {}
+    nodes: list[dict[str, Any]] = []
+    for idx, clip in enumerate(resolved):
+        src_id = f"s{idx + 1}"
+        sources[src_id] = {"path": clip["raw"]}
+        nodes.append(
+            {
+                "id": clip["id"],
+                "kind": "clip",
+                "depends_on": [],
+                "inputs": {"src": f"@sources.{src_id}"},
+                "params": {
+                    "start": {"numerator": 0, "denominator": 1},
+                    "duration": {"numerator": 1, "denominator": 1},
+                },
+                "output": f"@outputs.clip_{idx + 1}",
+            }
+        )
+    timeline = {
+        "ir_schema_version": 1,
+        "name": name,
+        "timebase": {"numerator": 1, "denominator": 30},
+        "sources": sources,
+        "nodes": nodes,
+        "outputs": {"final": {"path": "out/final.mp4"}},
+    }
+    ir = parse_timeline_ir(timeline)
+    return {
+        "artifact_kind": "timeline_ir",
+        **ir.model_dump(mode="json"),
+        "identity": None,
+        "import_mode": "foreign_local_media_confined",
+        "clip_count": len(nodes),
+    }
+
+
+def _import_foreign_otio(doc: dict[str, Any], path: Path) -> dict[str, Any]:
+    """Import foreign OTIO JSON when clips resolve to local media paths.
+
+    Absolute/local validated paths → ``foreign_otio_import`` + sequence shortcut.
+    Confined relative paths → full ``timeline_ir``.
+    """
+    children = _collect_track_children(doc)
+    if not children:
+        raise MCPVideoError(
+            "otio has no clips and no kinocut_ir",
+            error_type="validation_error",
+            code="empty_otio",
+        )
+    resolved = _resolve_foreign_clips(children)
     name = str(doc.get("name") or path.stem or "foreign_otio")
-    all_confined = all(_is_confined_relpath(c["raw"]) for c in resolved)
-    if all_confined:
-        sources: dict[str, dict[str, str]] = {}
-        nodes: list[dict[str, Any]] = []
-        for idx, clip in enumerate(resolved):
-            src_id = f"s{idx + 1}"
-            sources[src_id] = {"path": clip["raw"]}
-            nodes.append(
-                {
-                    "id": clip["id"],
-                    "kind": "clip",
-                    "depends_on": [],
-                    "inputs": {"src": f"@sources.{src_id}"},
-                    "params": {
-                        "start": {"numerator": 0, "denominator": 1},
-                        "duration": {"numerator": 1, "denominator": 1},
-                    },
-                    "output": f"@outputs.clip_{idx + 1}",
-                }
-            )
-        timeline = {
-            "ir_schema_version": 1,
-            "name": name,
-            "timebase": {"numerator": 1, "denominator": 30},
-            "sources": sources,
-            "nodes": nodes,
-            "outputs": {"final": {"path": "out/final.mp4"}},
-        }
-        ir = parse_timeline_ir(timeline)
-        return {
-            "artifact_kind": "timeline_ir",
-            **ir.model_dump(mode="json"),
-            "identity": None,
-            "import_mode": "foreign_local_media_confined",
-            "clip_count": len(nodes),
-        }
-
-    # Absolute (but validated) local media: sequence shortcut for video_edit/merge
-    clip_paths = [c["source"] for c in resolved]
+    if all(_is_confined_relpath(c["raw"]) for c in resolved):
+        return _timeline_ir_from_confined(resolved, name)
     return {
         "artifact_kind": "foreign_otio_import",
         "import_mode": "foreign_local_media",
@@ -205,7 +206,7 @@ def _import_foreign_otio(doc: dict[str, Any], path: Path) -> dict[str, Any]:
         "clip_count": len(resolved),
         "clips": resolved,
         "sequence_shortcut": {
-            "clips": clip_paths,
+            "clips": [c["source"] for c in resolved],
             "transitions": [],
             "transition_duration": 1.0,
         },

--- a/kinocut/multipliers/otio_io.py
+++ b/kinocut/multipliers/otio_io.py
@@ -116,9 +116,7 @@ def _is_confined_relpath(value: str) -> bool:
     """Match Timeline IR path rules: relative, no traversal, no absolute."""
     if not value or "\\" in value or "\x00" in value or value.startswith("/"):
         return False
-    if any(part in {"", ".", ".."} for part in value.split("/")):
-        return False
-    return True
+    return not any(part in {"", ".", ".."} for part in value.split("/"))
 
 
 def _import_foreign_otio(doc: dict[str, Any], path: Path) -> dict[str, Any]:

--- a/kinocut/multipliers/tts_dub.py
+++ b/kinocut/multipliers/tts_dub.py
@@ -2,10 +2,34 @@
 
 from __future__ import annotations
 
+import importlib.util
+import shutil
 from typing import Any
 
 from kinocut.errors import MCPVideoError
 from kinocut.intent.language_coverage import language_coverage_report
+
+
+def detect_tts_backend() -> dict[str, Any]:
+    """Doctor-visible TTS backend probe (no network, no synthesis)."""
+    backends: list[dict[str, Any]] = []
+    # Hyperframes local TTS CLI (optional integration).
+    hf = shutil.which("hyperframes") or shutil.which("hf")
+    if hf:
+        backends.append({"id": "hyperframes", "path": hf, "kind": "cli"})
+    # Optional Python packages commonly used for local TTS.
+    for mod_name, kind in (("edge_tts", "python"), ("piper", "python"), ("TTS", "python")):
+        try:
+            if importlib.util.find_spec(mod_name) is not None:
+                backends.append({"id": mod_name, "path": None, "kind": kind})
+        except Exception:
+            continue
+    primary = backends[0]["id"] if backends else None
+    return {
+        "available": bool(backends),
+        "primary": primary,
+        "backends": backends,
+    }
 
 
 def plan_tts_dub(
@@ -20,16 +44,24 @@ def plan_tts_dub(
     lang = (target_lang or "es").lower()
     coverage = language_coverage_report()
     dub_supported = list(coverage["surfaces"]["dub"]["supported_languages_or_pairs"])
-    # Plan surface exists; actual synth is still capability-gated.
+    backend = detect_tts_backend()
+    executable = bool(backend.get("available"))
+    if executable:
+        reason = f"TTS backend detected ({backend.get('primary')}); plan ready for explicit synth call"
+        next_action = "run_hyperframes_tts_or_configured_backend"
+    else:
+        reason = "Local TTS backend not bundled; plan only until a doctor-visible engine is configured"
+        next_action = "install_local_tts_backend"
     return {
         "artifact_kind": "tts_dub_plan",
         "caption_path": caption_path,
         "target_lang": lang,
         "voice": voice or ("es_default" if lang == "es" else "default"),
         "brand_primary": lang == "es",
-        "executable": False,
-        "reason": "Local TTS backend not bundled; plan only until a doctor-visible engine is configured",
+        "executable": executable,
+        "reason": reason,
         "coverage": coverage,
         "supported_now": dub_supported,
-        "next_action": "install_local_tts_backend",
+        "backend": backend,
+        "next_action": next_action,
     }

--- a/kinocut/multipliers/tts_dub.py
+++ b/kinocut/multipliers/tts_dub.py
@@ -3,11 +3,14 @@
 from __future__ import annotations
 
 import importlib.util
+import logging
 import shutil
 from typing import Any
 
 from kinocut.errors import MCPVideoError
 from kinocut.intent.language_coverage import language_coverage_report
+
+logger = logging.getLogger(__name__)
 
 
 def detect_tts_backend() -> dict[str, Any]:
@@ -22,7 +25,8 @@ def detect_tts_backend() -> dict[str, Any]:
         try:
             if importlib.util.find_spec(mod_name) is not None:
                 backends.append({"id": mod_name, "path": None, "kind": kind})
-        except Exception:
+        except Exception as exc:
+            logger.debug("TTS backend probe skipped for %s: %s", mod_name, exc)
             continue
     primary = backends[0]["id"] if backends else None
     return {

--- a/kinocut/semantic/models.py
+++ b/kinocut/semantic/models.py
@@ -24,7 +24,9 @@ def canonical_digest(value: BaseModel | dict[str, Any], *, exclude: set[str] | N
     """Hash one JSON-compatible payload with stable field and separator ordering."""
 
     payload = value.model_dump(mode="json", exclude=exclude or set()) if isinstance(value, BaseModel) else value
-    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False, allow_nan=False).encode("utf-8")
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False, allow_nan=False).encode(
+        "utf-8"
+    )
     return "sha256:" + hashlib.sha256(encoded).hexdigest()
 
 

--- a/kinocut/server_app.py
+++ b/kinocut/server_app.py
@@ -14,6 +14,7 @@ import mcp.server.fastmcp.server as _fastmcp_server
 from mcp.server.fastmcp import Context, FastMCP
 
 from .errors import MCPVideoError
+
 # MCP 1.29 leaves Settings.lifespan as a forward reference. Rebuild it after the
 # module is loaded so pydantic-settings 2.15 cannot emit warnings into JSON CLI stderr.
 _fastmcp_server.Settings.model_rebuild(_types_namespace=vars(_fastmcp_server))

--- a/kinocut/server_tools_intent.py
+++ b/kinocut/server_tools_intent.py
@@ -432,7 +432,11 @@ def video_generative_plan(
     max_spend_usd: float = 0.0,
     estimated_spend_usd: float = 0.0,
 ) -> dict[str, Any]:
-    """Generative last-mile plan with spend caps (P4.1) — plan only."""
+    """Generative last-mile plan with spend caps (P4.1) — plan only.
+
+    Paid providers require ``max_spend_usd > 0`` and estimate ≤ cap.
+    Use ``assert_generative_executable`` (multipliers) before any provider I/O.
+    """
 
     from kinocut.multipliers import plan_generative_last_mile
 

--- a/kinocut/server_tools_media.py
+++ b/kinocut/server_tools_media.py
@@ -477,11 +477,20 @@ def video_edit(
 
     Image overlays are applied in a single filtergraph pass (no multiple re-encodes).
 
+    Sequence shortcut (simple multi-clip chain with per-boundary transitions)::
+
+        {
+          "clips": ["a.mp4", "b.mp4", "c.mp4"],
+          "transitions": ["fade", "dissolve"],
+          "transition_duration": 0.5
+        }
+
     Args:
-        timeline: JSON object with keys: width, height, tracks (video/audio/text/image), export.
-            Can also be a JSON string or a path to a .json file.
-            Image overlays in tracks: {"type": "image", "images": [{"source":
-            "logo.png", "position": "top-right", "width": 200, "opacity": 0.8}]}
+        timeline: Full Timeline JSON (width/height/tracks/export) **or** the
+            sequence shortcut above. Can also be a JSON string or a path to a
+            .json file. Image overlays in tracks: {"type": "image", "images":
+            [{"source": "logo.png", "position": "top-right", "width": 200,
+            "opacity": 0.8}]}
         output_path: Where to save the final video. Auto-generated if omitted.
     """
     parsed_timeline = timeline

--- a/kinocut/te/cutfile_render.py
+++ b/kinocut/te/cutfile_render.py
@@ -125,11 +125,7 @@ def _bind_inputs(
                 f"ops[{index}] ({op_name}) requires non-empty srcs list",
                 "cutfile_srcs_required",
             )
-        return {
-            "srcs": [
-                _resolve_token(str(t), source_ids=source_id_set, step_outputs=step_outputs) for t in raw_srcs
-            ]
-        }
+        return {"srcs": [_resolve_token(str(t), source_ids=source_id_set, step_outputs=step_outputs) for t in raw_srcs]}
     raw_src = op.get("src")
     if raw_src is None:
         ref = _default_src(source_ids=source_ids, last_ref=last_ref)

--- a/kinocut/watching/vision_qc.py
+++ b/kinocut/watching/vision_qc.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import tempfile
 from dataclasses import asdict, dataclass
+from pathlib import Path
 from typing import Any
 
-from kinocut.ffmpeg_helpers import _validate_input_path
+from kinocut.ffmpeg_helpers import _run_ffmpeg, _validate_input_path
 
 
 @dataclass(frozen=True)
@@ -20,6 +22,53 @@ class VisionFinding:
         return asdict(self)
 
 
+def _vlm_available() -> bool:
+    try:
+        import importlib.util
+
+        return importlib.util.find_spec("anthropic") is not None
+    except Exception:
+        return False
+
+
+def _sample_keyframes(path: str, times: list[float]) -> list[dict[str, Any]]:
+    """Extract structural keyframe JPEGs when FFmpeg is available."""
+    samples: list[dict[str, Any]] = []
+    tmp = Path(tempfile.mkdtemp(prefix="kinocut_vision_"))
+    try:
+        for i, t in enumerate(times):
+            out = tmp / f"kf_{i:02d}.jpg"
+            try:
+                _run_ffmpeg(
+                    [
+                        "-ss",
+                        f"{float(t):.3f}",
+                        "-i",
+                        path,
+                        "-frames:v",
+                        "1",
+                        "-q:v",
+                        "5",
+                        str(out),
+                    ]
+                )
+                if out.is_file() and out.stat().st_size > 0:
+                    samples.append(
+                        {
+                            "time": float(t),
+                            "path": str(out.resolve()),
+                            "bytes": out.stat().st_size,
+                        }
+                    )
+                else:
+                    samples.append({"time": float(t), "path": None, "error": "empty_frame"})
+            except Exception as exc:
+                samples.append({"time": float(t), "path": None, "error": type(exc).__name__})
+    except Exception:
+        return samples
+    return samples
+
+
 def run_vision_qc(
     input_path: str,
     *,
@@ -30,14 +79,19 @@ def run_vision_qc(
     path = _validate_input_path(input_path)
     times = sample_times or [0.5, 1.0, 2.0]
     findings: list[VisionFinding] = []
-    # Without optional VLM stack, report graceful enhancement state.
-    vlm_available = False
-    try:
-        import importlib.util
+    vlm_available = _vlm_available()
+    keyframes = _sample_keyframes(path, times)
+    sampled = sum(1 for k in keyframes if k.get("path"))
 
-        vlm_available = importlib.util.find_spec("anthropic") is not None
-    except Exception:
-        vlm_available = False
+    findings.append(
+        VisionFinding(
+            check_id="vision.keyframe_sample",
+            severity="info",
+            message=f"Structural keyframe sample: {sampled}/{len(times)} frames extracted",
+            keyframe_times=list(times),
+            evidence={"keyframes": keyframes, "sampled": sampled},
+        )
+    )
 
     if require_vlm and not vlm_available:
         findings.append(
@@ -45,7 +99,7 @@ def run_vision_qc(
                 check_id="vision.vlm",
                 severity="warn",
                 message="VLM not installed; vision QC skipped (graceful)",
-                keyframe_times=times,
+                keyframe_times=list(times),
                 evidence={"vlm_available": False, "require_vlm": True},
             )
         )
@@ -55,18 +109,25 @@ def run_vision_qc(
                 check_id="vision.vlm",
                 severity="info",
                 message="VLM unavailable — structural keyframe sample only",
-                keyframe_times=times,
+                keyframe_times=list(times),
                 evidence={"vlm_available": False, "mode": "structural"},
             )
         )
     else:
+        # Package present: still no auto-score without explicit provider credentials.
+        # Evidence includes keyframe paths so a host can call a VLM out-of-band.
         findings.append(
             VisionFinding(
                 check_id="vision.vlm",
                 severity="info",
-                message="VLM package present — rubric deferred to explicit provider call",
-                keyframe_times=times,
-                evidence={"vlm_available": True, "auto_scored": False},
+                message="VLM package present — rubric deferred to explicit provider call; keyframes ready",
+                keyframe_times=list(times),
+                evidence={
+                    "vlm_available": True,
+                    "auto_scored": False,
+                    "keyframes": keyframes,
+                    "next_action": "call_provider_with_keyframe_paths",
+                },
             )
         )
 
@@ -74,6 +135,7 @@ def run_vision_qc(
         "artifact_kind": "vision_qc",
         "input_path": path,
         "vlm_available": vlm_available,
+        "keyframe_count": sampled,
         "findings": [f.to_dict() for f in findings],
         "verdict": "pass" if not any(f.severity == "fail" for f in findings) else "fail",
     }

--- a/mcpb/README.md
+++ b/mcpb/README.md
@@ -2,6 +2,6 @@
 
 This bundle launches Kinocut as a local stdio MCP server through the package's Node launcher.
 
-It is a staged/local-only distribution package. It expects Python 3.11+, `kinocut==1.13.2`, and FFmpeg to already be installed on the user's machine. Optional AI, shader, and Hyperframes tools remain capability-gated until their dependencies are installed and configured. Native MCPB bundles are not published with this release.
+It is a staged/local-only distribution package. It expects Python 3.11+, `kinocut==1.13.4`, and FFmpeg to already be installed on the user's machine. Optional AI, shader, and Hyperframes tools remain capability-gated until their dependencies are installed and configured. Native MCPB bundles are not published with this release.
 
 See `docs/MCPB.md` in the Kinocut repository for install, validation, and release-gate details.

--- a/npm/bin/kinocut.js
+++ b/npm/bin/kinocut.js
@@ -2,7 +2,7 @@
 
 import { spawnSync } from "node:child_process";
 
-const args = ["--from", "kinocut==1.13.2", "kino", ...process.argv.slice(2)];
+const args = ["--from", "kinocut==1.13.4", "kino", ...process.argv.slice(2)];
 const result = spawnSync("uvx", args, { stdio: "inherit" });
 
 if (result.error?.code === "ENOENT") {

--- a/scripts/build-mcpb.py
+++ b/scripts/build-mcpb.py
@@ -13,7 +13,7 @@ from typing import Any
 
 ROOT = Path(__file__).resolve().parents[1]
 MCPB_DIR = ROOT / "mcpb"
-VERSION = "1.13.2"
+VERSION = "1.13.4"
 TOP_LEVEL_KEYS = {
     "$schema",
     "manifest_version",

--- a/tests/test_add_audio_duration_policy.py
+++ b/tests/test_add_audio_duration_policy.py
@@ -248,9 +248,15 @@ def test_mix_filter_disables_amix_normalization():
     from kinocut.engine_audio_ops import _build_add_audio_args
 
     args = _build_add_audio_args(
-        "v.mp4", "a.wav", [], mix=True, start_time=None,
-        source_has_audio=True, output="out.mp4",
-        duration_policy="keep_video", video_duration=10.0,
+        "v.mp4",
+        "a.wav",
+        [],
+        mix=True,
+        start_time=None,
+        source_has_audio=True,
+        output="out.mp4",
+        duration_policy="keep_video",
+        video_duration=10.0,
     )
     fc = args[args.index("-filter_complex") + 1]
     assert "normalize=0" in fc, f"amix must disable 1/n normalization: {fc}"
@@ -261,9 +267,15 @@ def test_mix_with_start_time_also_disables_amix_normalization():
     from kinocut.engine_audio_ops import _build_add_audio_args
 
     args = _build_add_audio_args(
-        "v.mp4", "a.wav", ["volume=0.5"], mix=True, start_time=2.0,
-        source_has_audio=True, output="out.mp4",
-        duration_policy="keep_video", video_duration=10.0,
+        "v.mp4",
+        "a.wav",
+        ["volume=0.5"],
+        mix=True,
+        start_time=2.0,
+        source_has_audio=True,
+        output="out.mp4",
+        duration_policy="keep_video",
+        video_duration=10.0,
     )
     fc = args[args.index("-filter_complex") + 1]
     assert "normalize=0" in fc, f"amix must disable 1/n normalization: {fc}"

--- a/tests/test_architecture_guardrails.py
+++ b/tests/test_architecture_guardrails.py
@@ -89,7 +89,9 @@ def test_split_engine_modules_stay_below_size_limit() -> None:
         PACKAGE / "workflow" / "receipt.py",
     ]
     oversized = {
-        path.relative_to(ROOT).as_posix(): module_line_count(path) for path in split_modules if module_line_count(path) > 800
+        path.relative_to(ROOT).as_posix(): module_line_count(path)
+        for path in split_modules
+        if module_line_count(path) > 800
     }
     assert oversized == {}, f"split modules exceeded 800 LOC: {oversized}"
 
@@ -207,8 +209,7 @@ FUNCTION_LINE_LIMIT = 80
 
 #: Frozen baseline of functions that already exceed FUNCTION_LINE_LIMIT.
 #: As each function is decomposed, remove its entry here so the net tightens.
-_FUNCTION_SIZE_BASELINE: dict[str, set[str]] = {
-}
+_FUNCTION_SIZE_BASELINE: dict[str, set[str]] = {}
 
 
 def _functions_exceeding_limit() -> dict[str, set[str]]:

--- a/tests/test_captions_styled_timing.py
+++ b/tests/test_captions_styled_timing.py
@@ -62,8 +62,7 @@ def _visible_intervals(path: Path) -> tuple[tuple[float, float], ...]:
     )
     frame_size = _WIDTH * _HEIGHT
     visible = [
-        sum(value > 40 for value in raw[offset : offset + frame_size]) > 10
-        for offset in range(0, len(raw), frame_size)
+        sum(value > 40 for value in raw[offset : offset + frame_size]) > 10 for offset in range(0, len(raw), frame_size)
     ]
     intervals: list[tuple[float, float]] = []
     start: int | None = None
@@ -105,7 +104,14 @@ def test_every_styled_burned_word_is_within_80ms_of_whisper_ground_truth(tmp_pat
     measured = _visible_intervals(output)
     expected = tuple((word.start, word.end) for word in ground_truth)
     assert len(measured) == len(expected)
-    assert max(abs(actual - truth) for pair, expected_pair in zip(measured, expected, strict=True) for actual, truth in zip(pair, expected_pair, strict=True)) <= _MAX_ERROR_SECONDS
+    assert (
+        max(
+            abs(actual - truth)
+            for pair, expected_pair in zip(measured, expected, strict=True)
+            for actual, truth in zip(pair, expected_pair, strict=True)
+        )
+        <= _MAX_ERROR_SECONDS
+    )
     assert artifact.maximum_quantization_error_seconds <= 0.005
 
 

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -593,9 +593,7 @@ class TestHlsValidation:
             "../sibling/escape.m3u8",
         ],
     )
-    def test_hls_rejects_playlist_name_escape_output_dir(
-        self, sample_video, monkeypatch, tmp_path, malicious_playlist
-    ):
+    def test_hls_rejects_playlist_name_escape_output_dir(self, sample_video, monkeypatch, tmp_path, malicious_playlist):
         from mcp_video import engine_hls
         from mcp_video.errors import MCPVideoError
 

--- a/tests/test_finish_campaign.py
+++ b/tests/test_finish_campaign.py
@@ -78,8 +78,10 @@ def test_review_ui(tmp_path: Path) -> None:
 
 def test_tts_dub_plan_not_executable() -> None:
     p = plan_tts_dub("/tmp/cap.srt", target_lang="es")
-    assert p["executable"] is False
     assert p["brand_primary"] is True
+    assert "backend" in p
+    # executable is True only when a doctor-visible TTS backend is present
+    assert p["executable"] is bool(p["backend"].get("available"))
 
 
 def test_publish_validate() -> None:

--- a/tests/test_g004_and_mcpb_product.py
+++ b/tests/test_g004_and_mcpb_product.py
@@ -23,7 +23,6 @@ def test_g004_phone_frame_fixture_and_review(tmp_path: Path) -> None:
         timeout=180,
     )
     assert proc.returncode == 0, proc.stderr
-    phone = out_dir / "phone_frame_12s.mp4"
     # script names file phone_frame_12s even when seconds overridden — check any mp4
     phones = list(out_dir.glob("*.mp4"))
     assert phones, proc.stdout

--- a/tests/test_highlight_discovery_core.py
+++ b/tests/test_highlight_discovery_core.py
@@ -74,11 +74,14 @@ def test_empty_operator_examples_preserve_baseline_json() -> None:
     transcript = _realistic_transcript()
     config = _config()
 
-    assert discover_highlights(transcript, config=config).model_dump_json() == discover_highlights(
-        transcript,
-        examples=(),
-        config=config,
-    ).model_dump_json()
+    assert (
+        discover_highlights(transcript, config=config).model_dump_json()
+        == discover_highlights(
+            transcript,
+            examples=(),
+            config=config,
+        ).model_dump_json()
+    )
 
 
 def test_realistic_transcript_produces_at_least_three_distinct_candidates() -> None:

--- a/tests/test_hyperframes_engine.py
+++ b/tests/test_hyperframes_engine.py
@@ -807,6 +807,7 @@ class TestCompositions:
 
 class TestPreview:
     """Tests for preview()."""
+
     @pytest.fixture(autouse=True)
     def _clear_preview_registry(self):
         from mcp_video.hyperframes_engine import _active_previews
@@ -814,7 +815,6 @@ class TestPreview:
         _active_previews.clear()
         yield
         _active_previews.clear()
-
 
     def test_returns_url_with_correct_port(self, sample_hyperframes_project):
         """preview() should return a URL with the specified port."""
@@ -866,6 +866,7 @@ class TestPreview:
     def test_raises_when_process_exits_immediately(self, sample_hyperframes_project):
         """preview() should raise HyperframesProjectError if the process crashes on startup."""
         from mcp_video.hyperframes_engine import _active_previews
+
         project = str(sample_hyperframes_project)
         mock_proc = MagicMock()
         mock_proc.poll.return_value = 1
@@ -1657,8 +1658,6 @@ class TestErrorHandling:
             pytest.raises(HyperframesNotFoundError),
         ):
             create_project("test")
-
-
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_inspection_surfaces.py
+++ b/tests/test_inspection_surfaces.py
@@ -474,11 +474,11 @@ def test_public_counts_and_client_contracts():
 
     tools = {tool.name for tool in asyncio.run(mcp.list_tools())}
     assert {"video_ingest", "video_preflight", "video_inspect_temporal"} <= tools
-    assert len(tools) == 194
+    assert len(tools) == 196
 
     commands = build_parser()._subparsers._group_actions[0].choices
     assert {"video-ingest", "video-preflight", "video-inspect-temporal"} <= set(commands)
-    assert len(commands) == 165
+    assert len(commands) == 167
     assert Client().inspect("ingest")["return_type"] == "report"
     assert Client().inspect("preflight")["return_type"] == "report"
     assert Client().inspect("inspect_temporal")["return_type"] == "report"

--- a/tests/test_intent_surface.py
+++ b/tests/test_intent_surface.py
@@ -52,8 +52,7 @@ def test_broll_proposals_never_auto_accept() -> None:
 def test_translate_captions_en_es(tmp_path: Path) -> None:
     srt = tmp_path / "en.srt"
     srt.write_text(
-        "1\n00:00:00,000 --> 00:00:02,000\nHello world\n\n"
-        "2\n00:00:02,000 --> 00:00:04,000\nThanks\n",
+        "1\n00:00:00,000 --> 00:00:02,000\nHello world\n\n2\n00:00:02,000 --> 00:00:04,000\nThanks\n",
         encoding="utf-8",
     )
     result = translate_caption_file(str(srt), source_lang="en", target_lang="es")

--- a/tests/test_kinocut_distribution.py
+++ b/tests/test_kinocut_distribution.py
@@ -15,8 +15,8 @@ import mcp_video
 
 
 ROOT = Path(__file__).resolve().parents[1]
-KINOCUT_VERSION = "1.13.2"
-SHIM_VERSION = "1.6.6"
+KINOCUT_VERSION = "1.13.4"
+SHIM_VERSION = "1.6.8"
 
 
 def _toml(path: Path) -> dict:

--- a/tests/test_namespace_routing.py
+++ b/tests/test_namespace_routing.py
@@ -253,7 +253,7 @@ def test_flat_command_set_remains_130():
     over the 140-command flat parser (includes sound S12 public join).
     """
 
-    assert len(EXPECTED_CLI_COMMANDS) == 165
+    assert len(EXPECTED_CLI_COMMANDS) == 167
     assert len(NAMESPACED_ALIASES) == 41
     groups = namespaced_groups()
     assert set(groups) == {"aivideo", "audio", "qa", "edit", "shorts", "sound"}

--- a/tests/test_pending_gates_operator.py
+++ b/tests/test_pending_gates_operator.py
@@ -25,10 +25,7 @@ def _issue(number: int, *labels: str) -> dict:
 
 def test_pending_operator_keeps_human_and_release_gates_explicit() -> None:
     module = _module()
-    issues = {
-        number: _issue(number, "blocked:post-release")
-        for number in module.EXPECTED_POST_RELEASE
-    }
+    issues = {number: _issue(number, "blocked:post-release") for number in module.EXPECTED_POST_RELEASE}
 
     gates = module._build_gates(issues, "installed; daemon unavailable")
     by_name = {gate.name: gate for gate in gates}
@@ -44,10 +41,7 @@ def test_pending_operator_keeps_human_and_release_gates_explicit() -> None:
 
 def test_pending_operator_detects_changed_tracker_state() -> None:
     module = _module()
-    issues = {
-        number: _issue(number, "blocked:post-release")
-        for number in module.EXPECTED_POST_RELEASE
-    }
+    issues = {number: _issue(number, "blocked:post-release") for number in module.EXPECTED_POST_RELEASE}
     issues[73] = _issue(73)
 
     gates = module._build_gates(issues, "ready (fixture)")

--- a/tests/test_phase4_multipliers_go.py
+++ b/tests/test_phase4_multipliers_go.py
@@ -70,7 +70,9 @@ def test_review_ui_hot_reload_surface(tmp_path: Path) -> None:
 def test_tts_dub_es_first_not_translate() -> None:
     plan = plan_tts_dub("captions.srt", target_lang="es")
     d = plan if isinstance(plan, dict) else plan.to_dict()
-    assert d.get("executable") is False
     assert d.get("artifact_kind") == "tts_dub_plan"
     assert d.get("target_lang") == "es"
     assert d.get("brand_primary") is True
+    # executable tracks doctor-visible backend probe (hyperframes/edge_tts/etc.)
+    assert "backend" in d
+    assert d.get("executable") is bool((d.get("backend") or {}).get("available"))

--- a/tests/test_projectstore_project_recipes.py
+++ b/tests/test_projectstore_project_recipes.py
@@ -59,7 +59,11 @@ def test_project_revision_exports_and_replays_a_portable_recipe(tmp_path: Path):
     )
 
     assert replayed["portable_sha256"] == exported["portable_sha256"]
-    revisions = [record for record in read_records(project, "edit_revision") if record.record_id == replayed["replay_revision_id"]]
+    revisions = [
+        record
+        for record in read_records(project, "edit_revision")
+        if record.record_id == replayed["replay_revision_id"]
+    ]
     assert len(revisions) == 1
     assert len(revisions[0].operation_ids) == 2
 

--- a/tests/test_reframe_render_receipts.py
+++ b/tests/test_reframe_render_receipts.py
@@ -81,7 +81,9 @@ def _plan(source: Path, positions: tuple[int, int]):
     )
     return plan_subject_aware_reframe(
         analysis=analysis,
-        targets=(CropTarget(target_id="portrait", aspect_width=9, aspect_height=16, output_width=180, output_height=320),),
+        targets=(
+            CropTarget(target_id="portrait", aspect_width=9, aspect_height=16, output_width=180, output_height=320),
+        ),
         crop_budget=CropBudget(max_subject_loss=0.05, max_source_crop_fraction=0.7),
         max_center_step=1,
         speaker_turns=turns,

--- a/tests/test_still_plates.py
+++ b/tests/test_still_plates.py
@@ -198,7 +198,6 @@ def test_still_package_dry_run_and_happy_path(still_fixture_dir: Path) -> None:
         assert "~" in text
 
 
-
 def test_doctor_still_plates_check() -> None:
     from kinocut.doctor import run_diagnostics
 
@@ -283,7 +282,7 @@ def test_near_extrema_empty_band_not_treated_as_zero() -> None:
 def _write_identity_cube(path: Path, size: int = 2) -> Path:
     """Minimal identity 3D LUT (.cube) for FFmpeg lut3d smoke tests."""
     lines = [
-        "TITLE \"identity\"",
+        'TITLE "identity"',
         f"LUT_3D_SIZE {size}",
     ]
     # Domain default 0..1; identity samples at size^3 grid.
@@ -415,6 +414,7 @@ def test_mcp_stdio_still_match_round_trip(still_fixture_dir: Path) -> None:
     assert result.isError is False
     payload = result.structuredContent or json.loads(result.content[0].text)
     assert payload.get("success") is True
-    assert Path(payload.get("receipt_path") or (out / "still_match_receipt.json")).is_file() or (
-        out / "still_match_receipt.json"
-    ).is_file()
+    assert (
+        Path(payload.get("receipt_path") or (out / "still_match_receipt.json")).is_file()
+        or (out / "still_match_receipt.json").is_file()
+    )

--- a/tests/test_visual_intelligence_reframe.py
+++ b/tests/test_visual_intelligence_reframe.py
@@ -262,7 +262,9 @@ def test_speaker_turns_keep_active_speaker_in_crop_on_two_fixtures(
 
     samples = plan.variants[0].crop_track
     expected = tuple(turn.subject_id for turn in turns)
-    assert sum(sample.active_subject_id == subject_id for sample, subject_id in zip(samples, expected, strict=True)) / len(
-        samples
-    ) >= 0.95
+    assert (
+        sum(sample.active_subject_id == subject_id for sample, subject_id in zip(samples, expected, strict=True))
+        / len(samples)
+        >= 0.95
+    )
     assert sum(sample.subject_coverage >= 0.95 for sample in samples) / len(samples) >= 0.95

--- a/tests/test_wishlist_depth_closeout.py
+++ b/tests/test_wishlist_depth_closeout.py
@@ -67,6 +67,8 @@ def test_frame_accurate_seek_helpers() -> None:
 
 
 def test_configure_logging_to_file(tmp_path: Path) -> None:
+    import contextlib
+
     from kinocut.__main__ import _configure_logging
 
     log_path = tmp_path / "kinocut.log"
@@ -85,10 +87,8 @@ def test_configure_logging_to_file(tmp_path: Path) -> None:
     finally:
         for h in list(root.handlers):
             root.removeHandler(h)
-            try:
+            with contextlib.suppress(Exception):
                 h.close()
-            except Exception:
-                pass
         for h in before:
             root.addHandler(h)
 
@@ -101,9 +101,7 @@ def test_generative_paid_path_rigor() -> None:
     with pytest.raises(MCPVideoError, match="not executable"):
         assert_generative_executable(denied)
 
-    allowed = plan_generative_last_mile(
-        "x", provider="openai", max_spend_usd=2.0, estimated_spend_usd=0.5
-    )
+    allowed = plan_generative_last_mile("x", provider="openai", max_spend_usd=2.0, estimated_spend_usd=0.5)
     assert allowed.allowed is True
     assert allowed.executable is True
     assert assert_generative_executable(allowed)["provider"] == "openai"

--- a/tests/test_wishlist_depth_closeout.py
+++ b/tests/test_wishlist_depth_closeout.py
@@ -1,0 +1,221 @@
+"""Wishlist + optional depth closeout tests (sequence shortcut, logging, OTIO foreign, generative gate)."""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+import pytest
+
+from kinocut.engine_timeline import expand_sequence_shortcut
+from kinocut.errors import MCPVideoError
+from kinocut.multipliers import (
+    assert_generative_executable,
+    detect_tts_backend,
+    export_otio_json,
+    import_otio_json,
+    plan_generative_last_mile,
+    plan_tts_dub,
+)
+from kinocut.te import frame_to_timestamp, timestamp_to_frame
+from kinocut.watching import run_vision_qc
+
+
+def test_expand_sequence_shortcut_builds_tracks() -> None:
+    raw = {
+        "clips": ["a.mp4", "b.mp4", "c.mp4"],
+        "transitions": ["fade", "dissolve"],
+        "transition_duration": 0.5,
+    }
+    expanded = expand_sequence_shortcut(raw)
+    assert "tracks" in expanded
+    track = expanded["tracks"][0]
+    assert track["type"] == "video"
+    assert len(track["clips"]) == 3
+    assert track["clips"][0]["source"] == "a.mp4"
+    assert len(track["transitions"]) == 2
+    assert track["transitions"][0]["type"] == "fade"
+    assert track["transitions"][0]["after_clip"] == 0
+    assert track["transitions"][1]["type"] == "dissolve"
+    assert track["transitions"][0]["duration"] == 0.5
+
+
+def test_expand_sequence_shortcut_repeats_last_transition() -> None:
+    raw = {"clips": ["a.mp4", "b.mp4", "c.mp4", "d.mp4"], "transitions": ["fade"]}
+    expanded = expand_sequence_shortcut(raw)
+    types = [t["type"] for t in expanded["tracks"][0]["transitions"]]
+    assert types == ["fade", "fade", "fade"]
+
+
+def test_expand_sequence_shortcut_leaves_full_timeline() -> None:
+    full = {"tracks": [{"type": "video", "clips": [{"source": "x.mp4"}]}]}
+    assert expand_sequence_shortcut(full) is full
+
+
+def test_expand_sequence_shortcut_rejects_empty() -> None:
+    with pytest.raises(MCPVideoError, match="clips"):
+        expand_sequence_shortcut({"clips": []})
+
+
+def test_frame_accurate_seek_helpers() -> None:
+    s = frame_to_timestamp(90, 30.0)
+    assert abs(s["seconds"] - 3.0) < 1e-9
+    assert "ffmpeg_ss" in s
+    f = timestamp_to_frame(3.0, 30.0)
+    assert f["frame"] == 90
+
+
+def test_configure_logging_to_file(tmp_path: Path) -> None:
+    from kinocut.__main__ import _configure_logging
+
+    log_path = tmp_path / "kinocut.log"
+    # Clear handlers so basicConfig-like attach is isolated
+    root = logging.getLogger()
+    before = list(root.handlers)
+    try:
+        for h in list(root.handlers):
+            root.removeHandler(h)
+        _configure_logging(verbose=False, log_file=str(log_path))
+        logging.getLogger("kinocut.test").debug("hello-depth-closeout")
+        for h in list(root.handlers):
+            h.flush()
+        text = log_path.read_text(encoding="utf-8")
+        assert "hello-depth-closeout" in text
+    finally:
+        for h in list(root.handlers):
+            root.removeHandler(h)
+            try:
+                h.close()
+            except Exception:
+                pass
+        for h in before:
+            root.addHandler(h)
+
+
+def test_generative_paid_path_rigor() -> None:
+    denied = plan_generative_last_mile("x", provider="openai", max_spend_usd=0.0, estimated_spend_usd=0.5)
+    assert denied.allowed is False
+    assert denied.executable is False
+    assert denied.paid_path is True
+    with pytest.raises(MCPVideoError, match="not executable"):
+        assert_generative_executable(denied)
+
+    allowed = plan_generative_last_mile(
+        "x", provider="openai", max_spend_usd=2.0, estimated_spend_usd=0.5
+    )
+    assert allowed.allowed is True
+    assert allowed.executable is True
+    assert assert_generative_executable(allowed)["provider"] == "openai"
+
+    local = plan_generative_last_mile("x", provider="local")
+    assert local.local_only is True
+    assert local.executable is True
+
+
+def test_tts_backend_probe_shape() -> None:
+    backend = detect_tts_backend()
+    assert "available" in backend
+    assert "backends" in backend
+    plan = plan_tts_dub("captions.srt", target_lang="es")
+    assert plan["artifact_kind"] == "tts_dub_plan"
+    assert plan["brand_primary"] is True
+    assert "backend" in plan
+    assert plan["executable"] is bool(backend["available"])
+
+
+def test_foreign_otio_local_media_import(tmp_path: Path, sample_video: str) -> None:
+    doc = {
+        "OTIO_SCHEMA": "Timeline.1",
+        "name": "foreign_demo",
+        "tracks": {
+            "OTIO_SCHEMA": "Stack.1",
+            "children": [
+                {
+                    "OTIO_SCHEMA": "Track.1",
+                    "name": "V1",
+                    "kind": "Video",
+                    "children": [
+                        {
+                            "OTIO_SCHEMA": "Clip.1",
+                            "name": "shot_a",
+                            "media_reference": {
+                                "OTIO_SCHEMA": "ExternalReference.1",
+                                "target_url": f"file://{sample_video}",
+                            },
+                        }
+                    ],
+                }
+            ],
+        },
+    }
+    path = tmp_path / "foreign.otio.json"
+    path.write_text(json.dumps(doc), encoding="utf-8")
+    imported = import_otio_json(str(path))
+    assert imported["artifact_kind"] == "foreign_otio_import"
+    assert imported["import_mode"] == "foreign_local_media"
+    assert imported["name"] == "foreign_demo"
+    assert imported["clip_count"] == 1
+    assert imported["clips"][0]["id"] == "shot_a"
+    assert "sequence_shortcut" in imported
+    assert len(imported["sequence_shortcut"]["clips"]) == 1
+
+
+def test_foreign_otio_remote_rejected(tmp_path: Path) -> None:
+    doc = {
+        "OTIO_SCHEMA": "Timeline.1",
+        "name": "remote",
+        "tracks": {
+            "children": [
+                {
+                    "children": [
+                        {
+                            "name": "bad",
+                            "media_reference": {"target_url": "https://example.com/a.mp4"},
+                        }
+                    ]
+                }
+            ]
+        },
+    }
+    path = tmp_path / "remote.otio.json"
+    path.write_text(json.dumps(doc), encoding="utf-8")
+    with pytest.raises(MCPVideoError, match="local media"):
+        import_otio_json(str(path))
+
+
+def test_otio_kinocut_ir_still_preferred(tmp_path: Path) -> None:
+    timeline = {
+        "ir_schema_version": 1,
+        "name": "demo",
+        "timebase": {"numerator": 1, "denominator": 30},
+        "sources": {"s1": {"path": "media/in.mp4"}},
+        "nodes": [
+            {
+                "id": "c1",
+                "kind": "clip",
+                "depends_on": [],
+                "inputs": {"src": "@sources.s1"},
+                "params": {
+                    "start": {"numerator": 0, "denominator": 1},
+                    "duration": {"numerator": 30, "denominator": 1},
+                },
+                "output": "@outputs.final",
+            }
+        ],
+        "outputs": {"final": {"path": "out/final.mp4"}},
+    }
+    out = tmp_path / "demo.otio.json"
+    export_otio_json(timeline, str(out))
+    imported = import_otio_json(str(out))
+    assert imported["import_mode"] == "kinocut_ir"
+    assert imported["name"] == "demo"
+
+
+def test_vision_qc_structural_keyframes(sample_video: str) -> None:
+    result = run_vision_qc(sample_video, sample_times=[0.1], require_vlm=False)
+    assert result["artifact_kind"] == "vision_qc"
+    assert result["verdict"] in {"pass", "fail"}
+    assert "keyframe_count" in result
+    # At least attempted structural sample
+    assert any(f["check_id"] == "vision.keyframe_sample" for f in result["findings"])

--- a/tests/test_workflow_variants.py
+++ b/tests/test_workflow_variants.py
@@ -620,7 +620,7 @@ def test_variants_do_not_change_public_surface_counts():
     from mcp_video.server import mcp
 
     tool_names = {tool.name for tool in asyncio.run(mcp.list_tools())}
-    assert len(tool_names) == 194  # implement-all tip surface (1.13.0 cut).
+    assert len(tool_names) == 196  # implement-all tip surface (1.13.0 cut).
     assert {"video_workflow_render", "video_workflow_plan", "video_workflow_validate"} <= tool_names
 
 
@@ -636,4 +636,4 @@ def test_variant_flags_do_not_add_cli_commands():
     assert result.returncode == 0
     command_lists = re.findall(r"\{([^}]+)\}", result.stdout)
     command_list = max(command_lists, key=lambda value: len(value.split(",")))
-    assert len(set(command_list.split(","))) == 165  # implement-all tip CLI surface.
+    assert len(set(command_list.split(","))) == 167  # implement-all tip CLI surface.


### PR DESCRIPTION
## Summary

Forgejo is source of truth. Mirror PR for GitHub visibility.

Closes residual ROADMAP wishlist boxes, optional product depth, Renovate #3 runbook, and CI light topology docs.

See Forgejo PR for full notes. Branch: `feat/wishlist-depth-ops-closeout`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/kinocut/pr/440"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789161158&installation_model_id=20207&pr_number=440&repository=KyaniteLabs%2Fkinocut&return_to=https%3A%2F%2Fgithub.com%2FKyaniteLabs%2Fkinocut%2Fpull%2F440&signature=09f99f162e468d3f940d25040befa71ee1c8ba7e7daba09f79440114c31d66a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Create multi-clip edits with simplified clip lists, per-clip transitions, and transition durations.
  - Import compatible OTIO timelines containing local media references.
  - Add structural keyframe details to vision-quality checks.
  - Detect available TTS backends and validate generative-media execution and spending limits.
  - Configure detailed logs in the terminal and/or a file.

- **Documentation**
  - Updated editing, operations, roadmap, and workflow documentation with current capabilities and guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->