### PR TITLE
release: Kinocut 1.15.0 (honest diagnostics + community-driven release)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,23 @@ This project follows a simple release-note style:
 
 ## Unreleased
 
+## 1.15.0 - 2026-08-15
+
+### Added
+- **doctor `mcp-server-import` check:** `kino doctor` now imports the MCP server tool tree as a required core check, so it can no longer report OK while `kino --mcp` cannot start (#449, surfaced by #445).
+
+### Changed
+- **Honest MCP startup failures:** `kino --mcp` keeps the "requires the 'mcp' package" hint only when the `mcp` distribution is genuinely absent; any other server-tree import failure now prints its real cause — filesystem paths redacted, markup-safe — with a non-zero exit (#448, the second half of #445).
+- **Windows test portability groundwork:** shebang-executable test stubs (fake ffmpeg/ffprobe, c2patool) skip explicitly on Windows instead of erroring at collection; interpreter-invoked stubs land with the Windows CI job (#450, partial).
+
+### Compatibility
+- `mcp-video==1.6.11` installs `kinocut==1.15.0`.
+- Published surface stays **196 MCP tools / 167 CLI commands**.
+
+### Acknowledgements
+- [@gerardoscaglia-creator](https://github.com/gerardoscaglia-creator) filed the Windows MCP-mode investigation ([#445](https://github.com/KyaniteLabs/kinocut/issues/445)) — the root-cause traceback in it exposed both diagnostics gaps fixed above — and has the portable file-locking fix ([#446](https://github.com/KyaniteLabs/kinocut/pull/446)) in review. Every fix in this release traces to that report. Bug reports with reproduction steps are contributions; thank you.
+- Kinocut's external community predates this release: betsmayank's merged Hyperframes no-TTY fix ([#361](https://github.com/KyaniteLabs/kinocut/pull/361)), austinwmson's `remotion_still` props report ([#306](https://github.com/KyaniteLabs/kinocut/issues/306)), ismailkattakath's self-host reference stack ([#432](https://github.com/KyaniteLabs/kinocut/issues/432)), and early PRs from Dodothereal and OyaAIProd. All of them shaped the product.
+
 ## 1.14.1 - 2026-08-13
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 <p align="center">
   <a href="#see-it-work">Demo</a> &bull;
   <a href="#status-and-releases">Status</a> &bull;
-  <a href="#whats-in-1141-latest-release">1.14.1</a> &bull;
+  <a href="#whats-in-1141-latest-release">1.15.0</a> &bull;
   <a href="#changelog">Changelog</a> &bull;
   <a href="#beyond-1141-draft--gated">Beyond</a> &bull;
   <a href="#installation">Install</a> &bull;
@@ -70,7 +70,7 @@
 | | |
 | --- | --- |
 | **Also known as** | `kino` (CLI); formerly **mcp-video** / `mcp_video` |
-| **Latest published release** | **[1.14.1](https://github.com/KyaniteLabs/kinocut/releases/tag/v1.14.1)** (2026-08-13) |
+| **Latest published release** | **[1.15.0](https://github.com/KyaniteLabs/kinocut/releases/tag/v1.15.0)** (2026-08-15) |
 | **Product site** | [kinocut.dev](https://kinocut.dev/) |
 | **PyPI** | [`kinocut`](https://pypi.org/project/kinocut/) |
 | **MCP Registry** | [`io.github.KyaniteLabs/kinocut`](https://registry.modelcontextprotocol.io/v0/servers/io.github.KyaniteLabs%2Fkinocut/versions/latest) |
@@ -116,21 +116,24 @@ video.release_checkpoint(short.output_path)  # thumbnail + quality gate before y
 
 | Surface | Version / tip | What it means |
 | --- | --- | --- |
-| **PyPI / npm / GitHub Release** | **[1.14.1](https://github.com/KyaniteLabs/kinocut/releases/tag/v1.14.1)** (2026-08-13) | Latest **published** Kinocut. Install with `pip install kinocut`. |
-| **This repository (`master`)** | **1.14.1** · **196 MCP tools / 167 CLI commands** | Same published counts. 360 assembly reuses `video_intent` / review (not a 197th tool). |
+| **PyPI / npm / GitHub Release** | **[1.15.0](https://github.com/KyaniteLabs/kinocut/releases/tag/v1.15.0)** (2026-08-15) | Latest **published** Kinocut. Install with `pip install kinocut`. |
+| **This repository (`master`)** | **1.15.0** · **196 MCP tools / 167 CLI commands** | Same published counts. 360 assembly reuses `video_intent` / review (not a 197th tool). |
 | **Next public release** | **TBD** | Human residuals (directories, launch posts) stay gated; further bumps need a new go-ahead. |
 
 Install from PyPI for the stable package. Clone `master` only when you intentionally want unreleased tip work.
 
-## What's in 1.14.1 (latest release)
+## What's in 1.15.0 (latest release)
 
-Kinocut **1.14.1** is what you get from `pip install kinocut` today. It is a patch on **1.14.0**: same **360 dual-cam assembly** and committee performance fixes, plus a GitHub pyright Lint fix (`render_rescue` cancel path). Surface stays **196 MCP / 167 CLI** — no new public tool name.
+Kinocut **1.15.0** is what you get from `pip install kinocut` today. It is the **honest-diagnostics release** on top of 1.14.x (same 360 dual-cam assembly and performance surface), driven end-to-end by a community bug report. Surface stays **196 MCP / 167 CLI** — no new public tool name.
 
+- **Honest MCP startup failures** — `kino --mcp` keeps the "requires the 'mcp' package" hint only when `mcp` is genuinely absent; every other server-tree import failure now prints its real cause (filesystem paths redacted, markup-safe) and exits non-zero. Reported in [#445](https://github.com/KyaniteLabs/kinocut/issues/445).
+- **doctor verifies the MCP server import** — new required `mcp-server-import` check imports the same server tree `--mcp` uses, so `kino doctor` can no longer report OK while MCP mode is broken.
+- **Windows groundwork** — shebang-executable test stubs now skip explicitly on Windows instead of erroring, so the suite runs (and means it) on every platform. Full Windows MCP support ships with the portable file-locking fix ([#446](https://github.com/KyaniteLabs/kinocut/pull/446), in review).
 - **360 dual-cam assembly** — any stitched equirect MP4 (Insta360, Ricoh Theta, GoPro MAX, DJI Osmo 360, …) → reviewable `360_assembly_plan` (desk / table / `front_back`, split / switch / PiP / single) → approve → FFmpeg `v360` render. MCP: `video_intent` `goal=` + `video_review_decide`. Python: `Client.propose_360_assembly` / `decide_360_assembly` / `render_360_assembly`. Raw `.insv` / `.360` rejected. Director is a plug (local first; cloud opt-in). Not an optimized-AI claim. Guide: [docs/360_ASSEMBLY.md](docs/360_ASSEMBLY.md).
 - **Faster 360 and import path** — single-pass split/PiP/switch `filter_complex` (source audio kept); sampled quality-gate analyze window; SHA-256 path/mtime cache; merge can skip re-probe when `infos=` is supplied; batched 360 storyboard stills; lazy `mcp_video` / CLI / `Client.search_tools`; doctor skips `npx --yes` unless Hyperframes is already on PATH.
 - **Lazy public import** — `import kinocut` no longer eagerly loads Client/engines (PEP 562). `from kinocut import Client` and `kinocut.Client is mcp_video.Client` still hold.
 - **Ship-seam honesty** — CLI/Client `repurpose` default `--min-score` 80; `shorts-package` fail-closed unless `--allow-fail`; durable MCP `video_repurpose` does not apply `min_score`.
-- **Compatibility window** — `mcp-video==1.6.10` installs `kinocut==1.14.1`; `mcp_video` imports, `MCP_VIDEO_*` env vars, `~/.mcp-video` data, `mcp-video://` resources, and legacy receipt keys remain supported **on the 1.14.x line**.
+- **Compatibility window** — `mcp-video==1.6.11` installs `kinocut==1.15.0`; `mcp_video` imports, `MCP_VIDEO_*` env vars, `~/.mcp-video` data, `mcp-video://` resources, and legacy receipt keys remain supported **on the 1.14.x+ line**.
 
 Also already on the published line from 1.13.x:
 
@@ -140,15 +143,15 @@ Also already on the published line from 1.13.x:
 - Agent **workflow engine**, dedicated **video rescue**, **layered compositing**, Hyperframes, Shorts/Reels repurposing
 - **Canonical counts** — **196 MCP tools** and **167 CLI commands**
 
-Full notes: [CHANGELOG.md](CHANGELOG.md) · [v1.14.1 release](https://github.com/KyaniteLabs/kinocut/releases/tag/v1.14.1)
+Full notes: [CHANGELOG.md](CHANGELOG.md) · [v1.15.0 release](https://github.com/KyaniteLabs/kinocut/releases/tag/v1.15.0)
 
-## Beyond 1.14.1 (draft / gated)
+## Beyond 1.15.0 (draft / gated)
 
-**1.14.1 is the latest published release.** Live directory submissions and launch posts remain operator/human residual (`docs/HUMAN_GATES.md`) and are **not** claimed complete.
+**1.15.0 is the latest published release.** Live directory submissions and launch posts remain operator/human residual (`docs/HUMAN_GATES.md`) and are **not** claimed complete.
 
 ### Staged and Gated Surfaces
 
-While the core FFmpeg editing, 360 assembly, workflow engine, still/plate editing, AI-video review/salvage, and sound capabilities are fully integrated and published in **1.14.1**, the following surfaces remain gated, partial, or unreleased:
+While the core FFmpeg editing, 360 assembly, workflow engine, still/plate editing, AI-video review/salvage, and sound capabilities are fully integrated and published in **1.15.0**, the following surfaces remain gated, partial, or unreleased:
 
 - **Desktop MCPB Packaging:** The staged desktop package (`mcpb/`) is a staged configuration and is **not** a published self-contained native runtime yet (pending FFmpeg provenance, licensing, and clean-machine gates). See [docs/MCPB.md](docs/MCPB.md).
 - **Sonic World Audio (`kinocut_sound`):** While the S1–S12 capabilities are integrated on the published line, the remaining slices are blocked or gated:
@@ -231,7 +234,7 @@ In **Kinocut**, a contract-first path is provided for agent-edited media that mu
 3. **Verdict + acceptance** with exact human evidence (`video_verdict`, `video_acceptance_eval`)
 4. **Bounded derivatives only** — audio-preserving body swap or allowlisted salvage recipes (`video_body_swap`, `video_salvage`), each with lineage and a fresh non-approved review slot
 
-There is no force/bypass flag. Analyzer output alone cannot approve. Stale, aliased, or protected inputs fail closed. Operating guide: [docs/AI_VIDEO_REVIEW_AND_SALVAGE.md](docs/AI_VIDEO_REVIEW_AND_SALVAGE.md). These surfaces are fully integrated in the published 1.14.1 release — see [Status and releases](#status-and-releases).
+There is no force/bypass flag. Analyzer output alone cannot approve. Stale, aliased, or protected inputs fail closed. Operating guide: [docs/AI_VIDEO_REVIEW_AND_SALVAGE.md](docs/AI_VIDEO_REVIEW_AND_SALVAGE.md). These surfaces are fully integrated in the published 1.15.0 release — see [Status and releases](#status-and-releases).
 
 ## Dedicated Video Rescue
 
@@ -403,11 +406,11 @@ pip install --upgrade mcp-video
 mcp-video doctor
 ```
 
-`mcp-video==1.6.10` is a metadata-only compatibility installer for `kinocut==1.14.1`. The `mcp_video` import, `mcp-video` command, `MCP_VIDEO_*` environment variables, `~/.mcp-video` data directory, `mcp-video://` resource URIs, and existing receipt keys remain supported on the 1.14.x line. New integrations should use `kinocut`, `from kinocut import Client`, and the `kino` command.
+`mcp-video==1.6.11` is a metadata-only compatibility installer for `kinocut==1.15.0`. The `mcp_video` import, `mcp-video` command, `MCP_VIDEO_*` environment variables, `~/.mcp-video` data directory, `mcp-video://` resource URIs, and existing receipt keys remain supported on the 1.14.x+ line. New integrations should use `kinocut`, `from kinocut import Client`, and the `kino` command.
 
 ## En español
 
-Kinocut es un servidor MCP de edición de video para agentes de IA. La última versión publicada es **1.14.1** (`pip install kinocut`, **196 herramientas MCP / 167 CLI**). Incluye ensamblaje 360 de dual-cam desde un MP4 equirectangular ya stitched (no `.insv`), import perezoso PEP 562 y el mismo surface FFmpeg tipado para recortar, unir, subtitular, mezclar audio, efectos y reutilizar contenido (Shorts, Reels, TikTok), motor de flujos (`workflow`) con recibos verificables, rescate de video, revisión AI-video gobernada y barreras de seguridad antes de renderizar. Programas humanos residuales (directorios, lanzamiento) no se reclaman completos.
+Kinocut es un servidor MCP de edición de video para agentes de IA. La última versión publicada es **1.15.0** (`pip install kinocut`, **196 herramientas MCP / 167 CLI**). Incluye ensamblaje 360 de dual-cam desde un MP4 equirectangular ya stitched (no `.insv`), import perezoso PEP 562 y el mismo surface FFmpeg tipado para recortar, unir, subtitular, mezclar audio, efectos y reutilizar contenido (Shorts, Reels, TikTok), motor de flujos (`workflow`) con recibos verificables, rescate de video, revisión AI-video gobernada y barreras de seguridad antes de renderizar. Programas humanos residuales (directorios, lanzamiento) no se reclaman completos.
 
 Requisito: [FFmpeg](https://ffmpeg.org/) instalado y disponible en el `PATH`.
 
@@ -550,7 +553,7 @@ kino still-package --establish hero.png --beats shot1.png shot2.png --output-dir
 
 ## MCP Tools
 
-On the **published 1.14.1** surface (and matching tip), kino registers **196 MCP tools** and **167 CLI commands**. The table summarizes core categories — `search_tools` discovers the exact operation without loading every description.
+On the **published 1.15.0** surface (and matching tip), kino registers **196 MCP tools** and **167 CLI commands**. The table summarizes core categories — `search_tools` discovers the exact operation without loading every description.
 
 | Category | Count | Highlights |
 | --- | ---: | --- |
@@ -619,6 +622,13 @@ Safety contract:
 
 ## Changelog
 
+**1.15.0** (2026-08-15):
+- **Honest MCP startup failures** — `kino --mcp` reports real import causes; paths redacted, markup-safe (#448, from #445).
+- **doctor `mcp-server-import` check** — required core check; doctor can't say OK while `--mcp` is broken (#449).
+- **Windows test portability groundwork** — shebang stubs skip explicitly on Windows (#450, partial).
+- Community-driven release — @gerardoscaglia-creator credited in [Contributing](#contributing) and the [CHANGELOG acknowledgements](CHANGELOG.md).
+- `mcp-video==1.6.11` installs `kinocut==1.15.0`.
+
 **1.14.1** (2026-08-13):
 - Patch on 1.14.0: pyright `NoReturn` on rescue cancel so GitHub Lint stays green. Same 360 + perf surface.
 - `mcp-video==1.6.10` installs `kinocut==1.14.1`.
@@ -667,7 +677,7 @@ Any MCP-compatible client that can run a local stdio server (Claude Code, Cursor
 
 ### How many tools are there?
 
-Published **1.14.1** documents **196 MCP tools / 167 CLI commands**. The development tip keeps those counts. 360 assembly reuses `video_intent` and `video_review_decide` — it is not a 197th MCP tool.
+Published **1.15.0** documents **196 MCP tools / 167 CLI commands**. The development tip keeps those counts. 360 assembly reuses `video_intent` and `video_review_decide` — it is not a 197th MCP tool.
 
 ### Can Kinocut edit Insta360 X4 360 video?
 
@@ -675,7 +685,7 @@ Yes — from a **stitched 360 MP4**, not `.insv`. Propose a `360_assembly_plan`,
 
 ### Was it called mcp-video?
 
-Yes. `mcp-video==1.6.10` installs `kinocut==1.14.1`. Compatibility imports, CLI name, env vars, data dir, resource URIs, and receipt keys remain supported on the 1.14.x line.
+Yes. `mcp-video==1.6.11` installs `kinocut==1.15.0`. Compatibility imports, CLI name, env vars, data dir, resource URIs, and receipt keys remain supported on the 1.14.x+ line.
 
 More answers: [docs/faq.md](docs/faq.md) · on-site FAQ: [kinocut.dev/#faq](https://kinocut.dev/#faq)
 
@@ -808,7 +818,7 @@ Treat the README status and release tags as source of truth for maturity. Valida
 
 ### Can Kinocut turn an Insta360 X4 file into a two-cam edit?
 
-Yes: export a stitched 360 MP4, then propose → approve → render. `.insv` is rejected. This is in the published 1.14.1 package.
+Yes: export a stitched 360 MP4, then propose → approve → render. `.insv` is rejected. This is in the published 1.15.0 package.
 
 ## Status
 
@@ -825,6 +835,15 @@ Yes: export a stitched 360 MP4, then propose → approve → render. `.insv` is 
 ## Contributing
 
 Issues and PRs welcome on the canonical remote. Keep public docs free of secrets and machine-local paths.
+
+### Contributors
+
+Kinocut improves in public, and outside contributions shape it — 1.15.0's diagnostics fixes trace directly to one excellent bug report. Reports with reproduction steps and a real traceback are contributions, and contributors are credited by name in the [CHANGELOG acknowledgements](CHANGELOG.md) and the release notes.
+
+- **[@gerardoscaglia-creator](https://github.com/gerardoscaglia-creator)** — newest contributor. His Windows MCP-mode investigation ([#445](https://github.com/KyaniteLabs/kinocut/issues/445)) exposed both diagnostics gaps fixed in 1.15.0, and his portable file-locking PR ([#446](https://github.com/KyaniteLabs/kinocut/pull/446)) unblocks Windows MCP support. Thank you.
+- **[@betsmayank](https://github.com/betsmayank)** — first merged external fix: Hyperframes `init` no longer hangs under MCP without a TTY ([#361](https://github.com/KyaniteLabs/kinocut/pull/361)).
+- **[@austinwmson](https://github.com/austinwmson)** and **[@ismailkattakath](https://github.com/ismailkattakath)** — external reports that closed real gaps: `remotion_still` runtime props ([#306](https://github.com/KyaniteLabs/kinocut/issues/306)) and the self-host Funnel + OAuth reference stack ([#432](https://github.com/KyaniteLabs/kinocut/issues/432)).
+- **[@Dodothereal](https://github.com/Dodothereal)** and **[@OyaAIProd](https://github.com/OyaAIProd)** — early external PRs (ASS PlayRes for vertical burns [#378](https://github.com/KyaniteLabs/kinocut/pull/378), SafeSkill badges).
 
 ## License
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,15 +1,15 @@
 # Improvement Roadmap
 
-Kinocut 1.14.1 is published with 196 MCP tools and 167 CLI commands (`mcp-video` 1.6.10 shim).
+Kinocut 1.15.0 is published with 196 MCP tools and 167 CLI commands (`mcp-video` 1.6.11 shim).
 
-**Published product:** Kinocut **1.14.1** (2026-08-13) · **196 MCP / 167 CLI** · living snapshot [`docs/status/NOW.md`](docs/status/NOW.md)
+**Published product:** Kinocut **1.15.0** (2026-08-15) · **196 MCP / 167 CLI** · living snapshot [`docs/status/NOW.md`](docs/status/NOW.md)
 **Canonical claims:** [`docs/public_claims.json`](docs/public_claims.json)  
 **Human-only residuals:** [`docs/HUMAN_GATES.md`](docs/HUMAN_GATES.md)  
 **Residual portfolio (living truth):** [`docs/status/2026-08-12-residual-maturity-matrix.md`](docs/status/2026-08-12-residual-maturity-matrix.md) · [sound residual DAG](docs/status/2026-08-12-sound-residual-stage-dag.md) · [fixture freeze](docs/status/2026-08-12-sound-fixture-freeze.md) · [L1 truth pass](docs/status/2026-08-12-l1-truth-pass.md) · [phase checkpoints](docs/status/PHASE_CHECKPOINTS.md)  
 **Excellence program (snapshot):** [`docs/status/2026-08-07-kinocut-excellence-audit.md`](docs/status/2026-08-07-kinocut-excellence-audit.md) · handoff [`docs/handoffs/2026-08-07/kinocut-excellence-campaign.md`](docs/handoffs/2026-08-07/kinocut-excellence-campaign.md)  
 **Earlier tip snapshot:** [post-campaign tip status](docs/status/2026-07-27-post-campaign-tip-status.md) (evidence only)
 
-This file is **planning truth for after 1.14.1**. July 2026 status notes and pre-1.3 history live under **Archive** — they are evidence, not current claims. Prefer the **2026-08-12 residual matrix** over any July “S5–S15 incomplete / missing packages” language.
+This file is **planning truth for after 1.15.0**. July 2026 status notes and pre-1.3 history live under **Archive** — they are evidence, not current claims. Prefer the **2026-08-12 residual matrix** over any July “S5–S15 incomplete / missing packages” language.
 
 ---
 
@@ -26,7 +26,7 @@ Release ritual still documents *how* to freeze claims at cut time; this freeze *
 
 ---
 
-## Current (published 1.14.1)
+## Current (published 1.15.0)
 
 - **360 dual-cam assembly** — `360_assembly_plan` via `video_intent` `goal=` + Client methods; approve then render. Operator guide: [`docs/360_ASSEMBLY.md`](docs/360_ASSEMBLY.md). Not a new MCP name. Not an optimized-AI-director claim.
 - **PEP 562 lazy import** — `import kinocut` no longer eager-loads Client/engines
@@ -49,12 +49,12 @@ Ordered per residual matrix + excellence audit. Prefer one work package per PR. 
 
 | WP | Outcome | Notes |
 |----|---------|--------|
-| **A** S+ max + site stamp | README overall ≥95 preferred; site `llms.txt` date current | **Floor 100/100/100** verified 2026-08-13 (`verify-readme-splus`); preferred, **not** hard portfolio GO |
+| **A** S+ max + site stamp | README overall ≥95 preferred; site `llms.txt` date current | **Floor 100/100/100** verified 2026-08-15 (`verify-readme-splus`); preferred, **not** hard portfolio GO |
 | **B** Docs truth | L1.2 false-done punch list; residual matrix links | **L1.2 closed 2026-08-12** — see [L1 truth pass](docs/status/2026-08-12-l1-truth-pass.md); keep living docs aligned |
 | **G** Ruff hygiene | `ruff check kinocut` clean | **Done on tip** (2026-08-12 live) |
 | **C** Module size policy | ≤800 LOC modules | **Done** — engine/workflow splits + 2026-08-12 `hyperframes_ops`→helpers (ops ≤800; guardrail locks ops/helpers) |
 | **D** Long functions | ≤80 LOC functions | **Done on tip** (0 funcs >80, 2026-08-12 live) |
-| **F** Perf baselines | Golden-path p50/p95 | **Measured** 2026-08-12 + 2026-08-13 (import seam PEP 562) in [golden-path-timings.md](docs/status/golden-path-timings.md); not an “optimized” product claim |
+| **F** Perf baselines | Golden-path p50/p95 | **Measured** 2026-08-12 + 2026-08-15 (import seam PEP 562) in [golden-path-timings.md](docs/status/golden-path-timings.md); not an “optimized” product claim |
 
 **L2 residual (ultragoal, capacity-capped):** sound residual waves per [sound residual DAG](docs/status/2026-08-12-sound-residual-stage-dag.md); Phase 3/4 deepen → GO or DEFERRED; cutfile render or DEFERRED; TE/conversational/MCPB honesty. See [product pipeline complete](docs/status/2026-08-12-product-pipeline-complete.md) and residual matrix.
 
@@ -68,7 +68,7 @@ Ordered per residual matrix + excellence audit. Prefer one work package per PR. 
 | CI `light` vs `heavy` runner topology | Ops | Partial |
 | First-10 users (#92) | — | **Closed 2026-08-12** — adoption already past gate (107 GitHub stars; ~23k PyPI downloads last month). See `docs/HUMAN_GATES.md` |
 
-Product phases 1–4 + Track E are **GO** on tip (1.14.1). Agents must not invent third-party directory approvals. Do **not** re-open #92 as incomplete.
+Product phases 1–4 + Track E are **GO** on tip (1.15.0). Agents must not invent third-party directory approvals. Do **not** re-open #92 as incomplete.
 
 ---
 

--- a/compat/mcp-video-shim/README.md
+++ b/compat/mcp-video-shim/README.md
@@ -10,5 +10,5 @@ pip install kinocut
 kino doctor
 ```
 
-Compatibility identifiers remain supported on the Kinocut 1.14.x line. Project home:
+Compatibility identifiers remain supported on the Kinocut 1.15.x line. Project home:
 [kinocut.dev](https://kinocut.dev/).

--- a/compat/mcp-video-shim/pyproject.toml
+++ b/compat/mcp-video-shim/pyproject.toml
@@ -4,34 +4,34 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-video"
-version = "1.6.10"
+version = "1.6.11"
 description = "Compatibility installer for Kinocut, formerly mcp-video."
 readme = "README.md"
 license = "Apache-2.0"
 requires-python = ">=3.11"
-dependencies = ["kinocut==1.14.1"]
+dependencies = ["kinocut==1.15.0"]
 
 [project.scripts]
 mcp-video = "kinocut.__main__:main"
 
 [project.optional-dependencies]
-client = ["kinocut[client]==1.14.1"]
-image = ["kinocut[image]==1.14.1"]
-image-ai = ["kinocut[image-ai]==1.14.1"]
-audio = ["kinocut[audio]==1.14.1"]
-audio-enhanced = ["kinocut[audio-enhanced]==1.14.1"]
-audio-ai = ["kinocut[audio-ai]==1.14.1"]
-audio-midi = ["kinocut[audio-midi]==1.14.1"]
-audio-analysis = ["kinocut[audio-analysis]==1.14.1"]
-hyperframes = ["kinocut[hyperframes]==1.14.1"]
-transcribe = ["kinocut[transcribe]==1.14.1"]
-ai-scene = ["kinocut[ai-scene]==1.14.1"]
-stems = ["kinocut[stems]==1.14.1"]
-upscale = ["kinocut[upscale]==1.14.1"]
-ai = ["kinocut[ai]==1.14.1"]
-all-ai = ["kinocut[all-ai]==1.14.1"]
-audio-all = ["kinocut[audio-all]==1.14.1"]
-dev = ["kinocut[dev]==1.14.1"]
+client = ["kinocut[client]==1.15.0"]
+image = ["kinocut[image]==1.15.0"]
+image-ai = ["kinocut[image-ai]==1.15.0"]
+audio = ["kinocut[audio]==1.15.0"]
+audio-enhanced = ["kinocut[audio-enhanced]==1.15.0"]
+audio-ai = ["kinocut[audio-ai]==1.15.0"]
+audio-midi = ["kinocut[audio-midi]==1.15.0"]
+audio-analysis = ["kinocut[audio-analysis]==1.15.0"]
+hyperframes = ["kinocut[hyperframes]==1.15.0"]
+transcribe = ["kinocut[transcribe]==1.15.0"]
+ai-scene = ["kinocut[ai-scene]==1.15.0"]
+stems = ["kinocut[stems]==1.15.0"]
+upscale = ["kinocut[upscale]==1.15.0"]
+ai = ["kinocut[ai]==1.15.0"]
+all-ai = ["kinocut[all-ai]==1.15.0"]
+audio-all = ["kinocut[audio-all]==1.15.0"]
+dev = ["kinocut[dev]==1.15.0"]
 
 [project.urls]
 Homepage = "https://kinocut.dev/"

--- a/docs/AI_AGENT_DISCOVERY.md
+++ b/docs/AI_AGENT_DISCOVERY.md
@@ -5,14 +5,14 @@ This document is the short, explicit discovery map for agents, answer engines, a
 ## Canonical Positioning
 
 `Kinocut` is an open-source MCP server, Python library, and CLI for video editing
-and video creation workflows. Published 1.14.1 provides **196 MCP tools / 167 CLI
+and video creation workflows. Published 1.15.0 provides **196 MCP tools / 167 CLI
 commands**; the development tip keeps those counts. It
 wraps FFmpeg, governed AI-video review and salvage, deterministic project-backed
 inspection, durable edit projects, a resumable workflow engine, reviewed semantic
 selections, reusable recipes, PUSHING CREATION-style planning, Hyperframes
 authoring, bounded sound operations, layered compositing, and local repurposing
 packages with preflight guardrails. A 360/desk/table `video_intent` goal can also
-attach a reviewable `360_assembly_plan` (no extra MCP tool; in pip 1.14.1).
+attach a reviewable `360_assembly_plan` (no extra MCP tool; in pip 1.15.0).
 
 ## Best Queries To Match
 

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -40,7 +40,7 @@ inspection, decision, protection, derivative, and re-review sequence.
 
 ## Intent, review, and cutfiles
 
-Published 1.14.1 surface. These commands do **not** add a 360 CLI verb.
+Published 1.15.0 surface. These commands do **not** add a 360 CLI verb.
 
 | Command | Description |
 |---------|-------------|

--- a/docs/DIRECTORY_REBRAND_STATUS.md
+++ b/docs/DIRECTORY_REBRAND_STATUS.md
@@ -17,9 +17,9 @@ about third-party pages; verify an external page before acting on its listed sta
 - Description: Guardrailed video editing for AI agents with FFmpeg, captions,
   effects, Hyperframes, resumable workflows, repurposing, quality gates, and
   provenance receipts.
-- Published surface: 196 MCP tools / 167 CLI commands (1.14.1)
-- Development tip: 196 MCP tools / 167 CLI commands (matches published 1.14.1)
-- Current release: 1.14.1 (published 2026-08-13)
+- Published surface: 196 MCP tools / 167 CLI commands (1.15.0)
+- Development tip: 196 MCP tools / 167 CLI commands (matches published 1.15.0)
+- Current release: 1.15.0 (published 2026-08-13)
 - Submission ops: `docs/status/DIRECTORY_SUBMISSION_OPS.md`
 
 ## Reconciliation Snapshot (2026-07-10)

--- a/docs/HUMAN_GATES.md
+++ b/docs/HUMAN_GATES.md
@@ -22,7 +22,7 @@ where noted. Residual portfolio authority:
 | PyPI downloads (last day) | **608** | pypistats / pypi.org API |
 | PyPI downloads (last week) | **6,715** | same |
 | PyPI downloads (last month) | **23,034** | same |
-| Published package | **1.14.1** | PyPI |
+| Published package | **1.15.0** | PyPI |
 
 Downloads are not a unique-user census, but stars + forks + multi‑k weekly installs
 make “recruit first 10 users” an obsolete product gate. Do **not** re-open #92 as

--- a/docs/MCPB.md
+++ b/docs/MCPB.md
@@ -7,7 +7,7 @@ MCPB does not bundle Python, Kinocut, FFmpeg, Node, Hyperframes, or AI model wei
 ## Runtime Requirements
 
 - Node.js 18 or newer, used only by the MCPB launcher.
-- Python 3.11 or newer with `kinocut==1.14.1` installed.
+- Python 3.11 or newer with `kinocut==1.15.0` installed.
 - FFmpeg and ffprobe available on `PATH`, or an executable named `ffmpeg` configured through the installer field with an adjacent `ffprobe`.
 - Optional AI features require the matching Kinocut extras and local model dependencies.
 - Hyperframes tools require a resolvable Hyperframes command; leave the field blank if you do not use those tools.
@@ -29,7 +29,7 @@ python3 scripts/build-mcpb.py
 The script validates the v0.4 manifest fields used by this package and writes:
 
 ```text
-dist/kinocut-1.14.1.mcpb
+dist/kinocut-1.15.0.mcpb
 ```
 
 Focused validation:

--- a/docs/RELEASE_1.8_CHECKLIST.md
+++ b/docs/RELEASE_1.8_CHECKLIST.md
@@ -10,7 +10,7 @@ publish steps for this completed release.
 [`.github/workflows/publish.yml`](../.github/workflows/publish.yml)
 
 **Tip surface at freeze:** 155 MCP tools · 134 CLI commands  
-**Published result:** 1.14.1 · 196 MCP / 167 CLI
+**Published result:** 1.15.0 · 196 MCP / 167 CLI
 
 (1.8.0 cutover was 142/121; later tags: 1.9.0 150/129 · 1.10.0 155/134 · 1.11.1 161/140 ·
 1.12.0 169/145 · 1.13.0 194/165 · 1.13.1 194/165 · 1.13.2 194/165 · 1.13.4 194/165. This page remains the cutover procedure audit record.)

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -54,7 +54,7 @@ Kinocut covers Meta / Discovery, Cinematic Creation, Core Editing, AI-Powered me
 
 ## Can it edit Insta360 X4 360 video?
 
-Yes — from a **stitched 360 MP4**, not a raw `.insv`. `video_intent` with a 360/desk/table goal (or `Client.propose_360_assembly`) writes a reviewable `360_assembly_plan`. Approve, then render split / switch / PiP / single. There is no extra MCP tool name. This is in pip `kinocut==1.14.1`. See [360_ASSEMBLY.md](360_ASSEMBLY.md).
+Yes — from a **stitched 360 MP4**, not a raw `.insv`. `video_intent` with a 360/desk/table goal (or `Client.propose_360_assembly`) writes a reviewable `360_assembly_plan`. Approve, then render split / switch / PiP / single. There is no extra MCP tool name. This is in pip `kinocut==1.15.0`. See [360_ASSEMBLY.md](360_ASSEMBLY.md).
 
 ## What are the cinematic creation tools?
 

--- a/docs/public_claims.json
+++ b/docs/public_claims.json
@@ -6,9 +6,9 @@
     "kinocut",
     "mcp-video"
   ],
-  "published_version": "1.14.1",
-  "published_date": "2026-08-13",
-  "release_candidate_version": "1.14.1",
+  "published_version": "1.15.0",
+  "published_date": "2026-08-15",
+  "release_candidate_version": "1.15.0",
   "published_mcp_tools": 196,
   "published_cli_commands": 167,
   "development_mcp_tools": 196,

--- a/docs/status/2026-07-14-1.8-release-notes.md
+++ b/docs/status/2026-07-14-1.8-release-notes.md
@@ -4,7 +4,7 @@
 
 **Published surface:** 142 MCP tools / 121 CLI commands.
 
-**Later pin (current as of 1.14.1):** `mcp-video==1.6.10` installs `kinocut==1.14.1`.
+**Later pin (current as of 1.15.0):** `mcp-video==1.6.11` installs `kinocut==1.15.0`.
 
 ## Three agent-facing bullets
 
@@ -15,7 +15,7 @@
 2. **What got safer** — Approvals require active human decisions (analyzer-only cannot
    approve); salvage/body-swap reject stale/aliased/protected inputs; Hyperframes init
    no longer hangs under MCP (no TTY).
-3. **Compat** — `mcp-video==1.6.10` installs current Kinocut 1.14.1; `mcp_video` imports,
+3. **Compat** — `mcp-video==1.6.11` installs current Kinocut 1.15.0; `mcp_video` imports,
    `MCP_VIDEO_*`, `~/.mcp-video`, `mcp-video://`, and legacy receipt keys remain supported
    on the 1.14.x line. Prefer `kinocut` / `kino` for new work.
 

--- a/docs/status/2026-08-15-1.15.0-release-notes.md
+++ b/docs/status/2026-08-15-1.15.0-release-notes.md
@@ -1,0 +1,24 @@
+# Kinocut 1.15.0 release notes
+
+**Published:** 2026-08-15 — PyPI `kinocut==1.15.0`, npm `kinocut@1.15.0`, GitHub Release `v1.15.0`.
+
+**Published surface:** 196 MCP tools / 167 CLI commands (unchanged).
+
+**Compat:** `mcp-video==1.6.11` installs `kinocut==1.15.0`.
+
+## Three agent-facing bullets
+
+1. **What agents can do now** — Same surface as 1.14.x: stitched equirect 360 → `360_assembly_plan` → approve → `v360` render. No new MCP name. What changed is *trust in failure*: when `kino --mcp` cannot start, it now prints the real import error (paths redacted) instead of a misleading "missing mcp package" hint, and `kino doctor` runs a required `mcp-server-import` check that imports the same server tree, so doctor OK now covers MCP mode.
+2. **What got safer** — Windows users hitting #445 got a wrong message and a green doctor; both diagnostics gaps are closed and regression-tested. Test stubs that cannot execute on Windows now skip explicitly instead of erroring, so a red test means a real defect on every platform.
+3. **Compat** — `mcp-video==1.6.11` installs `kinocut==1.15.0`. Counts stay **196 / 167**.
+
+## Acknowledgements — community-driven release
+
+Every fix in this release traces to [@gerardoscaglia-creator](https://github.com/gerardoscaglia-creator), who filed [#445](https://github.com/KyaniteLabs/kinocut/issues/445): a Windows 10 reproduction of `kino --mcp` failing, with the real `fcntl` traceback dug out past a message that blamed the wrong cause. That single report exposed both diagnostics gaps fixed in 1.15.0, and his portable file-locking PR ([#446](https://github.com/KyaniteLabs/kinocut/pull/446)) is in review to unblock Windows MCP support outright. Reports like this are contributions — file them the same way and you will be credited the same way.
+
+He joins a community that predates him: betsmayank's merged Hyperframes no-TTY fix ([#361](https://github.com/KyaniteLabs/kinocut/pull/361)), austinwmson's `remotion_still` props report ([#306](https://github.com/KyaniteLabs/kinocut/issues/306)), ismailkattakath's self-host reference stack ([#432](https://github.com/KyaniteLabs/kinocut/issues/432)), and early PRs from Dodothereal ([#378](https://github.com/KyaniteLabs/kinocut/pull/378)) and OyaAIProd.
+
+## Not claimed
+
+- Windows MCP-mode support is **not yet claimed** — it lands with #446. Windows users get honest errors today, a working MCP server when that PR merges.
+- Not a vendor stitcher, not an optimized-AI-director, native MCPB staged/local-only — unchanged from 1.14.x.

--- a/docs/status/NOW.md
+++ b/docs/status/NOW.md
@@ -1,7 +1,7 @@
 # Kinocut now
 
-**Published:** 1.14.1 · **196 MCP / 167 CLI** · `docs/public_claims.json`  
-**Tip (`master`):** same published counts. 360 dual-cam assembly, PEP 562 lazy `import kinocut`, and QC-80 ship-seam honesty are in pip 1.14.1.
+**Published:** 1.15.0 · **196 MCP / 167 CLI** · `docs/public_claims.json`  
+**Tip (`master`):** same published counts. 360 dual-cam assembly, PEP 562 lazy `import kinocut`, QC-80 ship-seam honesty, and the honest-diagnostics release (real `--mcp` import errors, doctor `mcp-server-import` check — community-driven release, see CHANGELOG acknowledgements) are in pip 1.15.0.
 
 **Product pipeline:** Phase 1–4 + Track E **GO**.
 

--- a/docs/status/USER_PROGRAM_RUNBOOK.md
+++ b/docs/status/USER_PROGRAM_RUNBOOK.md
@@ -12,7 +12,7 @@ Live public adoption already exceeds a “first 10” product gate:
 | GitHub stars | **107** |
 | GitHub forks | **25** |
 | PyPI last day / week / month | **608 / 6,715 / 23,034** |
-| Published | Kinocut **1.14.1** |
+| Published | Kinocut **1.15.0** |
 
 This runbook remains as **optional** guided-onboarding material for support or
 content, **not** as an open residual that blocks product timeline or release.

--- a/kinocut/__init__.py
+++ b/kinocut/__init__.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import importlib
 from typing import Any
 
-__version__ = "1.14.1"
+__version__ = "1.15.0"
 
 # Heavy engines and Client stay off the import path until first attribute
 # access (PEP 562). Submodule imports such as ``from kinocut import

--- a/llms.txt
+++ b/llms.txt
@@ -13,10 +13,10 @@ Kinocut is a free, open-source Model Context Protocol (MCP) server that gives AI
 - **What it is:** MCP server + Python client + CLI for agentic video editing
 - **Publisher:** KyaniteLabs — https://kyanitelabs.tech/
 - **License:** Apache-2.0
-- **Latest published release:** 1.14.1 (2026-08-13)
-- **Last-updated:** 2026-08-13
-- **Published surface (1.14.1):** 196 MCP tools / 167 CLI commands
-- **Development tip (master at tag):** 196 MCP tools / 167 CLI commands — matches published 1.14.1
+- **Latest published release:** 1.15.0 (2026-08-15)
+- **Last-updated:** 2026-08-15
+- **Published surface (1.15.0):** 196 MCP tools / 167 CLI commands
+- **Development tip (master at tag):** 196 MCP tools / 167 CLI commands — matches published 1.15.0
 - **Runtime:** Python 3.11+, FFmpeg on PATH; optional extras for Whisper/upscale/etc.
 - **MCP transport:** stdio
 - **MCP Registry id:** `io.github.KyaniteLabs/kinocut`
@@ -46,7 +46,7 @@ Pack: python scripts/generate_golden_pack.py → demo/golden-pack/
 Compatibility:
 
 ```bash
-pip install --upgrade mcp-video   # 1.6.10 shim → kinocut 1.14.1
+pip install --upgrade mcp-video   # 1.6.11 shim → kinocut 1.15.0
 ```
 
 ## Canonical links

--- a/mcpb/README.md
+++ b/mcpb/README.md
@@ -2,6 +2,6 @@
 
 This bundle launches Kinocut as a local stdio MCP server through the package's Node launcher.
 
-It is a staged/local-only distribution package. It expects Python 3.11+, `kinocut==1.14.1`, and FFmpeg to already be installed on the user's machine. Optional AI, shader, and Hyperframes tools remain capability-gated until their dependencies are installed and configured. Native MCPB bundles are not published with this release.
+It is a staged/local-only distribution package. It expects Python 3.11+, `kinocut==1.15.0`, and FFmpeg to already be installed on the user's machine. Optional AI, shader, and Hyperframes tools remain capability-gated until their dependencies are installed and configured. Native MCPB bundles are not published with this release.
 
 See `docs/MCPB.md` in the Kinocut repository for install, validation, and release-gate details.

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "kinocut",
   "display_name": "Kinocut",
-  "version": "1.14.1",
+  "version": "1.15.0",
   "description": "Local stdio MCP server for guarded FFmpeg video workflows.",
   "long_description": "Kinocut exposes local video editing, analysis, workflow, rescue, and repurposing tools over MCP stdio. This MCPB package is a staged local launcher: it does not bundle Python, Kinocut, FFmpeg, Node, Hyperframes, optional AI packages, or model weights. Configure an existing Python environment with Kinocut installed, keep FFmpeg available on PATH or configured by path, and install optional AI or Hyperframes dependencies only when you intend to use those capabilities.",
   "author": {
@@ -44,7 +44,7 @@
     "pythonExecutable": {
       "type": "string",
       "title": "Python executable",
-      "description": "Optional Python command or absolute executable path for an environment with kinocut==1.14.1 installed. Leave blank to try python3 then python.",
+      "description": "Optional Python command or absolute executable path for an environment with kinocut==1.15.0 installed. Leave blank to try python3 then python.",
       "default": "",
       "required": false
     },

--- a/npm/bin/kinocut.js
+++ b/npm/bin/kinocut.js
@@ -2,7 +2,7 @@
 
 import { spawnSync } from "node:child_process";
 
-const args = ["--from", "kinocut==1.14.1", "kino", ...process.argv.slice(2)];
+const args = ["--from", "kinocut==1.15.0", "kino", ...process.argv.slice(2)];
 const result = spawnSync("uvx", args, { stdio: "inherit" });
 
 if (result.error?.code === "ENOENT") {

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kinocut",
-  "version": "1.14.1",
+  "version": "1.15.0",
   "description": "Thin uvx launcher for Kinocut, the trusted execution layer for agentic video.",
   "license": "Apache-2.0",
   "homepage": "https://kinocut.dev/",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kinocut"
-version = "1.14.1"
+version = "1.15.0"
 description = "Trusted, guardrailed video editing for AI agents. FFmpeg, Hyperframes, repurposing tools, Python client, CLI, and MCP server."
 readme = "README.md"
 license = "Apache-2.0"

--- a/scripts/build-mcpb.py
+++ b/scripts/build-mcpb.py
@@ -13,7 +13,7 @@ from typing import Any
 
 ROOT = Path(__file__).resolve().parents[1]
 MCPB_DIR = ROOT / "mcpb"
-VERSION = "1.14.1"
+VERSION = "1.15.0"
 TOP_LEVEL_KEYS = {
     "$schema",
     "manifest_version",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.KyaniteLabs/kinocut",
   "title": "Kinocut",
   "description": "Guardrailed video editing for AI agents: FFmpeg, captions, effects, Hyperframes, and receipts.",
-  "version": "1.14.1",
+  "version": "1.15.0",
   "websiteUrl": "https://kinocut.dev/",
   "repository": {
     "url": "https://github.com/KyaniteLabs/kinocut",
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "kinocut",
-      "version": "1.14.1",
+      "version": "1.15.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/tests/test_kinocut_distribution.py
+++ b/tests/test_kinocut_distribution.py
@@ -15,8 +15,8 @@ import mcp_video
 
 
 ROOT = Path(__file__).resolve().parents[1]
-KINOCUT_VERSION = "1.14.1"
-SHIM_VERSION = "1.6.10"
+KINOCUT_VERSION = "1.15.0"
+SHIM_VERSION = "1.6.11"
 
 
 def _toml(path: Path) -> dict:


### PR DESCRIPTION
Version cutover to **1.15.0** following the release checklist: full version sweep (26 surfaces incl. the claims-enforced ones — DIRECTORY_REBRAND_STATUS, RELEASE_1.8_CHECKLIST published-result line, 1.8 release-notes compat line), `mcp-video` shim 1.6.11 pinning `kinocut==1.15.0`, CHANGELOG entry with **Acknowledgements**, release-notes doc, README release section rewrite + a proper **Contributors roll**, ROADMAP/NOW/llms/public_claims refresh.

**Credit:** every fix in this release traces to @gerardoscaglia-creator's #445 report — and he joins a contributor community that predates him: betsmayank (merged #361), austinwmson (#306), ismailkattakath (#432), Dodothereal (#378), OyaAIProd. All credited by name in README → Contributing → Contributors, CHANGELOG acknowledgements, and the release notes. Windows MCP support stays explicitly *not claimed* until #446 merges.

Gates: full suite 4839 passed / 171 skipped, claims-consistency suite green (22 passed), ruff clean, import check pins 1.15.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `kino doctor` validation for MCP server imports.
  - MCP startup now reports actionable import errors instead of masking failures.
  - Added compatibility support for `mcp-video` 1.6.11.

- **Bug Fixes**
  - Improved Windows test portability and clarified that Windows MCP support remains unclaimed.

- **Documentation**
  - Published Kinocut 1.15.0 release notes and updated installation, compatibility, CLI, FAQ, roadmap, and status documentation.
  - Updated package and distribution metadata to version 1.15.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->