### PR TITLE
ci(publish): republish legacy io.github.KyaniteLabs/mcp-video registry entry

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -96,6 +96,18 @@ jobs:
           if package_versions != {version}:
               failures.append(f"server.json package versions {sorted(package_versions)!r} do not match {version!r}")
 
+          shim_server = json.loads(Path("compat/mcp-video-shim/server.json").read_text())
+          if shim_server.get("name") != "io.github.KyaniteLabs/mcp-video":
+              failures.append(f"compatibility server name is {shim_server.get('name')!r}, expected 'io.github.KyaniteLabs/mcp-video'")
+          if shim_server.get("version") != shim_version:
+              failures.append(f"compatibility server.json version {shim_server.get('version')!r} does not match mcp-video {shim_version!r}")
+          shim_packages = shim_server.get("packages", [])
+          if any(pkg.get("registryType") != "pypi" or pkg.get("identifier") != "mcp-video" for pkg in shim_packages):
+              failures.append("compatibility server.json packages must reference the mcp-video PyPI distribution")
+          shim_package_versions = {pkg.get("version") for pkg in shim_packages}
+          if shim_package_versions != {shim_version}:
+              failures.append(f"compatibility server.json package versions {sorted(shim_package_versions)!r} do not match {shim_version!r}")
+
           def allow_existing_release_artifact(url, label):
               try:
                   urllib.request.urlopen(url, timeout=20).close()
@@ -132,16 +144,17 @@ jobs:
 
           from jsonschema import Draft7Validator
 
-          server = json.loads(Path("server.json").read_text())
-          with urllib.request.urlopen(server["$schema"], timeout=20) as response:
-              schema = json.load(response)
-          errors = sorted(Draft7Validator(schema).iter_errors(server), key=lambda error: list(error.path))
-          if errors:
-              for error in errors:
-                  path = "/".join(str(part) for part in error.path) or "<root>"
-                  print(f"{path}: {error.message}")
-              raise SystemExit(1)
-          print(f"MCP registry metadata is valid for {server['name']} {server['version']}.")
+          for metadata_path in ("server.json", "compat/mcp-video-shim/server.json"):
+              server = json.loads(Path(metadata_path).read_text())
+              with urllib.request.urlopen(server["$schema"], timeout=20) as response:
+                  schema = json.load(response)
+              errors = sorted(Draft7Validator(schema).iter_errors(server), key=lambda error: list(error.path))
+              if errors:
+                  for error in errors:
+                      path = "/".join(str(part) for part in error.path) or "<root>"
+                      print(f"{metadata_path}: {path}: {error.message}")
+                  raise SystemExit(1)
+              print(f"MCP registry metadata is valid for {server['name']} {server['version']} ({metadata_path}).")
           PY
       - name: Build Python distributions
         run: |
@@ -308,4 +321,6 @@ jobs:
       - name: Authenticate to MCP Registry
         run: ./mcp-publisher login github-oidc
       - name: Publish server metadata
-        run: ./mcp-publisher publish
+        run: |
+          ./mcp-publisher publish
+          ./mcp-publisher publish compat/mcp-video-shim/server.json

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -108,6 +108,9 @@ jobs:
           if shim_package_versions != {shim_version}:
               failures.append(f"compatibility server.json package versions {sorted(shim_package_versions)!r} do not match {shim_version!r}")
 
+          if "mcp-name: io.github.KyaniteLabs/mcp-video" not in Path("compat/mcp-video-shim/README.md").read_text():
+              failures.append("shim README lost the mcp-name marker — PyPI ownership validation at registry publish would fail")
+
           def allow_existing_release_artifact(url, label):
               try:
                   urllib.request.urlopen(url, timeout=20).close()

--- a/compat/mcp-video-shim/README.md
+++ b/compat/mcp-video-shim/README.md
@@ -1,3 +1,4 @@
+<!-- mcp-name: io.github.KyaniteLabs/mcp-video -->
 # mcp-video is now Kinocut
 
 This package preserves existing installs after the project rename. It installs the matching

--- a/compat/mcp-video-shim/pyproject.toml
+++ b/compat/mcp-video-shim/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-video"
-version = "1.6.11"
+version = "1.6.12"
 description = "Compatibility installer for Kinocut, formerly mcp-video."
 readme = "README.md"
 license = "Apache-2.0"

--- a/compat/mcp-video-shim/server.json
+++ b/compat/mcp-video-shim/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.KyaniteLabs/mcp-video",
   "title": "mcp-video",
   "description": "Compatibility package: mcp-video now installs Kinocut (formerly mcp-video).",
-  "version": "1.6.11",
+  "version": "1.6.12",
   "websiteUrl": "https://kinocut.dev/",
   "repository": {
     "url": "https://github.com/KyaniteLabs/kinocut",

--- a/compat/mcp-video-shim/server.json
+++ b/compat/mcp-video-shim/server.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.KyaniteLabs/mcp-video",
+  "title": "mcp-video",
+  "description": "Compatibility package: mcp-video now installs Kinocut (formerly mcp-video).",
+  "version": "1.6.11",
+  "websiteUrl": "https://kinocut.dev/",
+  "repository": {
+    "url": "https://github.com/KyaniteLabs/kinocut",
+    "source": "github"
+  },
+  "packages": [
+    {
+      "registryType": "pypi",
+      "identifier": "mcp-video",
+      "version": "1.6.11",
+      "runtimeHint": "uvx",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## What

The legacy MCP registry entry `io.github.KyaniteLabs/mcp-video` still serves pre-rename metadata (v1.6.0, dead site). Downstream directories (Glama — which 301s to kinocut and has self-healed — and PulseMCP, whose canonical entry is correct) read stale data from it.

- Add `compat/mcp-video-shim/server.json` naming the legacy entry, pointing its `pypi` package at `mcp-video` (version aligned to the shim's `pyproject.toml`, currently 1.6.11), with `websiteUrl` `https://kinocut.dev/` and repo `KyaniteLabs/kinocut`.
- `publish-mcp-registry` job now publishes it alongside the canonical `server.json`: `mcp-publisher publish compat/mcp-video-shim/server.json` (`publish [PATH]` is a documented CLI form; default remains `./server.json`).
- `build` job now schema-validates both server.json files and asserts the shim server.json name/version/package match the shim's pyproject (same style as the existing canonical checks).

## Notes

- Namespace auth: `github-oidc` grants ownership of `io.github.KyaniteLabs/*` (the repo owner), so publishing the legacy name from this repo is allowed. The entry was originally published under the same org namespace.
- Verified locally against `server.schema.json` 2025-12-11 (description `maxLength` is 100 — caught and trimmed) and ran the full version-check script with `RELEASE_TAG=v1.15.0`: all aligned; `mcp-video 1.6.11` already exists on PyPI.
- No workflow triggers, permissions, `needs`, or conditions changed — only one extra publish command plus validation.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/kinocut/pr/469"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790721109&installation_model_id=20207&pr_number=469&repository=KyaniteLabs%2Fkinocut&return_to=https%3A%2F%2Fgithub.com%2FKyaniteLabs%2Fkinocut%2Fpull%2F469&signature=3d7d103102ad6e0e33067c78709b5a606531f56238fb4e7a6098a9e7baf4f530"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added compatibility metadata for the mcp-video package, including updated version details, descriptions, documentation links, and runtime configuration.
  * Added support for validating and publishing both server metadata files in the MCP registry.
  * Added the required package ownership marker to the compatibility package documentation.

* **Bug Fixes**
  * Improved release verification to check package references, names, and versions across all supported server metadata files.
  * Updated the compatibility package release to version 1.6.12.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->