### PR TITLE
fix: doctor verifies the MCP server import path

### DIFF
--- a/kinocut/doctor.py
+++ b/kinocut/doctor.py
@@ -24,6 +24,7 @@ WhichFn = Callable[[str], str | None]
 VersionRunner = Callable[[list[str]], str | None]
 FindSpecFn = Callable[[str], Any]
 PackageVersionFn = Callable[[str], str | None]
+ImportModuleFn = Callable[[str], Any]
 
 PYTHON_313_UPSCALE_BACKEND_HINT = (
     "Real-ESRGAN/BasicSR are skipped on Python 3.13+ because BasicSR currently fails to build there. "
@@ -471,15 +472,48 @@ def _rescue_summary(checks: list[dict[str, Any]]) -> dict[str, Any]:
     }
 
 
+def _check_mcp_server_import(import_module: ImportModuleFn) -> dict[str, Any]:
+    """Import the MCP server tool tree so 'doctor OK' covers ``kino --mcp`` (#445).
+
+    The package checks prove ``mcp`` exists on disk, not that the server tree
+    imports. A platform-specific import failure (a POSIX-only module, a broken
+    optional dependency) left ``kino --mcp`` dead while doctor reported OK —
+    so this check exercises the same import the entry point performs.
+    """
+
+    try:
+        import_module("kinocut.server")
+    except Exception as exc:  # the failure is the signal; doctor must never crash on it
+        return {
+            "name": "mcp-server-import",
+            "category": "core",
+            "required": True,
+            "ok": False,
+            "detail": f"{type(exc).__name__}: {exc}",
+            "install_hint": (
+                "Run 'kino --mcp' to see the full error; usually a broken install "
+                "(pip install --force-reinstall kinocut) or a platform-specific dependency issue."
+            ),
+        }
+    return {
+        "name": "mcp-server-import",
+        "category": "core",
+        "required": True,
+        "ok": True,
+        "detail": "kinocut.server imports cleanly",
+    }
+
+
 def run_diagnostics(
     *,
     which: WhichFn = shutil.which,
     version_runner: VersionRunner = _command_version,
     find_spec: FindSpecFn = importlib.util.find_spec,
     package_version: PackageVersionFn = _package_version,
+    import_module: ImportModuleFn = importlib.import_module,
 ) -> dict[str, Any]:
     """Return a structured report for core and optional integration dependencies."""
-    checks = [_check_mcp_video(find_spec, package_version)]
+    checks = [_check_mcp_video(find_spec, package_version), _check_mcp_server_import(import_module)]
     with ThreadPoolExecutor(max_workers=min(8, len(COMMAND_CHECKS))) as pool:
         checks.extend(pool.map(lambda definition: _check_command(definition, which, version_runner), COMMAND_CHECKS))
     checks.extend(

--- a/kinocut/doctor.py
+++ b/kinocut/doctor.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import importlib.metadata
 import importlib.util
+import logging
 import os
 import platform
 import re
@@ -19,6 +20,9 @@ from concurrent.futures import ThreadPoolExecutor
 from .errors import HyperframesNotFoundError
 from .defaults import MIN_FFMPEG_VERSION, MIN_FFMPEG_VERSION_HARD
 from .limits import DOCTOR_COMMAND_TIMEOUT
+
+logger = logging.getLogger(__name__)
+
 
 WhichFn = Callable[[str], str | None]
 VersionRunner = Callable[[list[str]], str | None]
@@ -484,6 +488,7 @@ def _check_mcp_server_import(import_module: ImportModuleFn) -> dict[str, Any]:
     try:
         import_module("kinocut.server")
     except Exception as exc:  # the failure is the signal; doctor must never crash on it
+        logger.warning("MCP server import check failed for kinocut.server: %s", exc)
         return {
             "name": "mcp-server-import",
             "category": "core",

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -365,3 +365,82 @@ def test_cli_doctor_text_outputs_summary():
     assert "ffmpeg" in result.stdout
     assert "hyperframes" in result.stdout
     assert "openai-whisper" in result.stdout
+
+
+def test_run_diagnostics_includes_mcp_server_import_check():
+    from mcp_video.doctor import run_diagnostics
+
+    def fake_which(name: str) -> str | None:
+        return f"/usr/bin/{name}" if name in {"ffmpeg", "ffprobe"} else None
+
+    def fake_version(command: list[str]) -> str | None:
+        return f"{command[0]} version test"
+
+    imported: list[str] = []
+
+    def fake_import_module(name: str) -> object:
+        imported.append(name)
+        return object()
+
+    report = run_diagnostics(
+        which=fake_which,
+        version_runner=fake_version,
+        find_spec=lambda name: ModuleSpec(name, loader=None),
+        package_version=lambda name: "1.0.0",
+        import_module=fake_import_module,
+    )
+
+    checks = {check["name"]: check for check in report["checks"]}
+    assert imported == ["kinocut.server"]
+    assert checks["mcp-server-import"]["ok"] is True
+    assert checks["mcp-server-import"]["required"] is True
+    assert report["summary"]["required_ok"] is True
+
+
+def test_server_import_failure_breaks_required_summary():
+    """The #445 scenario: doctor must not report OK while --mcp is dead."""
+
+    from mcp_video.doctor import run_diagnostics
+
+    def fake_which(name: str) -> str | None:
+        return f"/usr/bin/{name}" if name in {"ffmpeg", "ffprobe"} else None
+
+    def fake_version(command: list[str]) -> str | None:
+        return f"{command[0]} version test"
+
+    def broken_import(name: str) -> object:
+        raise ModuleNotFoundError("No module named 'fcntl'", name="fcntl")
+
+    report = run_diagnostics(
+        which=fake_which,
+        version_runner=fake_version,
+        find_spec=lambda name: ModuleSpec(name, loader=None),
+        package_version=lambda name: "1.0.0",
+        import_module=broken_import,
+    )
+
+    checks = {check["name"]: check for check in report["checks"]}
+    assert checks["mcp-server-import"]["ok"] is False
+    assert "fcntl" in checks["mcp-server-import"]["detail"]
+    assert checks["mcp-server-import"]["install_hint"]
+    assert report["summary"]["required_ok"] is False
+    assert "mcp-server-import" in report["summary"]["missing_required"]
+
+
+def test_server_import_check_survives_arbitrary_failure():
+    from mcp_video.doctor import _check_mcp_server_import
+
+    def exploding(name: str) -> object:
+        raise RuntimeError("boom during import")
+
+    check = _check_mcp_server_import(exploding)
+    assert check["ok"] is False
+    assert "RuntimeError" in check["detail"]
+
+
+def test_server_import_check_ok_path():
+    from mcp_video.doctor import _check_mcp_server_import
+
+    check = _check_mcp_server_import(lambda name: object())
+    assert check["ok"] is True
+    assert check["required"] is True

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -427,15 +427,17 @@ def test_server_import_failure_breaks_required_summary():
     assert "mcp-server-import" in report["summary"]["missing_required"]
 
 
-def test_server_import_check_survives_arbitrary_failure():
+def test_server_import_check_survives_arbitrary_failure(caplog):
     from mcp_video.doctor import _check_mcp_server_import
 
     def exploding(name: str) -> object:
         raise RuntimeError("boom during import")
 
-    check = _check_mcp_server_import(exploding)
+    with caplog.at_level("WARNING", logger="mcp_video.doctor"):
+        check = _check_mcp_server_import(exploding)
     assert check["ok"] is False
     assert "RuntimeError" in check["detail"]
+    assert "boom during import" in caplog.text
 
 
 def test_server_import_check_ok_path():


### PR DESCRIPTION
Closes #449 (spec #447).

## What this does

`kino doctor` gains a required core check, `mcp-server-import`, that actually imports the MCP server tool tree — the same import `kino --mcp` performs. On a machine in the #445 state (server tree unimportable), doctor now names `mcp-server-import` in its missing-required summary instead of reporting OK. The check is failure-isolated (any exception becomes a failing check, never a doctor crash) and reports the real error class plus a remediation hint. The import probe is injectable (`import_module`) like the other diagnostic seams.

Cost on a healthy machine: one `kinocut.server` import, measured at ~0.6s.

## Verification

- 4 new tests in `tests/test_doctor.py`: ok path (asserts exactly `kinocut.server` is probed), the #445 scenario (missing POSIX module breaks `required_ok` and lands in `missing_required`), arbitrary-failure isolation, and unit coverage of both check branches.
- Full suite: 4830 passed, 171 skipped; `ruff check` + `format --check` clean; canonical client-import check passes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/kinocut/pr/455"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789413894&installation_model_id=20207&pr_number=455&repository=KyaniteLabs%2Fkinocut&return_to=https%3A%2F%2Fgithub.com%2FKyaniteLabs%2Fkinocut%2Fpull%2F455&signature=e91c22defe71bc4fe6c3ca0d0b4f06def7a6fd14fb67334e1fe9d480b5a1c24e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a diagnostic check confirming that the MCP server loads successfully.
  * Diagnostics now provide remediation details when the server cannot be imported.

* **Bug Fixes**
  * Import errors and unexpected failures are reported cleanly without interrupting the diagnostic process.

* **Tests**
  * Added coverage for successful imports, missing modules, and unexpected import failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->