### PR TITLE
fix(windows): escape filter-option paths for both FFmpeg unescaping passes

### DIFF
--- a/kinocut/ai_engine/color.py
+++ b/kinocut/ai_engine/color.py
@@ -129,9 +129,9 @@ def _apply_style_filter(video_path: Path, output: str, filter_string: str) -> st
 
 def _apply_lut(video: str, output: str, lut_path: str) -> str:
     """Apply a .cube/.3dl LUT with FFmpeg's lut3d filter."""
-    from ..ffmpeg_helpers import _escape_ffmpeg_filter_value
+    from ..ffmpeg_helpers import _escape_ffmpeg_filter_path
 
-    filter_string = f"lut3d={_escape_ffmpeg_filter_value(lut_path)}"
+    filter_string = f"lut3d={_escape_ffmpeg_filter_path(lut_path)}"
     cmd = [
         "ffmpeg",
         "-y",

--- a/kinocut/aivideo/graphics_recipe.py
+++ b/kinocut/aivideo/graphics_recipe.py
@@ -47,6 +47,7 @@ from kinocut.engine_composite_layers import (
 from kinocut.engine_runtime_utils import _timed_operation
 from kinocut.errors import MCPVideoError
 from kinocut.ffmpeg_helpers import (
+    _escape_ffmpeg_filter_path,
     _escape_ffmpeg_filter_value,
     _run_ffmpeg,
     _sanitize_ffmpeg_number,
@@ -180,7 +181,7 @@ def _pre_render_text_layer(
     """
 
     safe_text = _escape_ffmpeg_filter_value(text)
-    safe_font = _escape_ffmpeg_filter_value(font_path)
+    safe_font = _escape_ffmpeg_filter_path(font_path)
     safe_color = _escape_ffmpeg_filter_value(color)
     safe_size = _escape_ffmpeg_filter_value(str(_sanitize_ffmpeg_number(size, "text size")))
     vf = (

--- a/kinocut/effects_engine/text.py
+++ b/kinocut/effects_engine/text.py
@@ -20,6 +20,7 @@ from ..ffmpeg_helpers import (
     _validate_input_path,
     _validate_output_path,
     _run_command,
+    _escape_ffmpeg_filter_path,
     _escape_ffmpeg_filter_value,
     _run_ffprobe_json,
 )
@@ -115,7 +116,7 @@ def _subtitle_filter(
     prepared_subtitles: str, font: str, size: int, color: str, outline: int, outline_color: str
 ) -> str:
     """Build a safe subtitles filter string."""
-    safe_subtitles = _escape_ffmpeg_filter_value(prepared_subtitles)
+    safe_subtitles = _escape_ffmpeg_filter_path(prepared_subtitles)
     safe_font = _escape_ffmpeg_filter_value(font)
     safe_color = _escape_ffmpeg_filter_value(color)
     safe_outline_color = _escape_ffmpeg_filter_value(outline_color)
@@ -231,7 +232,7 @@ def _escape_sendcmd_value(value: str) -> str:
 def _drawtext_font_option(font: str | None) -> str:
     """Return a drawtext font option that works for both font names and paths."""
     if font and os.path.exists(font):
-        return f"fontfile={_escape_ffmpeg_filter_value(font)}"
+        return f"fontfile={_escape_ffmpeg_filter_path(font)}"
     safe_font = _escape_ffmpeg_filter_value(font or "Arial")
     return f"font={safe_font}"
 
@@ -292,7 +293,7 @@ def _build_typewriter_filter(
             os.unlink(cmd_path)
         raise
 
-    safe_cmd_path = _escape_ffmpeg_filter_value(cmd_path)
+    safe_cmd_path = _escape_ffmpeg_filter_path(cmd_path)
     filter_complex = (
         f"sendcmd=f={safe_cmd_path},"
         f"drawtext@1=text='':{font_option}:fontsize={safe_size}:fontcolor={safe_color}:"

--- a/kinocut/engine_stabilize.py
+++ b/kinocut/engine_stabilize.py
@@ -22,7 +22,12 @@ from .ffmpeg_helpers import (
     _sanitize_ffmpeg_number,
 )
 from .errors import MCPVideoError, ProcessingError, parse_ffmpeg_error
-from .ffmpeg_helpers import _validate_input_path, _validate_output_path, _escape_ffmpeg_filter_value
+from .ffmpeg_helpers import (
+    _validate_input_path,
+    _validate_output_path,
+    _escape_ffmpeg_filter_path,
+    _escape_ffmpeg_filter_value,
+)
 from .limits import DEFAULT_FFMPEG_TIMEOUT
 from .models import EditResult
 
@@ -55,7 +60,7 @@ def stabilize(
             vectors_file = os.path.join(tmpdir, "vectors.trf")
             _detect_motion_vectors(input_path, vectors_file)
 
-            safe_vectors_file = _escape_ffmpeg_filter_value(vectors_file)
+            safe_vectors_file = _escape_ffmpeg_filter_path(vectors_file)
             _run_ffmpeg(
                 _build_ffmpeg_cmd(
                     input_path,
@@ -80,7 +85,7 @@ def _detect_motion_vectors(input_path: str, vectors_file: str) -> None:
             error_type="validation_error",
             code="invalid_path",
         )
-    safe_vectors_file = _escape_ffmpeg_filter_value(vectors_file)
+    safe_vectors_file = _escape_ffmpeg_filter_path(vectors_file)
     try:
         result = subprocess.run(  # noqa: S603
             [

--- a/kinocut/engine_subtitles.py
+++ b/kinocut/engine_subtitles.py
@@ -26,7 +26,7 @@ from .ffmpeg_helpers import (
     _build_ffmpeg_cmd,
     _run_ffmpeg,
 )
-from .ffmpeg_helpers import _validate_input_path, _validate_output_path, _escape_ffmpeg_filter_value
+from .ffmpeg_helpers import _validate_input_path, _validate_output_path, _escape_ffmpeg_filter_path
 from .defaults import DEFAULT_SUBTITLE_STYLE
 from .errors import MCPVideoError
 from .models import EditResult
@@ -125,7 +125,7 @@ def subtitles(
                 code="subtitle_prepare_failed",
             ) from exc
         _fill_burn_source(fd, subtitle_format, subtitle_path, input_path)
-        video_filter = f"subtitles={_escape_ffmpeg_filter_value(temp_ass)}"
+        video_filter = f"subtitles={_escape_ffmpeg_filter_path(temp_ass)}"
         if force_style:
             video_filter += f":force_style='{force_style}'"
 

--- a/kinocut/engine_text.py
+++ b/kinocut/engine_text.py
@@ -25,7 +25,12 @@ from .ffmpeg_helpers import (
 from .validation import (
     _validate_color,
 )
-from .ffmpeg_helpers import _escape_ffmpeg_filter_value, _validate_input_path, _validate_output_path
+from .ffmpeg_helpers import (
+    _escape_ffmpeg_filter_path,
+    _escape_ffmpeg_filter_value,
+    _validate_input_path,
+    _validate_output_path,
+)
 from .models import EditResult, Position
 from .design_guardrails import (
     validate_single_text,
@@ -238,7 +243,7 @@ def _build_drawtext_filter(
     if font is not None:
         _validate_input_path(fontfile)
 
-    escaped_fontfile = _escape_ffmpeg_filter_value(fontfile)
+    escaped_fontfile = _escape_ffmpeg_filter_path(fontfile)
     escaped_text = _escape_ffmpeg_filter_value(text)
     escaped_color = _escape_ffmpeg_filter_value(color)
 

--- a/kinocut/engine_timeline.py
+++ b/kinocut/engine_timeline.py
@@ -31,7 +31,12 @@ from .validation import (
     _validate_color,
 )
 from .errors import MCPVideoError
-from .ffmpeg_helpers import _escape_ffmpeg_filter_value, _validate_input_path, _validate_output_path
+from .ffmpeg_helpers import (
+    _escape_ffmpeg_filter_path,
+    _escape_ffmpeg_filter_value,
+    _validate_input_path,
+    _validate_output_path,
+)
 from .models import EditResult, NamedPosition, Timeline, TimelineClip, TimelineImageOverlay
 
 
@@ -373,7 +378,7 @@ def _image_enable_expression(img: TimelineImageOverlay) -> str:
 def _drawtext_filter(elem, width: int, height: int) -> str:
     fontfile = elem.style.get("font") or _default_font()
     if fontfile is not None:
-        fontfile = _escape_ffmpeg_filter_value(fontfile)
+        fontfile = _escape_ffmpeg_filter_path(fontfile)
     size = int(_sanitize_ffmpeg_number(elem.style.get("size", 48), "style.size"))
     color = elem.style.get("color", "white")
     _validate_color(color)

--- a/kinocut/ffmpeg_helpers.py
+++ b/kinocut/ffmpeg_helpers.py
@@ -544,7 +544,13 @@ def _format_ffmpeg_number(value: Any) -> str:
 
 
 def _escape_ffmpeg_filter_value(value: str) -> str:
-    """Escape special characters for FFmpeg filter expressions (subtitles, drawtext, etc.)."""
+    """Escape special characters for FFmpeg filter expressions (subtitles, drawtext, etc.).
+
+    This applies a single escaping pass, which is correct for values that reach the
+    filter already quoted (``lut3d=file='...'``) and for scalars such as numbers,
+    colours and font *names*. Unquoted filesystem paths need
+    ``_escape_ffmpeg_filter_path`` instead — see the note there.
+    """
     return (
         value.replace("\\", "\\\\")
         .replace("'", "'\\''")
@@ -555,6 +561,26 @@ def _escape_ffmpeg_filter_value(value: str) -> str:
         .replace(",", "\\,")
         .replace("=", "\\=")
     )
+
+
+def _escape_ffmpeg_filter_path(value: str) -> str:
+    """Escape a filesystem path used as an *unquoted* FFmpeg filter option value.
+
+    An unquoted option value is unescaped twice: once by the filtergraph parser and
+    once by the filter's own argument parser. ``_escape_ffmpeg_filter_value`` escapes
+    only once, which is enough on POSIX but breaks on Windows: the drive-letter colon
+    survives the first pass and is then read as an option separator, and the
+    backslashes are consumed as escape characters.
+
+    ``C:\\dir\\subs.ass`` currently becomes ``C\\:\\\\dir\\\\subs.ass``, which FFmpeg
+    resolves to the filename ``C`` plus a bogus ``original_size`` option. Normalising
+    the separators to forward slashes (accepted by FFmpeg on Windows) keeps them from
+    being eaten, and escaping the colon twice lets it survive both passes.
+
+    No-op for ordinary POSIX paths, and correct for POSIX paths that do contain a
+    colon, since the same two-pass parsing applies there.
+    """
+    return value.replace("\\", "/").replace(":", "\\\\:")
 
 
 def _get_video_duration(video_path: str, *, pass_fds: tuple[int, ...] = ()) -> float:

--- a/tests/test_ffmpeg_filter_path.py
+++ b/tests/test_ffmpeg_filter_path.py
@@ -1,0 +1,38 @@
+"""Escaping rules for paths embedded in FFmpeg filter option values.
+
+Regression cover for the Windows subtitle burn-in failure: an unquoted filter option
+value is unescaped twice, so a single-pass escape leaves the drive-letter colon acting
+as an option separator and lets the backslashes be eaten as escape characters.
+"""
+
+from kinocut.ffmpeg_helpers import _escape_ffmpeg_filter_path, _escape_ffmpeg_filter_value
+
+
+def test_windows_path_survives_both_unescaping_passes():
+    # The colon is escaped twice and separators become forward slashes, so neither is
+    # consumed by the filtergraph parser before the filter sees the filename.
+    assert _escape_ffmpeg_filter_path(r"C:\kctest\subs.ass") == "C\\\\:/kctest/subs.ass"
+
+
+def test_single_pass_escape_is_not_enough_for_a_windows_path():
+    # Documents the bug: this is what the value helper produces, and FFmpeg reads the
+    # filename as "C" and the remainder as an original_size option.
+    assert _escape_ffmpeg_filter_value(r"C:\kctest\subs.ass") == "C\\:\\\\kctest\\\\subs.ass"
+
+
+def test_posix_path_is_unchanged():
+    assert _escape_ffmpeg_filter_path("/tmp/kinocut/subs.ass") == "/tmp/kinocut/subs.ass"
+
+
+def test_posix_path_with_a_colon_is_escaped():
+    assert _escape_ffmpeg_filter_path("/tmp/a:b/subs.ass") == "/tmp/a\\\\:b/subs.ass"
+
+
+def test_relative_path_is_unchanged():
+    assert _escape_ffmpeg_filter_path("subs.ass") == "subs.ass"
+
+
+def test_value_helper_still_used_for_scalars():
+    # Numbers, colours and font *names* keep the single-pass helper.
+    assert _escape_ffmpeg_filter_value("15.0") == "15.0"
+    assert _escape_ffmpeg_filter_value("white") == "white"


### PR DESCRIPTION
Fixes the Windows subtitle burn-in failure, and the same class of failure in `fontfile=`, `lut3d=`,
`sendcmd=f=` and vidstab.

## The bug

An **unquoted** FFmpeg filter option value is unescaped **twice** — once by the filtergraph parser, once by
the filter's own argument parser. `_escape_ffmpeg_filter_value` escapes once. That is enough on POSIX, and
enough for numbers, colours and font names anywhere, but it breaks Windows paths: the drive-letter colon
survives the first pass and is then read as an option separator, and the backslashes are consumed as escape
characters.

`kino subtitles` fails 100% of the time on Windows:

```
kino subtitles C:\kctest\v.mp4 C:\kctest\l.srt -o C:\kctest\out.mp4

[Parsed_subtitles_0] Unable to parse "original_size" option value
"kctesttmp.ass" as image size
 Error applying option 'original_size' to filter 'subtitles': Invalid argument
```

`C:\kctest\tmp.ass` reached FFmpeg as `kctesttmp.ass`. Fails with long paths, short paths, relative paths and
with or without `--style`. No user-side workaround. `kino doctor` reports OK throughout.

## The fix

A new `_escape_ffmpeg_filter_path` next to the existing helper. Separators become forward slashes — FFmpeg
accepts them on Windows — so they cannot be eaten, and the colon is escaped twice so it survives both passes.

I tested the candidate forms against ffmpeg 9.0 rather than reasoning about them:

| Filter value | Result |
|---|---|
| `subtitles=C\:\\kctest\\tmp.ass` — current output | ❌ `original_size` = `kctesttmp.ass` |
| `subtitles=C\:/kctest/tmp.ass` | ❌ `original_size` = `/kctest/tmp.ass` |
| `subtitles=C\\:\\kctest\\tmp.ass` | ❌ `Unable to open C:kctesttmp.ass` |
| **`subtitles=C\\:/kctest/tmp.ass`** | ✅ |

## What is deliberately left alone

The escaping rule depends on whether the value lands inside single quotes, so this is not a blanket
substitution. Tested both ways with `lut3d`:

| Form | Current escape | New escape |
|---|---|---|
| unquoted `lut3d=<path>` | ❌ | ✅ |
| quoted `lut3d=file='<path>'` | ✅ | ❌ |

So `still_plates/grade.py`, which builds the quoted form, is **unchanged** — switching it would have broken
LUT grading. Font *names* (`FontName=`, `font=`) and every numeric or colour value also keep
`_escape_ffmpeg_filter_value`.

## Call sites changed

| File | Filter option |
|---|---|
| `engine_subtitles.py` | `subtitles=` |
| `effects_engine/text.py` | `subtitles=`, `fontfile=`, `sendcmd=f=` |
| `engine_text.py` | `fontfile=` |
| `engine_timeline.py` | `fontfile=` |
| `aivideo/graphics_recipe.py` | `fontfile=` |
| `ai_engine/color.py` | `lut3d=` |
| `engine_stabilize.py` | `vidstabdetect=result=`, `vidstabtransform=input=` |

## Verification

On Windows 11, Python 3.12, ffmpeg 9.0-full_build, against an editable install of this branch.

**It fixes 39 tests that already fail on `master`.** Same selection, same machine, `-m "not slow"
--continue-on-collection-errors`, filtered to `subtitle or drawtext or lut or stabilize or escape or filter`:

| | failed | passed |
|---|---|---|
| `master` (d6ebb6e) | 130 | 289 |
| this branch | **91** | **334** |

289 + 39 fixed + 6 new = 334, so nothing that passed before regressed.

Also:

- `kino subtitles` now succeeds, and the subtitles are visibly burned in — confirmed by extracting a frame,
  not just by exit code.
- `tests/test_ffmpeg_filter_path.py` — 6 tests, all passing. One of them pins the old single-pass behaviour so
  the distinction between the two helpers stays documented.
- The 71 collection errors in that run are identical with and without this change — pre-existing Windows
  issues in the suite, unrelated to it.
- All touched modules import cleanly, except `aivideo/graphics_recipe.py`, which is blocked upstream of this
  change by the known `projectstore/store.py` `fcntl` import (existing issue *"MCP mode fails on Windows"*).
  The traceback never reaches the edited code.

## Note

This looks like it belongs with the in-flight Windows work (*"CI: add a Windows smoke job"*, *"Wayfinder map:
first-class Windows support and honest diagnostics"*). A Windows smoke job covering `subtitles` would have
caught it.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/kinocut/pr/458"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789521411&installation_model_id=20207&pr_number=458&repository=KyaniteLabs%2Fkinocut&return_to=https%3A%2F%2Fgithub.com%2FKyaniteLabs%2Fkinocut%2Fpull%2F458&signature=2027404bb61275aaa145cdfb130cb0d31695f8491cc9366554bab74a2113ab81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Windows and other filesystem paths in video filters.
  * Fixed issues affecting LUTs, fonts, subtitles, stabilization files, and text-rendering assets.
  * Preserved correct escaping for regular filter values.

* **Tests**
  * Added coverage for Windows drive-letter paths, POSIX paths, relative paths, and scalar filter values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->