### PR TITLE
feat(windows): contention-only lock contract + Windows CI smoke job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -389,3 +389,45 @@ jobs:
       - name: Build Docker image
         if: needs.changes.outputs.docker == 'true'
         run: docker build -t kinocut:test .
+
+  windows-smoke:
+    name: Windows smoke
+    needs: changes
+    runs-on: windows-latest
+    steps:
+      - name: Skip Windows smoke
+        if: needs.changes.outputs.code != 'true'
+        run: echo "Code inputs unchanged; marking Windows smoke check successful."
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        if: needs.changes.outputs.code == 'true'
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        if: needs.changes.outputs.code == 'true'
+        with:
+          python-version: '3.14'
+          cache: 'pip'
+          cache-dependency-path: 'pyproject.toml'
+      - name: Ensure FFmpeg
+        if: needs.changes.outputs.code == 'true'
+        shell: pwsh
+        run: |
+          choco install -y ffmpeg --no-progress
+          ffmpeg -version
+          ffprobe -version
+      - name: Install package and dev dependencies
+        if: needs.changes.outputs.code == 'true'
+        run: python -m pip install -e ".[dev]" ruff
+      - name: Lint
+        if: needs.changes.outputs.code == 'true'
+        run: python -m ruff check kinocut/ mcp_video.py tests/
+      - name: Import checks (server tree imports on Windows)
+        if: needs.changes.outputs.code == 'true'
+        run: |
+          python -c "import kinocut.server"
+          python -c "import kinocut.projectstore._filelock"
+          python mcp_video.py --version
+      - name: Doctor (primary integration paths)
+        if: needs.changes.outputs.code == 'true'
+        run: kino doctor
+      - name: Public-surface tests (platform skips honored)
+        if: needs.changes.outputs.code == 'true'
+        run: python -m pytest tests/ -q -m "not slow" --tb=short -n auto --maxprocesses=4 --dist loadfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -430,4 +430,8 @@ jobs:
         run: kino doctor
       - name: Public-surface tests (platform skips honored)
         if: needs.changes.outputs.code == 'true'
-        run: python -m pytest tests/ -q -m "not slow" --tb=short -n auto --maxprocesses=4 --dist loadfile
+        run: >-
+          python -m pytest tests/test_public_surface.py tests/test_doctor.py
+          tests/test_models.py tests/test_errors.py
+          tests/test_projectstore_filelock.py
+          -q --tb=short

--- a/kinocut/__main__.py
+++ b/kinocut/__main__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import json
 import logging
 import re
@@ -171,7 +172,24 @@ def _dispatch_cli(args: object, *, use_json: bool) -> bool:
     )
 
 
+def _force_utf8_stdio() -> None:
+    """Windows consoles default to a legacy code page; CLI text is Unicode.
+
+    Help text and diagnostics contain non-ASCII characters (arrows, em dashes)
+    that crash on cp1252 with ``EncodeError`` instead of rendering. Reconfigure
+    to UTF-8 with replacement so output degrades gracefully everywhere (#447).
+    """
+
+    for stream in (sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, "reconfigure", None)
+        if reconfigure is None:
+            continue
+        with contextlib.suppress(ValueError, OSError):
+            reconfigure(encoding="utf-8", errors="replace")
+
+
 def main() -> None:
+    _force_utf8_stdio()
     parser = build_parser()
     args = parser.parse_args(_rewrite_namespaced_argv(sys.argv[1:]))
 

--- a/kinocut/doctor.py
+++ b/kinocut/doctor.py
@@ -328,6 +328,10 @@ def _check_audio_engine() -> dict[str, Any]:
 def _check_mcp_video(find_spec: FindSpecFn, package_version: PackageVersionFn) -> dict[str, Any]:
     spec = find_spec("kinocut")
     path = getattr(spec, "origin", None) if spec is not None else None
+    if path is not None:
+        # Report platform-stable separators so diagnostics compare and grep
+        # identically across Windows and POSIX (#447).
+        path = path.replace(os.sep, "/")
     found = spec is not None
     return {
         "name": "mcp-video",

--- a/kinocut/projectstore/_filelock.py
+++ b/kinocut/projectstore/_filelock.py
@@ -7,21 +7,30 @@ provides byte-range locking, which is enough for the whole-file advisory leases
 used here: every participant locks the same single byte of the same lease file.
 
 The two backends are kept behaviourally identical so callers need no platform
-branches:
+branches (#451 enforces this with cross-platform contract tests):
 
-- ``lock_exclusive(handle)`` blocks until the lock is acquired.
+- ``lock_exclusive(handle)`` blocks until the lock is acquired, retrying only
+  while the error signals genuine contention (the two Windows locking-contention
+  errnos). Permanent errors — bad descriptor, permissions, unreadable file —
+  propagate promptly so a broken lease fails loudly instead of hanging.
 - ``lock_exclusive(handle, blocking=False)`` raises :class:`BlockingIOError`
-  when another holder has it. ``flock`` does this natively; ``msvcrt`` raises a
-  plain ``OSError``, so it is normalised here.
+  when another holder has it; contention errnos are normalised to that signal
+  and every other error surfaces untranslated.
 - ``unlock(handle)`` releases it.
 
 Both accept either a raw file descriptor or any object with ``fileno()``,
 matching the mix already present in the store (``os.open`` in ``store`` versus
 ``Path.open`` in the render job modules).
+
+Backend selection happens at call time (``_HAVE_FCNTL``) rather than import
+time so the Windows contract is testable on POSIX by flipping the flag and
+injecting a fake ``msvcrt`` — the property "behaviourally identical" is a
+checked property, not a promise.
 """
 
 from __future__ import annotations
 
+import errno
 import os
 from typing import IO
 
@@ -38,6 +47,11 @@ except ImportError:  # Windows
 # sufficient and is what every participant agrees to lock.
 _LOCK_BYTES = 1
 
+# The only errnos msvcrt.locking raises for genuine lock contention, per the
+# Windows locking documentation (EACCES: region already locked; EDEADLK: would
+# deadlock). Everything else — EBADF, EPERM, EINVAL, ... — is permanent.
+_WINDOWS_CONTENTION_ERRNOS = frozenset({errno.EACCES, errno.EDEADLK})
+
 Lockable = int | IO[bytes]
 
 
@@ -45,45 +59,72 @@ def _descriptor(handle: Lockable) -> int:
     return handle if isinstance(handle, int) else handle.fileno()
 
 
-if _HAVE_FCNTL:
+def _is_windows_contention(exc: OSError) -> bool:
+    return exc.errno in _WINDOWS_CONTENTION_ERRNOS
 
-    def lock_exclusive(handle: Lockable, *, blocking: bool = True) -> None:
-        flags = fcntl.LOCK_EX if blocking else fcntl.LOCK_EX | fcntl.LOCK_NB
-        fcntl.flock(_descriptor(handle), flags)
 
-    def unlock(handle: Lockable) -> None:
-        fcntl.flock(_descriptor(handle), fcntl.LOCK_UN)
+def _lock_exclusive_posix(handle: Lockable, *, blocking: bool) -> None:
+    flags = fcntl.LOCK_EX if blocking else fcntl.LOCK_EX | fcntl.LOCK_NB
+    fcntl.flock(_descriptor(handle), flags)
 
-else:
 
-    def _at_offset_zero(fd: int, mode: int) -> None:
-        """Run one msvcrt lock operation at offset 0, restoring the position."""
-        previous = os.lseek(fd, 0, os.SEEK_CUR)
-        os.lseek(fd, 0, os.SEEK_SET)
+def _unlock_posix(handle: Lockable) -> None:
+    fcntl.flock(_descriptor(handle), fcntl.LOCK_UN)
+
+
+def _at_offset_zero(fd: int, mode: int) -> None:
+    """Run one msvcrt lock operation at offset 0, restoring the position."""
+    previous = os.lseek(fd, 0, os.SEEK_CUR)
+    os.lseek(fd, 0, os.SEEK_SET)
+    try:
+        msvcrt.locking(fd, mode, _LOCK_BYTES)
+    finally:
+        os.lseek(fd, previous, os.SEEK_SET)
+
+
+def _lock_exclusive_windows(handle: Lockable, *, blocking: bool) -> None:
+    fd = _descriptor(handle)
+    if not blocking:
         try:
-            msvcrt.locking(fd, mode, _LOCK_BYTES)
-        finally:
-            os.lseek(fd, previous, os.SEEK_SET)
+            _at_offset_zero(fd, msvcrt.LK_NBLCK)
+        except OSError as exc:
+            # flock signals contention with BlockingIOError; msvcrt uses a
+            # bare OSError for it. Callers catch BlockingIOError, so translate
+            # contention only — permanent errors surface untranslated.
+            if not _is_windows_contention(exc):
+                raise
+            raise BlockingIOError(exc.errno, exc.strerror) from exc
+        return
 
-    def lock_exclusive(handle: Lockable, *, blocking: bool = True) -> None:
-        fd = _descriptor(handle)
-        if not blocking:
-            try:
-                _at_offset_zero(fd, msvcrt.LK_NBLCK)
-            except OSError as exc:
-                # flock signals contention with BlockingIOError; msvcrt uses a
-                # bare OSError. Callers catch BlockingIOError, so translate.
-                raise BlockingIOError(exc.errno, exc.strerror) from exc
+    # LK_LOCK retries ten times at one-second intervals and then gives up,
+    # while the POSIX blocking contract waits indefinitely. Loop so the
+    # blocking contract holds — but only across genuine contention, so a
+    # permanently broken lease raises instead of hanging forever.
+    while True:
+        try:
+            _at_offset_zero(fd, msvcrt.LK_LOCK)
             return
+        except OSError as exc:
+            if not _is_windows_contention(exc):
+                raise
+            continue
 
-        # LK_LOCK retries ten times at one-second intervals and then gives up,
-        # while LOCK_EX waits indefinitely. Loop so the blocking contract holds.
-        while True:
-            try:
-                _at_offset_zero(fd, msvcrt.LK_LOCK)
-                return
-            except OSError:
-                continue
 
-    def unlock(handle: Lockable) -> None:
-        _at_offset_zero(_descriptor(handle), msvcrt.LK_UNLCK)
+def _unlock_windows(handle: Lockable) -> None:
+    _at_offset_zero(_descriptor(handle), msvcrt.LK_UNLCK)
+
+
+def lock_exclusive(handle: Lockable, *, blocking: bool = True) -> None:
+    """Acquire the exclusive lease lock; block until held unless ``blocking=False``."""
+    if _HAVE_FCNTL:
+        _lock_exclusive_posix(handle, blocking=blocking)
+    else:
+        _lock_exclusive_windows(handle, blocking=blocking)
+
+
+def unlock(handle: Lockable) -> None:
+    """Release the exclusive lease lock."""
+    if _HAVE_FCNTL:
+        _unlock_posix(handle)
+    else:
+        _unlock_windows(handle)

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -173,6 +173,8 @@ def test_hyperframes_core_probe_handles_esm_only_exports(tmp_path):
         ["node", "-e", HYPERFRAMES_CORE_PROBE],
         capture_output=True,
         text=True,
+        encoding="utf-8",
+        errors="replace",
         cwd=tmp_path,
         timeout=30,
     )
@@ -189,6 +191,8 @@ def test_hyperframes_core_probe_fails_when_package_absent(tmp_path):
         ["node", "-e", HYPERFRAMES_CORE_PROBE],
         capture_output=True,
         text=True,
+        encoding="utf-8",
+        errors="replace",
         cwd=tmp_path,
         timeout=30,
     )
@@ -356,6 +360,8 @@ def test_cli_doctor_json_outputs_structured_report():
         [sys.executable, "-m", "mcp_video", "doctor", "--json"],
         capture_output=True,
         text=True,
+        encoding="utf-8",
+        errors="replace",
         timeout=30,
     )
 
@@ -373,6 +379,8 @@ def test_cli_doctor_text_outputs_summary():
         [sys.executable, "-m", "mcp_video", "doctor"],
         capture_output=True,
         text=True,
+        encoding="utf-8",
+        errors="replace",
         timeout=30,
     )
 

--- a/tests/test_projectstore_filelock.py
+++ b/tests/test_projectstore_filelock.py
@@ -9,6 +9,7 @@ is enforced on every platform, not just Windows.
 from __future__ import annotations
 
 import errno
+import os
 from pathlib import Path
 
 import pytest
@@ -26,9 +27,13 @@ class _FakeMsvcrt:
     def __init__(self, outcomes: list[BaseException | None]) -> None:
         self._outcomes = list(outcomes)
         self.calls: list[tuple[int, int]] = []
+        self.seen_byte_counts: list[int] = []
+        self.seen_entry_offsets: list[int] = []
 
     def locking(self, fd: int, mode: int, nbytes: int) -> None:
         self.calls.append((fd, mode))
+        self.seen_byte_counts.append(nbytes)
+        self.seen_entry_offsets.append(os.lseek(fd, 0, os.SEEK_CUR))
         outcome = self._outcomes.pop(0) if self._outcomes else None
         if outcome is not None:
             raise outcome
@@ -88,6 +93,9 @@ class TestWindowsBlockingContract:
         with lease.open("a+b") as handle:
             filelock.unlock(handle)
         assert fake.calls[0][1] == _FakeMsvcrt.LK_UNLCK
+        # cross-participant agreement: exactly one byte, locked at offset 0
+        assert fake.seen_byte_counts == [filelock._LOCK_BYTES]
+        assert fake.seen_entry_offsets == [0]
 
 
 class TestWindowsNonBlockingContract:
@@ -116,6 +124,7 @@ class TestWindowsNonBlockingContract:
         assert len(fake.calls) == 1
 
 
+@pytest.mark.skipif(not hasattr(filelock, "fcntl"), reason="POSIX backend not importable on this platform")
 class TestPosixBackendUnchanged:
     def test_dispatch_uses_posix_when_fcntl_present(self, monkeypatch, tmp_path):
         monkeypatch.setattr(filelock, "_HAVE_FCNTL", True)

--- a/tests/test_projectstore_filelock.py
+++ b/tests/test_projectstore_filelock.py
@@ -1,0 +1,134 @@
+"""Cross-platform error-contract tests for the portable projectstore lock (#451).
+
+The Windows backend is exercised on POSIX by flipping the call-time backend
+flag and injecting a fake ``msvcrt`` module, so the contract — permanent errors
+raise promptly, only genuine contention waits or maps to ``BlockingIOError`` —
+is enforced on every platform, not just Windows.
+"""
+
+from __future__ import annotations
+
+import errno
+from pathlib import Path
+
+import pytest
+
+import kinocut.projectstore._filelock as filelock
+
+
+class _FakeMsvcrt:
+    """msvcrt.locking stand-in scripted per test."""
+
+    LK_LOCK = 1
+    LK_NBLCK = 2
+    LK_UNLCK = 3
+
+    def __init__(self, outcomes: list[BaseException | None]) -> None:
+        self._outcomes = list(outcomes)
+        self.calls: list[tuple[int, int]] = []
+
+    def locking(self, fd: int, mode: int, nbytes: int) -> None:
+        self.calls.append((fd, mode))
+        outcome = self._outcomes.pop(0) if self._outcomes else None
+        if outcome is not None:
+            raise outcome
+
+
+@pytest.fixture()
+def windows_backend(monkeypatch, tmp_path: Path):
+    """Force the Windows code path with a scriptable msvcrt lock primitive."""
+
+    def install(outcomes: list[BaseException | None]) -> _FakeMsvcrt:
+        fake = _FakeMsvcrt(outcomes)
+        monkeypatch.setattr(filelock, "_HAVE_FCNTL", False)
+        monkeypatch.setattr(filelock, "msvcrt", fake, raising=False)
+        return fake
+
+    return install
+
+
+class TestWindowsBlockingContract:
+    def test_permanent_error_raises_promptly(self, windows_backend, tmp_path):
+        lease = tmp_path / "lease"
+        lease.touch()
+        windows_backend([OSError(errno.EBADF, "bad descriptor")])
+        with lease.open("a+b") as handle, pytest.raises(OSError) as excinfo:
+            filelock.lock_exclusive(handle, blocking=True)
+        assert excinfo.value.errno == errno.EBADF
+
+    def test_permission_error_is_permanent_not_hang(self, windows_backend, tmp_path):
+        # EACCES is contention on Windows locking; a permissions failure there
+        # surfaces as EPERM, which must raise instead of retrying forever.
+        lease = tmp_path / "lease"
+        lease.touch()
+        fake = windows_backend([OSError(errno.EPERM, "permission denied")])
+        with lease.open("a+b") as handle, pytest.raises(OSError) as excinfo:
+            filelock.lock_exclusive(handle, blocking=True)
+        assert excinfo.value.errno == errno.EPERM
+        assert len(fake.calls) == 1
+
+    def test_contention_retries_until_acquired(self, windows_backend, tmp_path):
+        lease = tmp_path / "lease"
+        lease.touch()
+        fake = windows_backend(
+            [
+                OSError(errno.EACCES, "contention"),
+                OSError(errno.EDEADLK, "deadlock"),
+                None,  # third attempt succeeds
+            ]
+        )
+        with lease.open("a+b") as handle:
+            filelock.lock_exclusive(handle, blocking=True)
+        assert len(fake.calls) == 3
+
+    def test_unlock_runs_unlock_mode(self, windows_backend, tmp_path):
+        lease = tmp_path / "lease"
+        lease.touch()
+        fake = windows_backend([None])
+        with lease.open("a+b") as handle:
+            filelock.unlock(handle)
+        assert fake.calls[0][1] == _FakeMsvcrt.LK_UNLCK
+
+
+class TestWindowsNonBlockingContract:
+    def test_contention_maps_to_blockingioerror(self, windows_backend, tmp_path):
+        lease = tmp_path / "lease"
+        lease.touch()
+        windows_backend([OSError(errno.EACCES, "contention")])
+        with lease.open("a+b") as handle, pytest.raises(BlockingIOError):
+            filelock.lock_exclusive(handle, blocking=False)
+
+    def test_deadlock_maps_to_blockingioerror(self, windows_backend, tmp_path):
+        lease = tmp_path / "lease"
+        lease.touch()
+        windows_backend([OSError(errno.EDEADLK, "deadlock")])
+        with lease.open("a+b") as handle, pytest.raises(BlockingIOError):
+            filelock.lock_exclusive(handle, blocking=False)
+
+    def test_permanent_error_propagates_untranslated(self, windows_backend, tmp_path):
+        lease = tmp_path / "lease"
+        lease.touch()
+        fake = windows_backend([OSError(errno.EBADF, "bad descriptor")])
+        with lease.open("a+b") as handle, pytest.raises(OSError) as excinfo:
+            filelock.lock_exclusive(handle, blocking=False)
+        assert not isinstance(excinfo.value, BlockingIOError)
+        assert excinfo.value.errno == errno.EBADF
+        assert len(fake.calls) == 1
+
+
+class TestPosixBackendUnchanged:
+    def test_dispatch_uses_posix_when_fcntl_present(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(filelock, "_HAVE_FCNTL", True)
+        lease = tmp_path / "lease"
+        lease.touch()
+        calls: list[tuple[int, int]] = []
+        real_flock = filelock.fcntl.flock
+
+        def spy_flock(fd, flags):
+            calls.append((fd, flags))
+            return real_flock(fd, flags)
+
+        monkeypatch.setattr(filelock.fcntl, "flock", spy_flock)
+        with lease.open("a+b") as handle:
+            filelock.lock_exclusive(handle, blocking=False)
+        assert calls, "POSIX backend must be dispatched when _HAVE_FCNTL is true"

--- a/tests/test_public_surface.py
+++ b/tests/test_public_surface.py
@@ -795,9 +795,7 @@ def test_github_mirror_smoke_runs_on_master_without_private_runners():
 
 
 def test_public_surface_manifest_covers_agent_discovery_files():
-    public_paths = {
-        str(path.relative_to(ROOT)).replace(os.sep, "/") for path in _public_surface_paths()
-    }
+    public_paths = {str(path.relative_to(ROOT)).replace(os.sep, "/") for path in _public_surface_paths()}
 
     assert "llms.txt" in public_paths
     assert "docs/AI_AGENT_DISCOVERY.md" in public_paths

--- a/tests/test_public_surface.py
+++ b/tests/test_public_surface.py
@@ -1,6 +1,7 @@
 """Characterization tests for public import and command surfaces."""
 
 import re
+import os
 import subprocess
 import sys
 import asyncio
@@ -794,7 +795,9 @@ def test_github_mirror_smoke_runs_on_master_without_private_runners():
 
 
 def test_public_surface_manifest_covers_agent_discovery_files():
-    public_paths = {str(path.relative_to(ROOT)) for path in _public_surface_paths()}
+    public_paths = {
+        str(path.relative_to(ROOT)).replace(os.sep, "/") for path in _public_surface_paths()
+    }
 
     assert "llms.txt" in public_paths
     assert "docs/AI_AGENT_DISCOVERY.md" in public_paths


### PR DESCRIPTION
Implements the remaining Windows roadmap (#447): **#451** and **#452**.

## #451 — lock error narrowing
- `_filelock` rewritten with **call-time backend dispatch** (import-time selection made the Windows contract untestable on POSIX): blocking path retries **only across the two Windows contention errnos** (EACCES, EDEADLK per MS locking docs) so permanent errors (EBADF, EPERM, EINVAL) raise promptly — a broken lease fails loudly instead of hanging; non-blocking path translates **contention-only** to `BlockingIOError`. POSIX behavior unchanged (identical flock flags; verified by dispatch test + full suite).
- New `tests/test_projectstore_filelock.py`: 8 cross-platform contract tests via flag-flip + fake `msvcrt` — permanent-raise, contention-retry-until-acquired, EPERM-is-permanent, unlock mode, offset-0/one-byte cross-participant agreement, non-blocking translation both ways, POSIX dispatch. *Behaviourally identical* is now a checked property (#450's contract clause).

## #452 — Windows CI smoke job
- `windows-smoke` on `windows-latest`: changes-gated; choco ffmpeg; **lint → server-tree import checks (`import kinocut.server`, shim `--version`) → `kino doctor` → focused public-surface suite** (per spec: fast, not the full media tree). This is the on-platform verification loop for #447/#450/#451 — and the answer to "no Windows PC": CI is the Windows machine.

## Already landed elsewhere on the roadmap
#447's entry-point and doctor halves shipped as #454/#455; #450's skip half as #456. With this PR the map is complete: closes #451, closes #452, and completes #450 (skips proven on-platform by the new job; interpreter-invoked stubs can now be iterated against a green Windows baseline).

## Verification
- Full macOS suite: **4,695 passed**, 1 pre-existing env failure (mcpb node launcher — fails identically without this diff; stash-verified, not a regression).
- Focused subset (the CI job's set): 129 passed.
- ruff + format clean; review-passed (two catches fixed: POSIX-test skip-guard, focused CI subset).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/kinocut/pr/460"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789719369&installation_model_id=20207&pr_number=460&repository=KyaniteLabs%2Fkinocut&return_to=https%3A%2F%2Fgithub.com%2FKyaniteLabs%2Fkinocut%2Fpull%2F460&signature=c2fdb862e7a159f4db4d402aea13371b82f56876604fa48af1ee604180244d6a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cross-platform file-locking behavior, including more reliable Windows contention handling.
  * Permanent locking errors now surface promptly instead of being treated as temporary conflicts.
  * Preserved file position and unlock behavior across supported platforms.
  * Improved UTF-8 command-line output and platform-consistent diagnostic paths.

* **Tests**
  * Added comprehensive Windows and POSIX file-locking coverage.
  * Added Windows smoke checks for installation, command-line usage, diagnostics, and public behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->