### PR TITLE
test: skip shebang-stub tests explicitly on Windows

### DIFF
--- a/tests/test_c2pa_provenance.py
+++ b/tests/test_c2pa_provenance.py
@@ -24,6 +24,10 @@ def _fake_c2patool(
     verify_failure: bool = False,
     verify_payload: object = _DEFAULT_VERIFY_PAYLOAD,
 ) -> Path:
+    if os.name == "nt":
+        pytest.skip(
+            "shebang executable test stubs cannot run on Windows (see #450); interpreter-invoked stubs land with the Windows CI job (#452)"
+        )
     script = path / "fake-c2patool"
     success_payload = (
         {

--- a/tests/test_projectstore_compat.py
+++ b/tests/test_projectstore_compat.py
@@ -257,6 +257,10 @@ sys.exit(0)
 
 
 def _install_fake_binaries(bin_dir):
+    if os.name == "nt":
+        pytest.skip(
+            "shebang executable test stubs cannot run on Windows (see #450); interpreter-invoked stubs land with the Windows CI job (#452)"
+        )
     bin_dir.mkdir(parents=True, exist_ok=True)
     (bin_dir / "ffprobe").write_text(_FAKE_FFPROBE)
     (bin_dir / "ffmpeg").write_text(_FAKE_FFMPEG)

--- a/tests/test_projectstore_render_runner.py
+++ b/tests/test_projectstore_render_runner.py
@@ -20,6 +20,8 @@ import subprocess
 import sys
 import time
 
+import pytest
+
 from kinocut.projectstore import (
     append_revision,
     create_edit_project,
@@ -119,6 +121,10 @@ sys.exit(0)
 
 def _install_fake_binaries(bin_dir):
     """Write executable fake ``ffprobe``/``ffmpeg`` into ``bin_dir``; return its path."""
+    if os.name == "nt":
+        pytest.skip(
+            "shebang executable test stubs cannot run on Windows (see #450); interpreter-invoked stubs land with the Windows CI job (#452)"
+        )
     bin_dir.mkdir(parents=True, exist_ok=True)
     (bin_dir / "ffprobe").write_text(_FAKE_FFPROBE)
     (bin_dir / "ffmpeg").write_text(_FAKE_FFMPEG)


### PR DESCRIPTION
Part of #450 (spec #447) — the stub-portability half; the seam-fix half lands with PR #446.

## What this does

The three test files that build fake executables (ffmpeg/ffprobe shims in the projectstore render-runner and compat suites, the c2patool fake) write shebang scripts made executable with `chmod`. Windows cannot execute a shebang script, so on Windows those tests error or hang instead of failing meaningfully. Each stub-creation helper now `pytest.skip`s on `os.name == 'nt'` with a reason pointing at #450, so every future consumer of the helpers inherits the skip automatically — a red test on any platform always means a real defect, and every skip is visible and intentional.

Interpreter-invoked stubs (the better long-term fix) are deferred to the Windows CI job (#452) where they can actually be verified on-platform rather than shipped blind.

## Verification

- The three files on macOS: 55 passed, 1 skipped — the one skip is the pre-existing real-c2patool absence, i.e. **no new skips on POSIX**.
- Full suite: 4826 passed, 171 skipped; ruff check + format clean; canonical client-import check passes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/kinocut/pr/456"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789414395&installation_model_id=20207&pr_number=456&repository=KyaniteLabs%2Fkinocut&return_to=https%3A%2F%2Fgithub.com%2FKyaniteLabs%2Fkinocut%2Fpull%2F456&signature=6cf1762af9768ddb16aa02f4cedf154feadcbf53e6a568226545a0e07c167ad6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->