### PR TITLE
feat: finish half-built compilers into product surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 <p align="center">
   <a href="#see-it-work">Demo</a> &bull;
   <a href="#status-and-releases">Status</a> &bull;
-  <a href="#whats-in-1133-latest-release">1.13.2</a> &bull;
+  <a href="#whats-in-1134-latest-release">1.13.4</a> &bull;
   <a href="#changelog">Changelog</a> &bull;
   <a href="#beyond-1132-draft--gated">Beyond</a> &bull;
   <a href="#installation">Install</a> &bull;
@@ -115,14 +115,14 @@ video.release_checkpoint(short.output_path)  # thumbnail + quality gate before y
 | Surface | Version / tip | What it means |
 | --- | --- | --- |
 | **PyPI / npm / GitHub Release** | **[1.13.4](https://github.com/KyaniteLabs/kinocut/releases/tag/v1.13.4)** (2026-08-12) | Latest **published** Kinocut. Install with `pip install kinocut`. |
-| **This repository (`master`)** | **1.13.2** · **196 MCP tools / 167 CLI commands** | Intent/watching/TE + still/plate surface matches published package. |
+| **This repository (`master`)** | **1.13.4** · **196 MCP tools / 167 CLI commands** | Intent/watching/TE + still/plate surface matches published package. |
 | **Next public release** | **TBD** | Post-release pillars and human programs remain gated; further bumps need a new go-ahead. |
 
 Install from PyPI when you want the stable package. Clone or install from `master` only when you intentionally need unreleased surfaces.
 
-## What's in 1.13.2 (latest release)
+## What's in 1.13.4 (latest release)
 
-Kinocut **1.13.2** is what you get from `pip install kinocut` today. It is a patch release that adds **critical/high security hardening** plus **post-release correctness fixes** on top of the **1.13.1** feature baseline, which introduced the intent/watching/TE multiplier surface on top of still/plate (1.12) and the 1.11.x identity line:
+Kinocut **1.13.4** is what you get from `pip install kinocut` today. It is a patch release that adds **critical/high security hardening** plus **post-release correctness fixes** on top of the **1.13.1** feature baseline, which introduced the intent/watching/TE multiplier surface on top of still/plate (1.12) and the 1.11.x identity line:
 
 - **Intent-verb surface** — Semantic intent routing via `video_intent` / `intent` tools supporting ~10 verbs to dry-run plans without silent media mutations.
 - **Watching guardrail floor** — Validation and quality checkpoints (`video_review_run`, `video_review_decide`) performing metric QC (blackdetect/LUFS) and narrative first-15s inspection.
@@ -144,13 +144,13 @@ Also already on the published line from earlier 1.x surfaces:
 
 Full notes: [CHANGELOG.md](CHANGELOG.md) · [v1.13.2 release](https://github.com/KyaniteLabs/kinocut/releases/tag/v1.13.2)
 
-## Beyond 1.13.2 (draft / gated)
+## Beyond 1.13.4 (draft / gated)
 
-**1.13.2 is the latest published release.** Live directory submissions, launch posts, and first-10 real-user runs remain operator/human residual (`docs/HUMAN_GATES.md`) and are **not** claimed complete.
+**1.13.4 is the latest published release.** Live directory submissions, launch posts, and first-10 real-user runs remain operator/human residual (`docs/HUMAN_GATES.md`) and are **not** claimed complete.
 
 ### Staged and Gated Surfaces
 
-While the core FFmpeg editing, workflow engine, still/plate editing, AI-video review/salvage, and sound capabilities are fully integrated and published in **1.13.2**, the following surfaces remain gated, partial, or unreleased:
+While the core FFmpeg editing, workflow engine, still/plate editing, AI-video review/salvage, and sound capabilities are fully integrated and published in **1.13.4**, the following surfaces remain gated, partial, or unreleased:
 
 - **Desktop MCPB Packaging:** The staged desktop package (`mcpb/`) is a staged configuration and is **not** a published self-contained native runtime yet (pending FFmpeg provenance, licensing, and clean-machine gates). See [docs/MCPB.md](docs/MCPB.md).
 - **Sonic World Audio (`kinocut_sound`):** While the S1–S12 capabilities are integrated on the published line, the remaining slices are blocked or gated:
@@ -233,7 +233,7 @@ In **Kinocut**, a contract-first path is provided for agent-edited media that mu
 3. **Verdict + acceptance** with exact human evidence (`video_verdict`, `video_acceptance_eval`)
 4. **Bounded derivatives only** — audio-preserving body swap or allowlisted salvage recipes (`video_body_swap`, `video_salvage`), each with lineage and a fresh non-approved review slot
 
-There is no force/bypass flag. Analyzer output alone cannot approve. Stale, aliased, or protected inputs fail closed. Operating guide: [docs/AI_VIDEO_REVIEW_AND_SALVAGE.md](docs/AI_VIDEO_REVIEW_AND_SALVAGE.md). These surfaces are fully integrated in the published 1.13.2 release — see [Status and releases](#status-and-releases).
+There is no force/bypass flag. Analyzer output alone cannot approve. Stale, aliased, or protected inputs fail closed. Operating guide: [docs/AI_VIDEO_REVIEW_AND_SALVAGE.md](docs/AI_VIDEO_REVIEW_AND_SALVAGE.md). These surfaces are fully integrated in the published 1.13.4 release — see [Status and releases](#status-and-releases).
 
 ## Dedicated Video Rescue
 
@@ -394,7 +394,7 @@ mcp-video doctor
 
 ## En español
 
-Kinocut es un servidor MCP de edición de video para agentes de IA. La última versión publicada es **1.13.2** (`pip install kinocut`, **194 herramientas MCP / 167 CLI**). La punta de desarrollo (`master`) coincide con ese surface publicado: FFmpeg tipado para recortar, unir, subtitular, mezclar audio, efectos y reutilizar contenido (Shorts, Reels, TikTok), motor de flujos (`workflow`) con recibos verificables, rescate de video, revisión AI-video gobernada y barreras de seguridad antes de renderizar. Programas humanos residuales (directorios, lanzamiento, first-10) no se reclaman completos.
+Kinocut es un servidor MCP de edición de video para agentes de IA. La última versión publicada es **1.13.4** (`pip install kinocut`, **196 herramientas MCP / 167 CLI**). La punta de desarrollo (`master`) coincide con ese surface publicado: FFmpeg tipado para recortar, unir, subtitular, mezclar audio, efectos y reutilizar contenido (Shorts, Reels, TikTok), motor de flujos (`workflow`) con recibos verificables, rescate de video, revisión AI-video gobernada y barreras de seguridad antes de renderizar. Programas humanos residuales (directorios, lanzamiento, first-10) no se reclaman completos.
 
 Requisito: [FFmpeg](https://ffmpeg.org/) instalado y disponible en el `PATH`.
 
@@ -537,7 +537,7 @@ kino still-package --establish hero.png --beats shot1.png shot2.png --output-dir
 
 ## MCP Tools
 
-On the **published 1.13.2** surface (and matching tip), kino registers **196 MCP tools** and **167 CLI commands**. The table summarizes core categories — `search_tools` discovers the exact operation without loading every description.
+On the **published 1.13.4** surface (and matching tip), kino registers **196 MCP tools** and **167 CLI commands**. The table summarizes core categories — `search_tools` discovers the exact operation without loading every description.
 
 | Category | Count | Highlights |
 | --- | ---: | --- |
@@ -645,7 +645,7 @@ Any MCP-compatible client that can run a local stdio server (Claude Code, Cursor
 
 ### How many tools are there?
 
-Published **1.13.2** documents **196 MCP tools / 167 CLI commands**. The development tip matches the published surface.
+Published **1.13.4** documents **196 MCP tools / 167 CLI commands**. The development tip matches the published surface.
 
 ### Was it called mcp-video?
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 Kinocut 1.13.4 is published with 196 MCP tools and 167 CLI commands (`mcp-video` 1.6.6 shim).
 
-**Published product:** Kinocut **1.13.4** (2026-08-12) · **196 MCP / 167 CLI**
+**Published product:** Kinocut **1.13.4** (2026-08-12) · **196 MCP / 167 CLI** · living snapshot [`docs/status/NOW.md`](docs/status/NOW.md)
 **Canonical claims:** [`docs/public_claims.json`](docs/public_claims.json)  
 **Human-only residuals:** [`docs/HUMAN_GATES.md`](docs/HUMAN_GATES.md)  
 **Residual portfolio (living truth):** [`docs/status/2026-08-12-residual-maturity-matrix.md`](docs/status/2026-08-12-residual-maturity-matrix.md) · [sound residual DAG](docs/status/2026-08-12-sound-residual-stage-dag.md) · [fixture freeze](docs/status/2026-08-12-sound-fixture-freeze.md) · [L1 truth pass](docs/status/2026-08-12-l1-truth-pass.md) · [phase checkpoints](docs/status/PHASE_CHECKPOINTS.md)  

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -337,3 +337,5 @@ Hyperframes project paths may be relative or absolute. Relative paths are resolv
 | `--format text\|json` | Output format (default: text — rich tables & spinners) |
 | `--version` | Show version and exit |
 | `--mcp` | Run as MCP server (default when no command given) |
+| `-v`, `--verbose` | Debug logs to stderr |
+| `--log-file PATH` | Write structured DEBUG logs to PATH |

--- a/docs/status/NOW.md
+++ b/docs/status/NOW.md
@@ -9,4 +9,4 @@
 
 **Human residuals:** Renovate host token, directories #88, launch #90. First-10 **closed**. MCPB unsigned is the product path.
 
-**Living authority:** [residual matrix](2026-08-12-residual-maturity-matrix.md) · [HUMAN_GATES](../HUMAN_GATES.md) · [S+ excellence PRD](../../.omx/plans/prd-kinocut-splus-excellence.md)
+**Living authority:** [residual matrix](2026-08-12-residual-maturity-matrix.md) · [HUMAN_GATES](../HUMAN_GATES.md). S+ excellence PRD is local-only (`.omx/plans/`, gitignored).

--- a/docs/status/NOW.md
+++ b/docs/status/NOW.md
@@ -1,0 +1,12 @@
+# Kinocut now
+
+**Published:** 1.13.4 · **196 MCP / 167 CLI** · `docs/public_claims.json`  
+**Tip:** same surface as published unless `development_*` diverges.
+
+**Product pipeline:** Phase 1–4 + Track E **GO**.
+
+**Default agent path:** doctor/info → `video_intent` / cutfile → render → QC → human review.
+
+**Human residuals:** Renovate host token, directories #88, launch #90. First-10 **closed**. MCPB unsigned is the product path.
+
+**Living authority:** [residual matrix](2026-08-12-residual-maturity-matrix.md) · [HUMAN_GATES](../HUMAN_GATES.md) · [S+ excellence PRD](../../.omx/plans/prd-kinocut-splus-excellence.md)

--- a/kinocut/cli/handlers_shorts.py
+++ b/kinocut/cli/handlers_shorts.py
@@ -69,6 +69,7 @@ def handle_shorts_commands(args: Any, *, use_json: bool) -> bool:
                 candidate_id=a.candidate_id,
                 package_root=a.package_root,
                 overwrite=a.overwrite,
+                allow_fail=bool(getattr(a, "allow_fail", False)),
             ),
             j,
         )

--- a/kinocut/cli/parser/core.py
+++ b/kinocut/cli/parser/core.py
@@ -105,7 +105,9 @@ def _add_core_style_parsers(subparsers: argparse._SubParsersAction) -> None:
     repurpose_p.add_argument("-o", "--output-dir", help="Package output directory")
     repurpose_p.add_argument("--platforms", nargs="+", help="Platforms to include")
     repurpose_p.add_argument("--skip-release-checkpoint", action="store_true")
-    repurpose_p.add_argument("--min-score", type=float, default=0.0)
+    from kinocut.defaults import DEFAULT_QUALITY_GATE_SCORE
+
+    repurpose_p.add_argument("--min-score", type=float, default=DEFAULT_QUALITY_GATE_SCORE)
 
     # Effect commands
 

--- a/kinocut/cli/parser/shorts.py
+++ b/kinocut/cli/parser/shorts.py
@@ -41,3 +41,8 @@ def add_parsers(subparsers: argparse._SubParsersAction) -> None:
     package.add_argument("--candidate-id", required=True)
     package.add_argument("--package-root", default=None)
     package.add_argument("--overwrite", action="store_true")
+    package.add_argument(
+        "--allow-fail",
+        action="store_true",
+        help="Package even if release quality fails (still records quality_gate_failed)",
+    )

--- a/kinocut/client/media.py
+++ b/kinocut/client/media.py
@@ -51,6 +51,7 @@ from ..defaults import (
     DEFAULT_AUDIO_BED_LOOP_CROSSFADE,
     DEFAULT_AUDIO_BED_MUSIC_VOLUME,
     DEFAULT_AUDIO_BED_TARGET_LUFS,
+    DEFAULT_QUALITY_GATE_SCORE,
 )
 from ..engine_audio_bed import audio_bed as _audio_bed
 from ..errors import MCPVideoError
@@ -678,7 +679,7 @@ class ClientMediaMixin:
         output_dir: str | None = None,
         platforms: list[str] | None = None,
         include_release_checkpoint: bool = True,
-        min_score: float = 0.0,
+        min_score: float = DEFAULT_QUALITY_GATE_SCORE,
     ) -> dict[str, Any]:
         """Render a local repurposing package."""
         from ..engine_repurpose import repurpose
@@ -797,7 +798,3 @@ class ClientMediaMixin:
         from ..engine import video_batch
 
         return video_batch(inputs, operation=operation, params=params, output_dir=output_dir)
-
-    # ------------------------------------------------------------------
-    # Image Analysis
-    # ------------------------------------------------------------------

--- a/kinocut/client/shorts.py
+++ b/kinocut/client/shorts.py
@@ -66,6 +66,7 @@ class ClientShortsMixin:
         candidate_id: str,
         package_root: str | None = None,
         overwrite: bool = False,
+        allow_fail: bool = False,
     ) -> dict[str, Any]:
         """Package approved platform renders from a saved plan. Never posts."""
         from ..product.shorts_package import package_approved_candidate
@@ -75,4 +76,5 @@ class ClientShortsMixin:
             candidate_id=candidate_id,
             package_root=package_root,
             overwrite=overwrite,
+            allow_fail=allow_fail,
         )

--- a/kinocut/engine_repurpose.py
+++ b/kinocut/engine_repurpose.py
@@ -15,6 +15,7 @@ from .engine_thumbnail import thumbnail
 from .errors import MCPVideoError
 from .ffmpeg_helpers import _validate_input_path, _validate_output_path
 from .paths import _auto_output_dir
+from .defaults import DEFAULT_QUALITY_GATE_SCORE
 from .quality_guardrails import assert_quality
 
 
@@ -163,7 +164,7 @@ def repurpose(
     output_dir: str | None = None,
     platforms: list[str] | None = None,
     include_release_checkpoint: bool = True,
-    min_score: float = 0.0,
+    min_score: float = DEFAULT_QUALITY_GATE_SCORE,
 ) -> dict[str, Any]:
     """Render a local content repurposing package and manifest."""
     input_path = _validate_input_path(input_path)

--- a/kinocut/product/shorts_package.py
+++ b/kinocut/product/shorts_package.py
@@ -61,12 +61,26 @@ def _renders_for(plan: ShortsPlan, candidate_id: str) -> tuple[RenderRecord, ...
     return tuple(record for record in plan.renders if record.candidate_id == candidate_id)
 
 
+def _gate_package_media(path: str, *, allow_fail: bool) -> dict[str, Any] | None:
+    """Run release quality on a packaged render. Dummy bytes use allow_fail."""
+    from ..defaults import DEFAULT_QUALITY_GATE_SCORE
+    from ..quality_guardrails import assert_quality
+
+    try:
+        return assert_quality(path, min_score=DEFAULT_QUALITY_GATE_SCORE)
+    except Exception as exc:
+        if allow_fail:
+            return {"quality_gate_failed": True, "error": type(exc).__name__, "message": str(exc)[:200]}
+        raise
+
+
 def package_approved_candidate(
     plan_path_or_dir: str,
     *,
     candidate_id: str,
     package_root: str | None = None,
     overwrite: bool = False,
+    allow_fail: bool = False,
 ) -> dict[str, Any]:
     """Package every platform draft for an approved candidate and persist the plan."""
     plan = load_shorts_plan(plan_path_or_dir)
@@ -114,6 +128,7 @@ def package_approved_candidate(
         )
         if result.manifest_path not in manifests:
             manifests.append(result.manifest_path)
+        gate = _gate_package_media(record.output_path, allow_fail=allow_fail)
         emitted.append(
             {
                 "platform": record.platform,
@@ -121,6 +136,7 @@ def package_approved_candidate(
                 "manifest_path": result.manifest_path,
                 "asset_paths": list(result.asset_paths),
                 "external_posting": False,
+                "quality": gate,
             }
         )
 

--- a/kinocut/server_app.py
+++ b/kinocut/server_app.py
@@ -22,10 +22,10 @@ _fastmcp_server.Settings.model_rebuild(_types_namespace=vars(_fastmcp_server))
 mcp = FastMCP(
     "kinocut",
     instructions=(
-        "Kinocut is a video editing MCP server. Use these tools to trim, merge, "
-        "add text overlays, sync audio, resize, convert, and export video files. "
-        "All file paths should be absolute. Output files are generated automatically "
-        "if no output_path is provided."
+        "Kinocut is a video editing MCP server. Default path: inspect (info/doctor) → "
+        "plan (video_intent or cutfile) → render → quality check → human review. "
+        "Do not publish without QC and a human gate. Prefer video_intent verbs over "
+        "listing every tool. Paths should be absolute. Output is auto-generated if omitted."
     ),
 )
 

--- a/kinocut/server_tools_intent.py
+++ b/kinocut/server_tools_intent.py
@@ -136,15 +136,26 @@ def video_intent(
     verb: str,
     params: dict[str, Any] | None = None,
     list_verbs: bool = False,
+    goal: str | None = None,
+    source: str | None = None,
 ) -> dict[str, Any]:
-    """Route a semantic intent verb to a plan (does not silently mutate media)."""
+    """Route a semantic intent verb to a plan (does not silently mutate media).
+
+    Optional ``goal`` compiles a reviewable cutfile (N1) without rendering.
+    """
 
     from kinocut.intent import list_intent_verbs, route_intent
 
     if list_verbs:
         return _result({"artifact_kind": "intent_catalog", "verbs": list_intent_verbs()})
     plan = route_intent(verb, params)
-    return _result({"artifact_kind": "intent_plan", **plan.to_dict()})
+    payload: dict[str, Any] = {"artifact_kind": "intent_plan", **plan.to_dict()}
+    if goal:
+        from kinocut.te import compile_goal_to_cutfile
+
+        payload["cutfile"] = compile_goal_to_cutfile(goal, source=source or "media/hero.mp4")
+        payload["next_action"] = "review_then_cutfile_render"
+    return _result(payload)
 
 
 @mcp.tool()
@@ -226,12 +237,23 @@ def video_review_decide(
     review_run: dict[str, Any],
     decision: str,
     reason: str = "",
+    input_path: str | None = None,
+    output_path: str | None = None,
+    edl: dict[str, Any] | None = None,
+    approval: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
-    """Record human accept/reject/revise on a review_run artifact."""
+    """Record human accept/reject/revise. Accept + EDL approval can render (N4)."""
 
     from kinocut.watching import decide_review
 
-    return _result(decide_review(review_run, decision, reason).to_dict())
+    decided = decide_review(review_run, decision, reason).to_dict()
+    if (decision or "").lower() == "accept" and input_path and output_path and edl and approval:
+        from kinocut.te import render_approved_edl
+
+        decided["edl_render"] = render_approved_edl(
+            input_path, edl=edl, approval=approval, output_path=output_path
+        )
+    return _result(decided)
 
 
 @mcp.tool()
@@ -326,11 +348,24 @@ def video_estimate_operation(
 
 @mcp.tool()
 @_safe_tool
-def video_cutfile_validate(path: str) -> dict[str, Any]:
-    """Validate a text-first Cutfile (v1 JSON or minimal YAML scaffold)."""
+def video_cutfile_validate(
+    path: str | None = None,
+    goal: str | None = None,
+    source: str | None = None,
+    platform: str | None = None,
+) -> dict[str, Any]:
+    """Validate a Cutfile, or compile one from ``goal`` / ``platform`` (N1/N5)."""
 
-    from kinocut.te import load_cutfile
+    from kinocut.te import compile_goal_to_cutfile, load_cutfile, solve_publish_cutfile
 
+    if platform:
+        return _result(solve_publish_cutfile(platform, source=source or "media/hero.mp4"))
+    if goal:
+        return _result(compile_goal_to_cutfile(goal, source=source or "media/hero.mp4"))
+    if not path:
+        from kinocut.errors import MCPVideoError
+
+        raise MCPVideoError("path, goal, or platform required", error_type="validation_error", code="cutfile_args")
     cf = load_cutfile(path)
     return _result(cf.to_dict())
 
@@ -386,10 +421,39 @@ def video_metric_qc(
 @mcp.tool()
 @_safe_tool
 def video_timeline_ir_validate(timeline: dict[str, Any]) -> dict[str, Any]:
-    """Validate Timeline IR and compile to render DAG (P3.0)."""
+    """Validate Timeline IR and compile to render DAG (P3.0).
 
+    Semantic timelines (shots/silences/words) also get agent-visible ``text`` (N2).
+    """
+
+    from kinocut.te import render_timeline_text
     from kinocut.timeline_ir import compile_ir_to_dag, ir_identity, parse_timeline_ir
 
+    view = None
+    if any(timeline.get(k) for k in ("shots", "silences", "words", "scenes")):
+        try:
+            view = render_timeline_text(timeline)
+        except Exception as exc:
+            import logging
+
+            logging.getLogger(__name__).debug("timeline text skipped: %s", exc)
+            view = None
+    if timeline.get("ir_schema_version") or timeline.get("nodes"):
+        ir = parse_timeline_ir(timeline)
+        dag = compile_ir_to_dag(ir)
+        payload = {
+            "artifact_kind": "timeline_ir",
+            "identity": ir_identity(ir),
+            "ir": ir.model_dump(mode="json"),
+            "dag_node_count": len(getattr(dag, "nodes", []) or []),
+            "compiled": True,
+        }
+        if view:
+            payload["text"] = view.get("text")
+            payload["timeline_view"] = view
+        return _result(payload)
+    if view:
+        return _result(view)
     ir = parse_timeline_ir(timeline)
     dag = compile_ir_to_dag(ir)
     return _result(
@@ -499,11 +563,23 @@ def video_publish_validate(
     height: int,
     width: int,
     container: str = "mp4",
+    solve: bool = False,
+    source: str | None = None,
+    captions: bool = False,
 ) -> dict[str, Any]:
-    """Local-first per-platform publish spec validation (TE.1) — no upload."""
+    """Validate a publish spec. ``solve=True`` also emits a cutfile (N5)."""
 
-    from kinocut.te import validate_publish_spec
+    from kinocut.te import solve_publish_cutfile, validate_publish_spec
 
+    if solve:
+        return _result(
+            solve_publish_cutfile(
+                platform,
+                source=source or "media/hero.mp4",
+                source_duration=duration_seconds or 60.0,
+                captions=captions,
+            )
+        )
     return _result(
         validate_publish_spec(
             platform,
@@ -574,15 +650,26 @@ def video_edit_session(
     step_action: str | None = None,
     score: float | None = None,
     notes: str = "",
+    input_path: str | None = None,
 ) -> dict[str, Any]:
-    """Conversational edit session open/step with measured improvement (TE.13)."""
+    """Conversational edit session. Step with ``input_path`` measures real QC (N6)."""
 
     from kinocut.errors import MCPVideoError
-    from kinocut.te import session_open, session_step
+    from kinocut.te import session_close, session_open, session_step
 
     act = (action or "").lower()
     if act == "open":
         return _result(session_open(path, goal or "edit"))
     if act == "step":
-        return _result(session_step(path, action=step_action or "step", score=score, notes=notes))
-    raise MCPVideoError("action must be open|step", error_type="validation_error", code="session_action")
+        return _result(
+            session_step(
+                path,
+                action=step_action or "step",
+                score=score,
+                notes=notes,
+                input_path=input_path,
+            )
+        )
+    if act == "close":
+        return _result(session_close(path))
+    raise MCPVideoError("action must be open|step|close", error_type="validation_error", code="session_action")

--- a/kinocut/server_tools_intent.py
+++ b/kinocut/server_tools_intent.py
@@ -250,9 +250,7 @@ def video_review_decide(
     if (decision or "").lower() == "accept" and input_path and output_path and edl and approval:
         from kinocut.te import render_approved_edl
 
-        decided["edl_render"] = render_approved_edl(
-            input_path, edl=edl, approval=approval, output_path=output_path
-        )
+        decided["edl_render"] = render_approved_edl(input_path, edl=edl, approval=approval, output_path=output_path)
     return _result(decided)
 
 

--- a/kinocut/server_tools_shorts.py
+++ b/kinocut/server_tools_shorts.py
@@ -75,6 +75,7 @@ def shorts_package(
     candidate_id: str,
     package_root: str | None = None,
     overwrite: bool = False,
+    allow_fail: bool = False,
 ) -> dict[str, Any]:
     """Package approved platform renders from a saved plan. Never posts."""
     from .product.shorts_package import package_approved_candidate
@@ -85,5 +86,6 @@ def shorts_package(
             candidate_id=candidate_id,
             package_root=package_root,
             overwrite=overwrite,
+            allow_fail=allow_fail,
         )
     )

--- a/kinocut/server_tools_workflow.py
+++ b/kinocut/server_tools_workflow.py
@@ -132,7 +132,7 @@ def video_workflow_render(
 
 @mcp.tool()
 @_safe_tool
-def video_workflow_inspect(receipt_path: str) -> dict[str, Any]:
+def video_workflow_inspect(receipt_path: str, compare_path: str | None = None) -> dict[str, Any]:
     """Summarize any receipt this project emits, with a read-only integrity check.
 
     Reads a workflow render receipt, a dry-run ``workflow_plan`` artifact, or a
@@ -150,5 +150,14 @@ def video_workflow_inspect(receipt_path: str) -> dict[str, Any]:
 
     Args:
         receipt_path: Absolute path to the receipt JSON file to inspect.
+        compare_path: Optional second receipt; when set, also return a diff (N3).
     """
-    return _result(inspect_receipt(receipt_path))
+    inspected = inspect_receipt(receipt_path)
+    if compare_path:
+        from kinocut.te import diff_receipts
+
+        payload = inspected if isinstance(inspected, dict) else {"inspection": inspected}
+        payload = dict(payload)
+        payload["diff"] = diff_receipts(receipt_path, compare_path)
+        return _result(payload)
+    return _result(inspected)

--- a/kinocut/te/__init__.py
+++ b/kinocut/te/__init__.py
@@ -5,9 +5,14 @@ from __future__ import annotations
 from .audiogram import plan_audiogram
 from .brand_kit import BrandKit, load_brand_kit, save_brand_kit
 from .cost_oracle import estimate_operation
+from .constraint_solve import solve_publish_cutfile
 from .cutfile import Cutfile, load_cutfile, validate_cutfile
 from .cutfile_render import compile_cutfile_to_workflow, render_cutfile
 from .edit_session import session_close, session_open, session_step
+from .edl_apply import render_approved_edl
+from .goal_cutfile import compile_goal_to_cutfile
+from .receipt_diff import diff_receipts
+from .timeline_view import render_timeline_text
 from .hooks import generate_hook_candidates
 from .init_project import init_project
 from .publish_connectors import validate_publish_spec
@@ -18,6 +23,8 @@ __all__ = [
     "BrandKit",
     "Cutfile",
     "compile_cutfile_to_workflow",
+    "compile_goal_to_cutfile",
+    "diff_receipts",
     "estimate_operation",
     "frame_to_timestamp",
     "generate_hook_candidates",
@@ -26,12 +33,15 @@ __all__ = [
     "load_cutfile",
     "plan_audiogram",
     "plan_punch_zooms",
+    "render_approved_edl",
     "render_cutfile",
+    "render_timeline_text",
     "save_brand_kit",
     "session_close",
     "session_open",
     "session_step",
     "timestamp_to_frame",
+    "solve_publish_cutfile",
     "validate_cutfile",
     "validate_publish_spec",
 ]

--- a/kinocut/te/__init__.py
+++ b/kinocut/te/__init__.py
@@ -40,8 +40,8 @@ __all__ = [
     "session_close",
     "session_open",
     "session_step",
-    "timestamp_to_frame",
     "solve_publish_cutfile",
+    "timestamp_to_frame",
     "validate_cutfile",
     "validate_publish_spec",
 ]

--- a/kinocut/te/constraint_solve.py
+++ b/kinocut/te/constraint_solve.py
@@ -1,0 +1,59 @@
+"""Inverse of publish validation: platform constraints → cutfile (N5)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from kinocut.te.cutfile import validate_cutfile
+from kinocut.te.publish_connectors import PLATFORM_SPECS, validate_publish_spec
+
+
+def solve_publish_cutfile(
+    platform: str,
+    *,
+    source: str = "media/hero.mp4",
+    source_duration: float = 60.0,
+    captions: bool = False,
+) -> dict[str, Any]:
+    """Build a cutfile that should pass ``validate_publish_spec`` after render."""
+    key = (platform or "").strip().lower().replace("-", "_").replace(" ", "_")
+    spec = PLATFORM_SPECS.get(key)
+    if spec is None:
+        return validate_publish_spec(platform, duration_seconds=0, height=0, width=0)
+    max_dur = float(spec["max_duration_seconds"])
+    duration = min(float(source_duration), max_dur)
+    ar = str(spec.get("aspect_ratio") or "9:16")
+    min_h = int(spec["min_height"])
+    if ar == "9:16":
+        width, height = max(1080, int(min_h * 9 / 16)), max(min_h, 1920)
+    elif ar == "1:1":
+        width = height = max(min_h, 1080)
+    else:
+        height = max(min_h, 1080)
+        width = int(height * 16 / 9)
+    ops: list[dict[str, Any]] = [{"op": "trim", "start": 0, "duration": duration}]
+    if ar != "any":
+        ops.append({"op": "resize", "width": width, "height": height})
+    if captions:
+        ops.append({"op": "add_text", "text": "CAPTIONS", "position": "bottom-center"})
+    cf = validate_cutfile(
+        {
+            "name": f"{key}-solve",
+            "version": 1,
+            "sources": [{"id": "hero", "path": source}],
+            "ops": ops,
+        }
+    )
+    proof = validate_publish_spec(
+        key,
+        duration_seconds=duration,
+        height=height,
+        width=width,
+        container=str(spec["container"]),
+    )
+    return {
+        **cf.to_dict(),
+        "platform": key,
+        "publish_proof": proof,
+        "next_action": "review_then_cutfile_render",
+    }

--- a/kinocut/te/edit_session.py
+++ b/kinocut/te/edit_session.py
@@ -32,6 +32,7 @@ def session_step(
     action: str,
     score: float | None = None,
     notes: str = "",
+    input_path: str | None = None,
 ) -> dict[str, Any]:
     p = Path(session_path)
     if not p.is_file():
@@ -39,18 +40,23 @@ def session_step(
     state = json.loads(p.read_text(encoding="utf-8"))
     if not action:
         raise MCPVideoError("action required", error_type="validation_error", code="action_required")
+    measured = score
+    if measured is None and input_path:
+        measured = _qc_score(input_path)
+        notes = notes or f"qc:{input_path}"
     step = {
         "index": len(state.get("steps") or []) + 1,
         "action": action,
-        "score": score,
+        "score": measured,
         "notes": notes,
         "at": time.time(),
+        "input_path": input_path,
     }
     state.setdefault("steps", []).append(step)
-    if state.get("baseline_score") is None and score is not None:
-        state["baseline_score"] = score
-    if score is not None:
-        state["current_score"] = score
+    if state.get("baseline_score") is None and measured is not None:
+        state["baseline_score"] = measured
+    if measured is not None:
+        state["current_score"] = measured
     baseline = state.get("baseline_score")
     current = state.get("current_score")
     improvement = None
@@ -59,6 +65,13 @@ def session_step(
     state["improvement"] = improvement
     p.write_text(json.dumps(state, indent=2) + "\n", encoding="utf-8")
     return {**state, "path": str(p.resolve()), "measured_improvement": improvement}
+
+
+def _qc_score(input_path: str) -> float:
+    from kinocut.quality_guardrails import quality_check
+
+    report = quality_check(input_path, fail_on_warning=False)
+    return float(report.get("overall_score") or 0.0)
 
 
 def session_close(session_path: str, *, write_receipt: bool = True) -> dict[str, Any]:

--- a/kinocut/te/edl_apply.py
+++ b/kinocut/te/edl_apply.py
@@ -1,0 +1,103 @@
+"""Human-gated EDL apply: approved delete ids → keep-range trim/merge (N4)."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from typing import Any
+
+from kinocut.errors import MCPVideoError
+from kinocut.ffmpeg_helpers import _validate_input_path, _validate_output_path
+from kinocut.semantic.edl import EditApproval, EditDecisionList, EditOperation
+
+
+def render_approved_edl(
+    input_path: str,
+    *,
+    edl: dict[str, Any],
+    approval: dict[str, Any],
+    output_path: str,
+    source_duration: float | None = None,
+) -> dict[str, Any]:
+    """Render keep-ranges after an ``EditApproval``. Never applies without approval."""
+    src = _validate_input_path(input_path)
+    out = _validate_output_path(output_path)
+    decision = EditDecisionList.model_validate(edl)
+    grant = EditApproval.model_validate(approval)
+    if grant.edl_sha256 != decision.edl_sha256:
+        raise MCPVideoError(
+            "approval does not match this EDL",
+            error_type="validation_error",
+            code="edl_approval_mismatch",
+        )
+    if not grant.selected_edit_ids:
+        raise MCPVideoError(
+            "approval selected_edit_ids is empty",
+            error_type="validation_error",
+            code="edl_nothing_selected",
+        )
+    duration = float(source_duration or decision.source_duration_seconds)
+    removed = _selected_deletes(decision, grant)
+    keep = _invert_ranges(removed, duration)
+    if not keep:
+        raise MCPVideoError("approved deletes leave no media", error_type="validation_error", code="edl_empty_keep")
+    written = _concat_keeps(src, keep, out)
+    return {
+        "artifact_kind": "edl_render",
+        "output_path": written,
+        "keep_segments": [{"start": a, "end": b} for a, b in keep],
+        "applied_edit_ids": list(grant.selected_edit_ids),
+        "edl_sha256": decision.edl_sha256,
+        "approval_sha256": grant.approval_sha256,
+        "next_action": "quality_check_then_human_review",
+    }
+
+
+def _selected_deletes(edl: EditDecisionList, approval: EditApproval) -> list[tuple[float, float]]:
+    wanted = set(approval.selected_edit_ids)
+    removed: list[tuple[float, float]] = []
+    for edit in edl.edits:
+        if edit.edit_id not in wanted:
+            continue
+        if edit.operation != EditOperation.DELETE:
+            raise MCPVideoError(
+                f"only delete edits can render in this apply path ({edit.operation})",
+                error_type="validation_error",
+                code="edl_op_unsupported",
+            )
+        removed.append((float(edit.source_start_seconds), float(edit.source_end_seconds)))
+    if not removed:
+        raise MCPVideoError(
+            "no approved delete edits to apply",
+            error_type="validation_error",
+            code="edl_no_deletes",
+        )
+    return removed
+
+
+def _invert_ranges(removed: list[tuple[float, float]], duration: float) -> list[tuple[float, float]]:
+    ordered = sorted(removed)
+    keep: list[tuple[float, float]] = []
+    cursor = 0.0
+    for start, end in ordered:
+        if start > cursor:
+            keep.append((cursor, start))
+        cursor = max(cursor, end)
+    if cursor < duration:
+        keep.append((cursor, duration))
+    return [(a, b) for a, b in keep if b - a > 1e-3]
+
+
+def _concat_keeps(src: str, keep: list[tuple[float, float]], out: str) -> str:
+    from kinocut.engine_edit import trim
+    from kinocut.engine_merge import merge
+
+    if len(keep) == 1:
+        start, end = keep[0]
+        return trim(src, start=start, duration=end - start, output_path=out, accurate=True).output_path
+    tmp = tempfile.mkdtemp(prefix="kinocut_edl_")
+    parts: list[str] = []
+    for i, (start, end) in enumerate(keep):
+        part = os.path.join(tmp, f"k{i:03d}.mp4")
+        parts.append(trim(src, start=start, duration=end - start, output_path=part, accurate=True).output_path)
+    return merge(parts, output_path=out).output_path

--- a/kinocut/te/goal_cutfile.py
+++ b/kinocut/te/goal_cutfile.py
@@ -1,0 +1,76 @@
+"""Compile a natural-language goal into a reviewable Cutfile (N1)."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from kinocut.errors import MCPVideoError
+from kinocut.te.cutfile import validate_cutfile
+
+
+def compile_goal_to_cutfile(
+    goal: str,
+    *,
+    source: str = "media/hero.mp4",
+    name: str | None = None,
+) -> dict[str, Any]:
+    """Turn a goal string into a schema-valid cutfile dict.
+
+    Does not render. Agents and humans review ops before ``render_cutfile``.
+    """
+    text = (goal or "").strip()
+    if not text:
+        raise MCPVideoError("goal required", error_type="validation_error", code="goal_required")
+    lower = text.lower()
+    duration = _infer_duration(lower)
+    aspect = _infer_aspect(lower)
+    ops: list[dict[str, Any]] = []
+    if duration is not None:
+        ops.append({"op": "trim", "start": 0, "duration": duration})
+    if aspect:
+        height = 1920 if aspect == "9:16" else 1080
+        width = 1080 if aspect == "9:16" else 1920
+        if aspect == "1:1":
+            width, height = 1080, 1080
+        ops.append({"op": "resize", "width": width, "height": height})
+    if any(k in lower for k in ("caption", "subtitle", "srt")):
+        ops.append({"op": "add_text", "text": "CAPTIONS", "position": "bottom-center"})
+    if not ops:
+        ops.append({"op": "trim", "start": 0, "duration": duration or 15})
+    cf = validate_cutfile(
+        {
+            "name": name or _slug(text),
+            "version": 1,
+            "sources": [{"id": "hero", "path": source}],
+            "ops": ops,
+        }
+    )
+    payload = cf.to_dict()
+    payload["goal"] = text
+    payload["next_action"] = "review_then_cutfile_render"
+    return payload
+
+
+def _infer_duration(lower: str) -> float | None:
+    m = re.search(r"(\d+(?:\.\d+)?)\s*(?:s|sec|secs|second|seconds)\b", lower)
+    if m:
+        return float(m.group(1))
+    if "short" in lower or "reel" in lower or "tiktok" in lower:
+        return 15.0
+    return None
+
+
+def _infer_aspect(lower: str) -> str | None:
+    if "9:16" in lower or "vertical" in lower or "reel" in lower or "tiktok" in lower or "short" in lower:
+        return "9:16"
+    if "1:1" in lower or "square" in lower:
+        return "1:1"
+    if "16:9" in lower or "landscape" in lower or "widescreen" in lower:
+        return "16:9"
+    return None
+
+
+def _slug(text: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", text.lower()).strip("-")
+    return (slug or "goal")[:48]

--- a/kinocut/te/receipt_diff.py
+++ b/kinocut/te/receipt_diff.py
@@ -60,7 +60,9 @@ def _ops(receipt: dict[str, Any]) -> list[str]:
                 if isinstance(item, str):
                     out.append(item)
                 elif isinstance(item, dict):
-                    out.append(str(item.get("op") or item.get("tool") or item.get("action") or item.get("name") or item))
+                    out.append(
+                        str(item.get("op") or item.get("tool") or item.get("action") or item.get("name") or item)
+                    )
             return out
     if receipt.get("operation"):
         return [str(receipt["operation"])]

--- a/kinocut/te/receipt_diff.py
+++ b/kinocut/te/receipt_diff.py
@@ -1,0 +1,67 @@
+"""Diff two workflow/session receipts (N3)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from kinocut.errors import InputFileError, MCPVideoError
+from kinocut.ffmpeg_helpers import _validate_input_path
+
+
+def diff_receipts(left: str | dict[str, Any], right: str | dict[str, Any]) -> dict[str, Any]:
+    """Compare two receipt objects or JSON paths. Does not render."""
+    a = _load(left)
+    b = _load(right)
+    a_ops = _ops(a)
+    b_ops = _ops(b)
+    added = [op for op in b_ops if op not in a_ops]
+    removed = [op for op in a_ops if op not in b_ops]
+    replay = {
+        "artifact_kind": "receipt_replay_plan",
+        "ops": b_ops,
+        "next_action": "compile_cutfile_or_workflow_from_ops",
+        "dry_run": True,
+    }
+    return {
+        "artifact_kind": "receipt_diff",
+        "added": added,
+        "removed": removed,
+        "unchanged": [op for op in a_ops if op in b_ops],
+        "left_kind": a.get("artifact_kind"),
+        "right_kind": b.get("artifact_kind"),
+        "replay": replay,
+        "changed": bool(added or removed),
+    }
+
+
+def _load(value: str | dict[str, Any]) -> dict[str, Any]:
+    if isinstance(value, dict):
+        return value
+    path = Path(_validate_input_path(str(value)))
+    if not path.is_file():
+        raise InputFileError(str(path), "receipt not found")
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise MCPVideoError(f"invalid receipt json: {exc}", error_type="validation_error", code="bad_receipt") from exc
+    if not isinstance(data, dict):
+        raise MCPVideoError("receipt root must be an object", error_type="validation_error", code="bad_receipt")
+    return data
+
+
+def _ops(receipt: dict[str, Any]) -> list[str]:
+    for key in ("ops", "tool_calls", "steps"):
+        raw = receipt.get(key)
+        if isinstance(raw, list) and raw:
+            out: list[str] = []
+            for item in raw:
+                if isinstance(item, str):
+                    out.append(item)
+                elif isinstance(item, dict):
+                    out.append(str(item.get("op") or item.get("tool") or item.get("action") or item.get("name") or item))
+            return out
+    if receipt.get("operation"):
+        return [str(receipt["operation"])]
+    return []

--- a/kinocut/te/timeline_view.py
+++ b/kinocut/te/timeline_view.py
@@ -1,0 +1,64 @@
+"""Agent-visible timeline text from a SemanticTimeline or span dicts (N2)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from kinocut.errors import MCPVideoError
+
+
+def render_timeline_text(
+    timeline: dict[str, Any] | None = None,
+    *,
+    spans: list[dict[str, Any]] | None = None,
+    duration_seconds: float | None = None,
+) -> dict[str, Any]:
+    """Render a scannable text score (shots / silence / words).
+
+    Accepts a SemanticTimeline dump or a flat ``spans`` list with
+    ``kind``, ``start``, ``end``, and optional ``label``.
+    """
+    rows = _collect_rows(timeline, spans)
+    if not rows:
+        raise MCPVideoError(
+            "timeline has no spans to render",
+            error_type="validation_error",
+            code="empty_timeline",
+        )
+    dur = duration_seconds
+    if dur is None and timeline and isinstance(timeline.get("source"), dict):
+        dur = float(timeline["source"].get("duration_seconds") or 0) or None
+    if dur is None:
+        dur = max(r["end"] for r in rows)
+    lines = [f"t={r['start']:.2f}-{r['end']:.2f} [{r['kind']}] {r['label']}" for r in rows]
+    return {
+        "artifact_kind": "timeline_view",
+        "duration_seconds": dur,
+        "row_count": len(rows),
+        "spans": rows,
+        "text": "\n".join(lines),
+        "next_action": "use_timestamps_in_trim_or_cutfile",
+    }
+
+
+def _collect_rows(
+    timeline: dict[str, Any] | None,
+    spans: list[dict[str, Any]] | None,
+) -> list[dict[str, Any]]:
+    raw: list[dict[str, Any]] = list(spans or [])
+    if isinstance(timeline, dict):
+        for key in ("shots", "scenes", "silences", "words", "speakers", "audio_events", "keyframes"):
+            for item in timeline.get(key) or []:
+                if isinstance(item, dict):
+                    raw.append(item)
+    rows: list[dict[str, Any]] = []
+    for item in raw:
+        start = item.get("source_start_seconds", item.get("start"))
+        end = item.get("source_end_seconds", item.get("end"))
+        if start is None or end is None:
+            continue
+        kind = str(item.get("kind") or "span")
+        label = item.get("text") or item.get("label") or item.get("speaker_label") or kind
+        rows.append({"kind": kind, "start": float(start), "end": float(end), "label": str(label)})
+    rows.sort(key=lambda r: (r["start"], r["end"], r["kind"]))
+    return rows

--- a/skills/kinocut/SKILL.md
+++ b/skills/kinocut/SKILL.md
@@ -7,19 +7,20 @@ description: Use Kinocut for guarded video editing, source-backed planning, FFmp
 
 Use Kinocut when an agent needs a structured video-editing surface instead of hand-writing FFmpeg commands. It exposes MCP tools, a Python client, and a CLI for editing, analysis, subtitles, audio, Hyperframes, layered compositing, and local repurposing workflows.
 
+## Default path (do this first)
+
+1. `kino doctor` then `kino --format json info <file>`.
+2. Plan with `video_intent` (optional `goal=` compiles a cutfile) — do not list 196 tools.
+3. Render (`video_cutfile_render`, `video_edit`, workflow, or a single engine tool).
+4. `video-quality-check` / `assert_quality`. Sync `repurpose` and `shorts-package` fail-closed at score 80 unless skipped/`allow_fail`.
+5. Human visual/audio review. Never treat a receipt as published.
+
+Depth (rescue, salvage, composite, Hyperframes, thin sound S12): `docs/TOOLS.md`, `docs/RESCUE.md`, `docs/WORKFLOWS.md`. Workflow allowlist: probe, trim, resize, convert, crop, add_text, merge, composite_layers, burn_in.
+
 ## Start Here
 
-- Read `../../README.md` for installation, agent workflows, and the safety contract.
-- Read `../../docs/CLI_REFERENCE.md` for command names and flags.
-- Read `../../docs/TOOLS.md` for MCP tool coverage.
-- Read `../../docs/PYTHON_CLIENT.md` when scripting multi-step workflows.
-- Read `../../docs/WORKFLOWS.md` for the agent workflow engine (job-spec, `@refs`, variants, resume, receipts).
-- Read `../../docs/STREAM_SHORTS.md` for saved-plan stream-to-shorts review → render → package (no posting).
-- Read `../../docs/TOOLS.md` (Sound public join) and `../../docs/CLI_REFERENCE.md` for the thin `kinocut_sound` S12 surface — discover/invoke only; not full-episode sound completion.
-- Read `../../docs/RESCUE.md` for local diagnosis and content-preserving "fix this clip" work.
-- Read `../../docs/POST_RESCUE_FEATURES.md` for semantic, visual, restorative, composition, autopilot, and egress planning.
-- Read `../../docs/AI_VIDEO_INSPECTION.md` for content-addressed ingest and deterministic temporal evidence.
-- Run `kino doctor` before media work that depends on FFmpeg, Hyperframes, image tools, or AI dependencies.
+- Read `../../README.md` for install and the safety contract.
+- Run `kino doctor` before FFmpeg / Hyperframes / AI extras.
 
 ## Choose A Surface
 

--- a/tests/test_product_finish.py
+++ b/tests/test_product_finish.py
@@ -1,0 +1,142 @@
+"""Product-finish: goal cutfile, timeline text, receipt diff, EDL apply, solver, session QC."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from kinocut.semantic.edl import EditOperation, approve_edl, create_edl, make_edit
+from kinocut.semantic.models import AnalyzerProvenance, SemanticTimeline, ShotSpan, SourceMedia, WordSpan
+from kinocut.te import (
+    compile_goal_to_cutfile,
+    diff_receipts,
+    render_approved_edl,
+    render_timeline_text,
+    session_open,
+    session_step,
+    solve_publish_cutfile,
+    validate_cutfile,
+    validate_publish_spec,
+)
+
+
+def test_goal_compiles_valid_vertical_cutfile() -> None:
+    cf = compile_goal_to_cutfile("15s vertical short with captions", source="media/hero.mp4")
+    validate_cutfile(cf)
+    ops = [o["op"] for o in cf["ops"]]
+    assert "trim" in ops
+    assert "resize" in ops
+    assert "add_text" in ops
+    assert any(o.get("duration") == 15 for o in cf["ops"] if o["op"] == "trim")
+
+
+def test_timeline_text_from_spans() -> None:
+    view = render_timeline_text(
+        spans=[
+            {"kind": "shot", "start": 0, "end": 2, "label": "A"},
+            {"kind": "silence", "start": 2, "end": 2.4, "label": "gap"},
+        ]
+    )
+    assert view["row_count"] == 2
+    assert "t=0.00-2.00" in view["text"]
+    assert "[shot]" in view["text"]
+
+
+def test_receipt_diff_and_replay_plan() -> None:
+    left = {"artifact_kind": "workflow_receipt", "ops": ["trim", "resize"]}
+    right = {"artifact_kind": "workflow_receipt", "ops": ["trim", "add_text"]}
+    diff = diff_receipts(left, right)
+    assert diff["added"] == ["add_text"]
+    assert diff["removed"] == ["resize"]
+    assert diff["replay"]["dry_run"] is True
+    assert diff["changed"] is True
+
+
+def test_constraint_solver_passes_publish_spec() -> None:
+    solved = solve_publish_cutfile("youtube_shorts", source="media/in.mp4", source_duration=120)
+    assert solved["ops"]
+    proof = solved["publish_proof"]
+    assert proof["verdict"] == "pass"
+    assert proof["blocked"] is False
+    resize = next(o for o in solved["ops"] if o["op"] == "resize")
+    check = validate_publish_spec(
+        "youtube_shorts",
+        duration_seconds=60,
+        height=resize["height"],
+        width=resize["width"],
+    )
+    assert check["verdict"] == "pass"
+
+
+def test_session_step_measures_qc_without_caller_score(tmp_path: Path, sample_video: str) -> None:
+    opened = session_open(str(tmp_path / "sess"), "improve")
+    stepped = session_step(opened["path"], action="qc", input_path=sample_video)
+    assert stepped["current_score"] is not None
+    assert stepped["measured_improvement"] == pytest.approx(0.0)
+
+
+def _tiny_timeline() -> SemanticTimeline:
+    source = SourceMedia.create(content_sha256="sha256:" + "a" * 64, duration_seconds=4)
+    provenance = AnalyzerProvenance(
+        analyzer_id="fixture.timeline",
+        analyzer_version="1",
+        model_id="fixture",
+        model_sha256="sha256:" + "b" * 64,
+        determinism_scope="fixture",
+    )
+    shots = (
+        ShotSpan.create(source=source, start_seconds=0, end_seconds=2, confidence=1, provenance=provenance, ordinal=0),
+        ShotSpan.create(source=source, start_seconds=2, end_seconds=4, confidence=1, provenance=provenance, ordinal=1),
+    )
+    filler = WordSpan.create(
+        source=source,
+        start_seconds=1,
+        end_seconds=1.5,
+        confidence=1,
+        provenance=provenance,
+        text="um",
+        disfluency="filler",
+    )
+    return SemanticTimeline.create(source=source, words=(filler,), shots=shots)
+
+
+def test_edl_apply_requires_approval() -> None:
+    timeline = _tiny_timeline()
+    edit = make_edit(operation=EditOperation.DELETE, target_span=timeline.words[0], rationale="drop filler")
+    edl = create_edl(timeline, edits=(edit,))
+    with pytest.raises(Exception):
+        render_approved_edl(
+            "missing.mp4",
+            edl=edl.model_dump(mode="json"),
+            approval={"edl_sha256": edl.edl_sha256, "selected_edit_ids": [], "approval_sha256": "sha256:" + "0" * 64},
+            output_path="/tmp/out.mp4",
+        )
+
+
+def test_edl_apply_renders_keep_ranges(tmp_path: Path, sample_video: str) -> None:
+    timeline = _tiny_timeline()
+    edit = make_edit(operation=EditOperation.DELETE, target_span=timeline.words[0], rationale="drop filler")
+    edl = create_edl(timeline, edits=(edit,))
+    approval = approve_edl(edl, selected_edit_ids=(edit.edit_id,))
+    out = tmp_path / "edl.mp4"
+    result = render_approved_edl(
+        sample_video,
+        edl=edl.model_dump(mode="json"),
+        approval=approval.model_dump(mode="json"),
+        output_path=str(out),
+        source_duration=4.0,
+    )
+    assert Path(result["output_path"]).is_file()
+    assert result["applied_edit_ids"] == [edit.edit_id]
+    assert result["keep_segments"]
+
+
+def test_goal_cutfile_is_what_intent_would_attach() -> None:
+    from kinocut.intent import route_intent
+
+    plan = route_intent("repurpose")
+    cut = compile_goal_to_cutfile("15 second vertical reel")
+    assert plan.verb == "repurpose"
+    assert cut["artifact_kind"] == "cutfile"
+    assert cut["ops"]

--- a/tests/test_shorts_package.py
+++ b/tests/test_shorts_package.py
@@ -91,7 +91,7 @@ def test_package_fails_closed_without_approve(tmp_path):
 def test_package_writes_both_platform_packages(tmp_path):
     plan = _plan_with_renders(tmp_path)
     review_shorts_plan(plan, candidate_id="candidate_01", decision="approve")
-    result = package_approved_candidate(plan, candidate_id="candidate_01")
+    result = package_approved_candidate(plan, candidate_id="candidate_01", allow_fail=True)
     assert result["status"] == "packaged"
     assert result["external_posting"] is False
     assert len(result["packages"]) == 2


### PR DESCRIPTION
Forgejo SoT PR. See git.kyanitelabs.tech kinocut pulls for full notes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/kinocut/pr/441"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789186390&installation_model_id=20207&pr_number=441&repository=KyaniteLabs%2Fkinocut&return_to=https%3A%2F%2Fgithub.com%2FKyaniteLabs%2Fkinocut%2Fpull%2F441&signature=7eea0550132c8bd65c36a5eb62dff58d25e409586b38e26c2c8163153df05ffa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added goal-based video planning, cutfile generation, timeline views, receipt comparisons, and publish validation.
  * Added human-approved EDL rendering and measured quality checks during editing sessions.
  * Expanded workflow tools for planning, review, validation, publishing, and session management.
  * Workflow inspections can now compare receipts and highlight changes.
* **Improvements**
  * Repurposing now applies a quality threshold by default.
  * CLI supports verbose and file-based debug logging.
  * Shorts packaging can optionally continue after quality-gate failures while recording results.
* **Documentation**
  * Updated release information, product status, workflow guidance, and CLI references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->