### PR TITLE
fix: surface real import failures in MCP mode entry

### DIFF
--- a/kinocut/__main__.py
+++ b/kinocut/__main__.py
@@ -4,14 +4,23 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 import sys
 from collections.abc import Callable
 from typing import Any
+
+from rich.markup import escape
 
 from .cli.parser import build_parser
 from .cli.formatting import _format_error, console, err_console
 
 logger = logging.getLogger(__name__)
+
+# Import failures rendered for the console must not leak filesystem paths.
+# Any whitespace-delimited token containing a path separator collapses to a
+# placeholder; module names ("fcntl", "kinocut.server") carry no separators
+# and survive untouched.
+_PATH_TOKEN = re.compile(r"\S*[/\\]\S*")
 
 
 def _import_mcp_server() -> Any:
@@ -20,12 +29,20 @@ def _import_mcp_server() -> Any:
     return mcp
 
 
+def _render_import_failure(exc: ImportError) -> str:
+    """Render an import failure as literal text, free of paths and rich markup."""
+
+    text = _PATH_TOKEN.sub("[path]", f"{type(exc).__name__}: {exc}")
+    return escape(text)
+
+
 def _run_mcp_mode(import_server: Callable[[], Any] = _import_mcp_server) -> None:
     """Start the MCP server, reporting import failures under their real cause.
 
-    Only the genuine absence of the ``mcp`` package keeps the install hint.
-    Any other import failure in the server tree previously masqueraded as a
-    missing ``mcp`` package (#445), hiding the real error from users.
+    Only the genuine absence of the ``mcp`` package (a ``ModuleNotFoundError``)
+    keeps the install hint. Any other import failure in the server tree
+    previously masqueraded as a missing ``mcp`` package (#445), hiding the real
+    error from users.
     """
 
     try:
@@ -33,12 +50,12 @@ def _run_mcp_mode(import_server: Callable[[], Any] = _import_mcp_server) -> None
         mcp.run()
     except ImportError as exc:
         missing = getattr(exc, "name", None)
-        if missing == "mcp" or (missing or "").startswith("mcp."):
+        if isinstance(exc, ModuleNotFoundError) and (missing == "mcp" or str(missing).startswith("mcp.")):
             err_console.print(
                 "[red]MCP mode requires the 'mcp' package.[/red]\nInstall with: [bold]pip install kinocut[/bold]",
             )
         else:
-            err_console.print(f"[red]MCP mode failed to start:[/red] {type(exc).__name__}: {exc}")
+            err_console.print(f"[red]MCP mode failed to start:[/red] {_render_import_failure(exc)}")
         sys.exit(1)
 
 

--- a/kinocut/__main__.py
+++ b/kinocut/__main__.py
@@ -5,11 +5,41 @@ from __future__ import annotations
 import json
 import logging
 import sys
+from collections.abc import Callable
+from typing import Any
 
 from .cli.parser import build_parser
 from .cli.formatting import _format_error, console, err_console
 
 logger = logging.getLogger(__name__)
+
+
+def _import_mcp_server() -> Any:
+    from .server import mcp
+
+    return mcp
+
+
+def _run_mcp_mode(import_server: Callable[[], Any] = _import_mcp_server) -> None:
+    """Start the MCP server, reporting import failures under their real cause.
+
+    Only the genuine absence of the ``mcp`` package keeps the install hint.
+    Any other import failure in the server tree previously masqueraded as a
+    missing ``mcp`` package (#445), hiding the real error from users.
+    """
+
+    try:
+        mcp = import_server()
+        mcp.run()
+    except ImportError as exc:
+        missing = getattr(exc, "name", None)
+        if missing == "mcp" or (missing or "").startswith("mcp."):
+            err_console.print(
+                "[red]MCP mode requires the 'mcp' package.[/red]\nInstall with: [bold]pip install kinocut[/bold]",
+            )
+        else:
+            err_console.print(f"[red]MCP mode failed to start:[/red] {type(exc).__name__}: {exc}")
+        sys.exit(1)
 
 
 def _rewrite_namespaced_argv(argv: list[str]) -> list[str]:
@@ -137,15 +167,7 @@ def main() -> None:
         return
 
     if args.mcp or args.command is None:
-        try:
-            from .server import mcp
-
-            mcp.run()
-        except ImportError:
-            err_console.print(
-                "[red]MCP mode requires the 'mcp' package.[/red]\nInstall with: [bold]pip install kinocut[/bold]",
-            )
-            sys.exit(1)
+        _run_mcp_mode()
         return
 
     from .cli.runner import resolve_use_json

--- a/tests/test_mcp_entry.py
+++ b/tests/test_mcp_entry.py
@@ -85,3 +85,36 @@ def test_main_dispatches_mcp_mode(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr("sys.argv", ["kino", "--mcp"])
     entry.main()
     assert calls == [1]
+
+
+def test_plain_import_error_with_mcp_name_surfaces_real_error(printed: _Recorder) -> None:
+    """Only ModuleNotFoundError means absence; a crafted ImportError('name=mcp') does not."""
+
+    def _boom() -> None:
+        raise ImportError("custom import failure", name="mcp")
+
+    with pytest.raises(SystemExit):
+        entry._run_mcp_mode(import_server=_boom)
+    assert any("MCP mode failed to start" in line for line in printed.lines)
+    assert not any("requires the 'mcp' package" in line for line in printed.lines)
+
+
+def test_path_bearing_import_error_is_redacted(printed: _Recorder) -> None:
+    def _boom() -> None:
+        raise ImportError("cannot load /Users/secret/codec/lib.py on this platform")
+
+    with pytest.raises(SystemExit):
+        entry._run_mcp_mode(import_server=_boom)
+    joined = "\n".join(printed.lines)
+    assert "/Users/secret" not in joined
+    assert "[path]" in joined
+
+
+def test_markup_in_import_error_is_neutralized(printed: _Recorder) -> None:
+    def _boom() -> None:
+        raise ImportError("use [bold]red[/bold] tags carefully")
+
+    with pytest.raises(SystemExit):
+        entry._run_mcp_mode(import_server=_boom)
+    joined = "\n".join(printed.lines)
+    assert "[bold]red[/bold]" not in joined  # escaped to literal \[bold]...

--- a/tests/test_mcp_entry.py
+++ b/tests/test_mcp_entry.py
@@ -1,0 +1,87 @@
+"""MCP-mode entry error honesty (#448, second half of #445).
+
+A broad ``except ImportError`` used to report every server-tree import failure
+as a missing ``mcp`` package. These tests pin the two failure classes: the
+genuine absence of ``mcp`` keeps the install hint; anything else surfaces its
+real cause.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import kinocut.__main__ as entry
+
+
+class _Recorder:
+    def __init__(self) -> None:
+        self.lines: list[str] = []
+
+    def __call__(self, *args: object, **_kwargs: object) -> None:
+        self.lines.append("".join(str(arg) for arg in args))
+
+
+@pytest.fixture()
+def printed(monkeypatch: pytest.MonkeyPatch) -> _Recorder:
+    recorder = _Recorder()
+    monkeypatch.setattr(entry.err_console, "print", recorder)
+    return recorder
+
+
+def test_missing_mcp_package_keeps_install_hint(printed: _Recorder) -> None:
+    def _boom() -> None:
+        raise ModuleNotFoundError("No module named 'mcp'", name="mcp")
+
+    with pytest.raises(SystemExit) as excinfo:
+        entry._run_mcp_mode(import_server=_boom)
+    assert excinfo.value.code == 1
+    assert any("MCP mode requires the 'mcp' package" in line for line in printed.lines)
+
+
+def test_missing_mcp_submodule_keeps_install_hint(printed: _Recorder) -> None:
+    def _boom() -> None:
+        raise ModuleNotFoundError("No module named 'mcp.server'", name="mcp.server")
+
+    with pytest.raises(SystemExit):
+        entry._run_mcp_mode(import_server=_boom)
+    assert any("MCP mode requires the 'mcp' package" in line for line in printed.lines)
+
+
+def test_other_missing_module_surfaces_real_error(printed: _Recorder) -> None:
+    """The #445 scenario: a POSIX-only module fails to import on Windows."""
+
+    def _boom() -> None:
+        raise ModuleNotFoundError("No module named 'fcntl'", name="fcntl")
+
+    with pytest.raises(SystemExit) as excinfo:
+        entry._run_mcp_mode(import_server=_boom)
+    assert excinfo.value.code == 1
+    assert any("MCP mode failed to start" in line and "fcntl" in line for line in printed.lines)
+    assert not any("requires the 'mcp' package" in line for line in printed.lines)
+
+
+def test_nameless_import_error_surfaces_real_error(printed: _Recorder) -> None:
+    def _boom() -> None:
+        raise ImportError("cannot import name 'tool' from 'kinocut.server'")
+
+    with pytest.raises(SystemExit) as excinfo:
+        entry._run_mcp_mode(import_server=_boom)
+    assert excinfo.value.code == 1
+    assert any("MCP mode failed to start" in line and "cannot import name" in line for line in printed.lines)
+
+
+def test_non_import_errors_from_server_propagate() -> None:
+    class _Server:
+        def run(self) -> None:
+            raise RuntimeError("server crashed")
+
+    with pytest.raises(RuntimeError, match="server crashed"):
+        entry._run_mcp_mode(import_server=_Server)
+
+
+def test_main_dispatches_mcp_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[int] = []
+    monkeypatch.setattr(entry, "_run_mcp_mode", lambda: calls.append(1))
+    monkeypatch.setattr("sys.argv", ["kino", "--mcp"])
+    entry.main()
+    assert calls == [1]


### PR DESCRIPTION
Closes #448 (spec #447, second half of #445).

## What this does

`kino --mcp` no longer reports every server-tree import failure as a missing `mcp` package. Only the genuine absence of the `mcp` distribution (or its submodules) keeps the install hint; any other import failure now prints the real cause — e.g. `MCP mode failed to start: ModuleNotFoundError: No module named 'fcntl'` — and exits 1. The lazy import structure, the CLI path, and non-import failures from the server loop behave exactly as before.

This is the fix that would have made #445 self-diagnosing on Windows instead of a misattributed packaging report.

## Verification

- 6 new tests in `tests/test_mcp_entry.py`: hint preserved for `mcp`/`mcp.*` absence, real error surfaced for other missing modules and nameless ImportErrors, non-ImportError propagation preserved, and main() wiring.
- Full suite: 4832 passed, 171 skipped.
- `ruff check` + `ruff format --check` clean; canonical `kinocut.Client is mcp_video.Client` check passes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/kinocut/pr/454"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789413400&installation_model_id=20207&pr_number=454&repository=KyaniteLabs%2Fkinocut&return_to=https%3A%2F%2Fgithub.com%2FKyaniteLabs%2Fkinocut%2Fpull%2F454&signature=d69f67109456f98b8a3f4d9dbe2f9c64d44af5c3fa35b00335fb173324babd2c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MCP startup error messages by distinguishing missing installations from other import and server errors.
  * Preserved installation guidance only when the MCP package is unavailable.
  * Displayed clearer details for unrelated startup failures.

* **Tests**
  * Added coverage for MCP startup error handling and command dispatch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->