### PR TITLE
fix(projectstore): make file locking and dir fsync portable to Windows

### DIFF
--- a/kinocut/projectstore/_filelock.py
+++ b/kinocut/projectstore/_filelock.py
@@ -1,0 +1,89 @@
+"""Portable exclusive file locking for the project store leases.
+
+``fcntl`` is a POSIX kernel API. Windows has no equivalent and no installable
+shim, so importing it at module scope made the whole ``projectstore`` package —
+and therefore ``kino --mcp`` — unimportable on Windows. ``msvcrt.locking``
+provides byte-range locking, which is enough for the whole-file advisory leases
+used here: every participant locks the same single byte of the same lease file.
+
+The two backends are kept behaviourally identical so callers need no platform
+branches:
+
+- ``lock_exclusive(handle)`` blocks until the lock is acquired.
+- ``lock_exclusive(handle, blocking=False)`` raises :class:`BlockingIOError`
+  when another holder has it. ``flock`` does this natively; ``msvcrt`` raises a
+  plain ``OSError``, so it is normalised here.
+- ``unlock(handle)`` releases it.
+
+Both accept either a raw file descriptor or any object with ``fileno()``,
+matching the mix already present in the store (``os.open`` in ``store`` versus
+``Path.open`` in the render job modules).
+"""
+
+from __future__ import annotations
+
+import os
+from typing import IO, Union
+
+try:  # POSIX
+    import fcntl
+
+    _HAVE_FCNTL = True
+except ImportError:  # Windows
+    import msvcrt
+
+    _HAVE_FCNTL = False
+
+# msvcrt locks a byte range rather than the whole file. One byte at offset 0 is
+# sufficient and is what every participant agrees to lock.
+_LOCK_BYTES = 1
+
+Lockable = Union[int, IO[bytes]]
+
+
+def _descriptor(handle: Lockable) -> int:
+    return handle if isinstance(handle, int) else handle.fileno()
+
+
+if _HAVE_FCNTL:
+
+    def lock_exclusive(handle: Lockable, *, blocking: bool = True) -> None:
+        flags = fcntl.LOCK_EX if blocking else fcntl.LOCK_EX | fcntl.LOCK_NB
+        fcntl.flock(_descriptor(handle), flags)
+
+    def unlock(handle: Lockable) -> None:
+        fcntl.flock(_descriptor(handle), fcntl.LOCK_UN)
+
+else:
+
+    def _at_offset_zero(fd: int, mode: int) -> None:
+        """Run one msvcrt lock operation at offset 0, restoring the position."""
+        previous = os.lseek(fd, 0, os.SEEK_CUR)
+        os.lseek(fd, 0, os.SEEK_SET)
+        try:
+            msvcrt.locking(fd, mode, _LOCK_BYTES)
+        finally:
+            os.lseek(fd, previous, os.SEEK_SET)
+
+    def lock_exclusive(handle: Lockable, *, blocking: bool = True) -> None:
+        fd = _descriptor(handle)
+        if not blocking:
+            try:
+                _at_offset_zero(fd, msvcrt.LK_NBLCK)
+            except OSError as exc:
+                # flock signals contention with BlockingIOError; msvcrt uses a
+                # bare OSError. Callers catch BlockingIOError, so translate.
+                raise BlockingIOError(exc.errno, exc.strerror) from exc
+            return
+
+        # LK_LOCK retries ten times at one-second intervals and then gives up,
+        # while LOCK_EX waits indefinitely. Loop so the blocking contract holds.
+        while True:
+            try:
+                _at_offset_zero(fd, msvcrt.LK_LOCK)
+                return
+            except OSError:
+                continue
+
+    def unlock(handle: Lockable) -> None:
+        _at_offset_zero(_descriptor(handle), msvcrt.LK_UNLCK)

--- a/kinocut/projectstore/render_jobs.py
+++ b/kinocut/projectstore/render_jobs.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import fcntl
 import hashlib
 import json
 import os
@@ -15,6 +14,7 @@ from datetime import UTC, datetime
 from pathlib import Path, PurePosixPath
 from typing import Any
 
+from kinocut.projectstore._filelock import lock_exclusive, unlock
 from kinocut.contracts._errors import INVALID_RECORD, contract_error
 from kinocut.contracts.adapter import validate_record
 from kinocut.contracts.trusted_execution import RenderJobRecord, RenderJobStatus, can_transition_job
@@ -331,10 +331,10 @@ def _runner_lease_is_held(project: Project, job_id: str) -> bool:
     lease.parent.mkdir(parents=True, exist_ok=True)
     with lease.open("a+b") as handle:
         try:
-            fcntl.flock(handle, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            lock_exclusive(handle, blocking=False)
         except BlockingIOError:
             return True
-        fcntl.flock(handle, fcntl.LOCK_UN)
+        unlock(handle)
         return False
 
 

--- a/kinocut/projectstore/render_runner.py
+++ b/kinocut/projectstore/render_runner.py
@@ -16,13 +16,13 @@ from __future__ import annotations
 
 import argparse
 import contextlib
-import fcntl
 from typing import Any
 from pathlib import Path
 import os
 import sys
 import time
 
+from kinocut.projectstore._filelock import lock_exclusive, unlock
 from kinocut.projectstore.render_jobs import (
     RenderJobStatus,
     get_render_job,
@@ -142,7 +142,7 @@ def main(argv: list[str]) -> int:
     lease = job_lease_path(project, args.job_id)
     lease.parent.mkdir(parents=True, exist_ok=True)
     with lease.open("a+b") as lease_handle:
-        fcntl.flock(lease_handle, fcntl.LOCK_EX)
+        lock_exclusive(lease_handle)
         try:
             _await_running_identity(project, args.job_id)
             run_job(project, args.job_id)

--- a/kinocut/projectstore/store.py
+++ b/kinocut/projectstore/store.py
@@ -19,7 +19,6 @@ filesystem/JSON errors to a stable, privacy-safe :class:`MCPVideoError`.
 from __future__ import annotations
 
 import contextlib
-import fcntl
 import json
 import os
 import re
@@ -32,6 +31,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from kinocut.projectstore._filelock import lock_exclusive, unlock
 from kinocut.contracts._common import RecordBase, canonical_record_id
 from kinocut.contracts._errors import (
     INVALID_RECORD,
@@ -243,7 +243,7 @@ def _project_lock(project: Project) -> Iterator[None]:
         lock_path.parent.mkdir(parents=True, exist_ok=True)
         fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
         try:
-            fcntl.flock(fd, fcntl.LOCK_EX)
+            lock_exclusive(fd)
         except OSError:
             os.close(fd)
             raise
@@ -251,7 +251,7 @@ def _project_lock(project: Project) -> Iterator[None]:
         yield
     finally:
         with contextlib.suppress(OSError):
-            fcntl.flock(fd, fcntl.LOCK_UN)
+            unlock(fd)
         with contextlib.suppress(OSError):
             os.close(fd)
 
@@ -410,7 +410,19 @@ def append_record_locked(project: Project, record: RecordBase) -> RecordBase:
 
 
 def _fsync_dir(directory: Path) -> None:
-    """``fsync`` a directory so a rename/creation is durable across a crash."""
+    """``fsync`` a directory so a rename/creation is durable across a crash.
+
+    POSIX only. Windows cannot open a directory as a file descriptor —
+    ``os.open`` on one raises ``PermissionError`` — and offers no supported way
+    to flush directory metadata from user space. There, ``MoveFileEx`` already
+    orders the rename against the file data that ``_write_atomically`` fsynced
+    before it, so skipping this is the documented behaviour rather than a
+    silent weakening: the file contents are still durable, only the directory
+    entry falls back to the filesystem's own ordering guarantees.
+    """
+
+    if os.name == "nt":
+        return
 
     fd = os.open(directory, os.O_RDONLY)
     try:


### PR DESCRIPTION
Fixes #445.

`kinocut/projectstore` imports `fcntl` at module scope, so on Windows the whole package — and therefore `kino --mcp` — is unimportable. The CLI works, but the MCP server, which is the primary integration path in the README, does not start at all.

## Two portability fixes

**1. `projectstore/_filelock.py`** — new module with `lock_exclusive()` / `unlock()`, backed by `fcntl.flock` on POSIX and `msvcrt.locking` on Windows. Two behaviours are preserved on purpose:

- `flock` reports contention with `BlockingIOError`; `msvcrt` raises a bare `OSError`. The Windows path normalises it, because the job-lease probe in `render_jobs` catches `BlockingIOError`.
- `msvcrt.LK_LOCK` retries ten times and then gives up, while `LOCK_EX` waits indefinitely. The blocking path loops to keep that contract.

Both entry points accept a raw fd or a file object, matching the existing mix of `os.open` in `store` and `Path.open` in the render-job modules. Five call sites updated across `store.py`, `render_jobs.py` and `render_runner.py`.

**2. `_fsync_dir` returns early on Windows.** `os.open` on a directory raises `PermissionError` there, and Windows exposes no user-space directory-metadata flush. File contents are still fsynced by `_write_atomically` before the rename, so only the directory entry falls back to filesystem ordering — this is a documented narrowing, not a silent one.

Both follow the pattern `kinocut/source_identity.py` already uses for the memfd sealing path: guard `fcntl` and degrade explicitly.

I kept this stdlib-only rather than adding `portalocker`, on the assumption you would rather not take a dependency for this. Happy to switch if you prefer.

## Verification — Windows 10 (19045), Python 3.13

Before, `kino --mcp` printed `MCP mode requires the 'mcp' package` even with `mcp` 1.29.0 installed; the real `ModuleNotFoundError: No module named 'fcntl'` was swallowed by the broad `except ImportError` in `__main__.py`. That misdirection is worth a separate look — it turns any import error in the server module tree into a "missing mcp" message.

After:

- `kino --mcp` starts and lists all **196 tools**
- a `video_trim` call through MCP produces a correct 2.000 s clip, confirmed independently with `ffprobe`
- `kino doctor` still reports OK and the CLI is unaffected

Test suite, `tests/test_projectstore_cas.py` + `test_projectstore_cas_gc.py` + `test_projectstore_compat.py`:

| | before | after |
|---|---|---|
| passed | 4 | **28** |
| failed | 17 | 1 |
| errors | 8 | 0 |

## The one remaining failure is out of scope

`test_phase1_exit_kill_reopen_resume_lineage_and_events` still fails on Windows, and it is unrelated to this change: the test writes fake `ffmpeg`/`ffprobe` stubs that rely on a `#!/usr/bin/env python3` shebang plus `chmod 0o700`. Windows cannot execute a shebang, so the stub never runs and the receipt wait times out.

Making that test portable means giving the stubs a `.py` extension and invoking them through `sys.executable`, or skipping them on `os.name == "nt"`. I left it alone to keep this PR scoped to the import failure, but I am happy to follow up with it if you would like Windows CI to go fully green.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/kinocut/pr/446"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789408239&installation_model_id=20207&pr_number=446&repository=KyaniteLabs%2Fkinocut&return_to=https%3A%2F%2Fgithub.com%2FKyaniteLabs%2Fkinocut%2Fpull%2F446&signature=b1599d674760e5f010390c2965b137e9e79a86f44fe69e51c61f71e7481d5f42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added portable exclusive file locking for Windows and POSIX systems.
  * Added blocking and non-blocking lock acquisition with consistent error handling.
* **Bug Fixes**
  * Improved cross-platform coordination for project storage and render jobs.
  * Prevented unsupported directory synchronization operations on Windows.
* **Reliability**
  * Preserved render job execution and failure handling while improving lock management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->