### PR TITLE
docs(changelog): record 1.15.1; backfill #458 item + credit in 1.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ This project follows a simple release-note style:
 
 ## Unreleased
 
+## 1.15.1 - 2026-08-31
+
+Maintenance release: registry ownership plus the object-matte streaming port.
+
+### Changed
+- **mcp-video shim 1.6.12:** the compatibility shim carries the registry ownership marker, and the legacy `io.github.KyaniteLabs/mcp-video` registry entry was republished so directory listings (Glama, PulseMCP) point at living metadata (#469).
+- **Object-matte streaming decode:** the object-matte engine now streams decode with scratch-directory caps — bounded memory on large inputs — with matching human-gate and product docs (#414, port of #412).
+
+### Docs
+- Colima warm-land recipe for CI landings, and the pinned tip SHA recorded after the #414 port (#415, #416).
+
 ## 1.15.0 - 2026-08-19
 
 ### Added
@@ -26,12 +37,16 @@ This project follows a simple release-note style:
 - **First-class Windows support:** portable projectstore file locking (`fcntl`/`msvcrt`) by [@gerardoscaglia-creator](https://github.com/gerardoscaglia-creator) (#446, landed with credit) — `kino --mcp` is importable on Windows; the lock backends enforce a contention-only error contract (permanent errors raise promptly; only genuine contention waits or maps to `BlockingIOError`) verified by cross-platform contract tests (#451).
 - **Windows CI smoke job:** `windows-latest` runs lint, server-tree import checks, `kino doctor`, and the focused public-surface suite on every code change — Windows breakage can no longer land silently (#452).
 
+### Fixed
+- **Windows filter-option paths:** both FFmpeg unescaping passes escape filter-option paths correctly on Windows ([#458](https://github.com/KyaniteLabs/kinocut/pull/458) by [@pedropaav-art](https://github.com/pedropaav-art), merged with credit — item and credit backfilled 2026-08-31; the fix shipped in this release).
+
 ### Compatibility
 - `mcp-video==1.6.11` installs `kinocut==1.15.0`.
 - Published surface stays **196 MCP tools / 167 CLI commands**.
 
 ### Acknowledgements
 - [@gerardoscaglia-creator](https://github.com/gerardoscaglia-creator) filed the Windows MCP-mode investigation ([#445](https://github.com/KyaniteLabs/kinocut/issues/445)) — the root-cause traceback in it exposed both diagnostics gaps fixed above — and contributed the portable file-locking fix ([#446](https://github.com/KyaniteLabs/kinocut/pull/446), landed on master with credit). Every fix in this release traces to that report. Bug reports with reproduction steps are contributions; thank you.
+- [@pedropaav-art](https://github.com/pedropaav-art) contributed the Windows filter-option path escaping fix ([#458](https://github.com/KyaniteLabs/kinocut/pull/458)), which shipped in this release (credit backfilled 2026-08-31). Thank you.
 - Kinocut's external community predates this release: betsmayank's merged Hyperframes no-TTY fix ([#361](https://github.com/KyaniteLabs/kinocut/pull/361)), austinwmson's `remotion_still` props report ([#306](https://github.com/KyaniteLabs/kinocut/issues/306)), ismailkattakath's self-host reference stack ([#432](https://github.com/KyaniteLabs/kinocut/issues/432)), and early PRs from Dodothereal and OyaAIProd. All of them shaped the product.
 
 ## 1.14.1 - 2026-08-13


### PR DESCRIPTION
## Root cause
1.15.1 (published 2026-08-31) shipped with no CHANGELOG section — its shim 1.6.12 registry republish (#469), the object-matte streaming port (#414), and docs tips (#415/#416) went unrecorded. Separately, #458 by @pedropaav-art merged 2026-08-18 and shipped in v1.15.0, but the 1.15.0 section carried neither the item nor the acknowledgement (credit was owed at the next release; the window was missed).

## Change
- Adds the full `## 1.15.1 - 2026-08-31` section (Changed: #469, #414; Docs: #415, #416).
- Backfills a `### Fixed` item for #458 in the 1.15.0 section + adds @pedropaav-art to 1.15.0 Acknowledgements (marked as backfilled 2026-08-31).

## Verification
`pytest tests/test_public_claims.py tests/test_kinocut_distribution.py -q`: 13 passed, 10 failed — failure set **byte-identical to clean github/master** on this machine (known local environment failures: mcpb build/node-floor under local Node v26.7.0), so the docs change introduces no regressions. Docs-only diff; no version strings altered.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/kinocut/pr/470"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790749361&installation_model_id=20207&pr_number=470&repository=KyaniteLabs%2Fkinocut&return_to=https%3A%2F%2Fgithub.com%2FKyaniteLabs%2Fkinocut%2Fpull%2F470&signature=9ae79e0363eadd7a7c390d70fc5f4a2a8e5160ff6c3c1f01b10a0213a1a2edde"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added release notes for version 1.15.1, including registry updates, object-matte streaming improvements, scratch-directory limits, and Colima warm-land guidance.
  * Documented a Windows fix for filter-option path escaping in the 1.15.0 release notes.
  * Added contributor acknowledgement for the Windows fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->