### PR TITLE
fix(release): complete the 1.15.1 version-constellation sweep

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 <p align="center">
   <a href="#see-it-work">Demo</a> &bull;
   <a href="#status-and-releases">Status</a> &bull;
-  <a href="#whats-in-1150">1.15.0</a> &bull;
+  <a href="#whats-in-1151">1.15.1</a> &bull;
   <a href="#changelog">Changelog</a> &bull;
   <a href="#beyond-1150-draft--gated">Beyond</a> &bull;
   <a href="#installation">Install</a> &bull;
@@ -70,7 +70,7 @@
 | | |
 | --- | --- |
 | **Also known as** | `kino` (CLI); formerly **mcp-video** / `mcp_video` |
-| **Latest published release** | **[1.15.0](https://github.com/KyaniteLabs/kinocut/releases/tag/v1.15.0)** (2026-08-19) |
+| **Latest published release** | **[1.15.1](https://github.com/KyaniteLabs/kinocut/releases/tag/v1.15.1)** (2026-08-31) |
 | **Product site** | [kinocut.dev](https://kinocut.dev/) |
 | **PyPI** | [`kinocut`](https://pypi.org/project/kinocut/) |
 | **MCP Registry** | [`io.github.KyaniteLabs/kinocut`](https://registry.modelcontextprotocol.io/v0/servers/io.github.KyaniteLabs%2Fkinocut/versions/latest) |
@@ -116,11 +116,15 @@ video.release_checkpoint(short.output_path)  # thumbnail + quality gate before y
 
 | Surface | Version / tip | What it means |
 | --- | --- | --- |
-| **PyPI / npm / GitHub Release** | **[1.15.0](https://github.com/KyaniteLabs/kinocut/releases/tag/v1.15.0)** (2026-08-19) | Latest **published** Kinocut. Install with `pip install kinocut`. |
-| **This repository (`master`)** | **1.15.0** counts · **196 MCP / 167 CLI** | Same public counts as published 1.15.0. Tip also has `kinocut[object-matte]` (not in pip 1.15.0 yet). |
+| **PyPI / npm / GitHub Release** | **[1.15.1](https://github.com/KyaniteLabs/kinocut/releases/tag/v1.15.1)** (2026-08-31) | Latest **published** Kinocut. Install with `pip install kinocut`. |
+| **This repository (`master`)** | **1.15.1** counts · **196 MCP / 167 CLI** | Same public counts as published 1.15.1. |
 | **Next public release** | **TBD** | Human residuals (directories, launch posts) stay gated; further bumps need a new go-ahead. |
 
 Install from PyPI for the stable package. Clone `master` when you want tip work after the latest tag (today that includes object-matte; see [docs/PRODUCT_MATTE.md](docs/PRODUCT_MATTE.md)).
+
+## What's in 1.15.1
+
+Kinocut **1.15.1** is a maintenance release on top of 1.15.0: the `mcp-video` compatibility shim **1.6.12** carries the registry ownership marker, the legacy `io.github.KyaniteLabs/mcp-video` registry entry was republished so directory listings (Glama, PulseMCP) point at living metadata (#469), and the object-matte engine now streams decode with scratch-directory caps — bounded memory on large inputs (#414). Surface stays **196 MCP / 167 CLI** — no new public tool name.
 
 ## What's in 1.15.0
 
@@ -133,7 +137,7 @@ Kinocut **1.15.0** is what you get from `pip install kinocut` today: first-class
 - **Faster 360 and import path** — single-pass split/PiP/switch `filter_complex` (source audio kept); sampled quality-gate analyze window; SHA-256 path/mtime cache; merge can skip re-probe when `infos=` is supplied; batched 360 storyboard stills; lazy `mcp_video` / CLI / `Client.search_tools`; doctor skips `npx --yes` unless Hyperframes is already on PATH.
 - **Lazy public import** — `import kinocut` no longer eagerly loads Client/engines (PEP 562). `from kinocut import Client` and `kinocut.Client is mcp_video.Client` still hold.
 - **Ship-seam honesty** — CLI/Client `repurpose` default `--min-score` 80; `shorts-package` fail-closed unless `--allow-fail`; durable MCP `video_repurpose` does not apply `min_score`.
-- **Compatibility window** — `mcp-video==1.6.11` installs `kinocut==1.15.0`. `mcp_video` imports, `MCP_VIDEO_*` env vars, `~/.mcp-video` data, `mcp-video://` resources, and legacy receipt keys remain supported **on the 1.14.x+ line**.
+- **Compatibility window** — `mcp-video==1.6.12` installs `kinocut==1.15.1`. `mcp_video` imports, `MCP_VIDEO_*` env vars, `~/.mcp-video` data, `mcp-video://` resources, and legacy receipt keys remain supported **on the 1.14.x+ line**.
 
 Also already on the published line from 1.13.x:
 
@@ -407,7 +411,7 @@ pip install --upgrade mcp-video
 mcp-video doctor
 ```
 
-Published `mcp-video==1.6.11` is a metadata-only compatibility installer for `kinocut==1.15.0`. The `mcp_video` import, `mcp-video` command, `MCP_VIDEO_*` environment variables, `~/.mcp-video` data directory, `mcp-video://` resource URIs, and existing receipt keys remain supported on the 1.14.x+ line. New integrations should use `kinocut`, `from kinocut import Client`, and the `kino` command.
+Published `mcp-video==1.6.12` is a metadata-only compatibility installer for `kinocut==1.15.1`. The `mcp_video` import, `mcp-video` command, `MCP_VIDEO_*` environment variables, `~/.mcp-video` data directory, `mcp-video://` resource URIs, and existing receipt keys remain supported on the 1.14.x+ line. New integrations should use `kinocut`, `from kinocut import Client`, and the `kino` command.
 
 ## En español
 
@@ -628,6 +632,7 @@ Safety contract:
 - **doctor `mcp-server-import` check** — required core check; doctor can't say OK while `--mcp` is broken (#449).
 - **First-class Windows support** — portable projectstore file locking (#446), contention-only lock contract, UTF-8 stdio, `windows-latest` smoke job.
 - Community-driven release — @gerardoscaglia-creator credited in [Contributing](#contributing) and the [CHANGELOG acknowledgements](CHANGELOG.md).
+- `mcp-video==1.6.12` installs `kinocut==1.15.1`.
 - `mcp-video==1.6.11` installs `kinocut==1.15.0`.
 
 **1.14.1** (2026-08-13):

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,15 +1,15 @@
 # Improvement Roadmap
 
-Kinocut 1.15.0 is published with 196 MCP tools and 167 CLI commands (`mcp-video` 1.6.11 shim).
+Kinocut 1.15.1 is published with 196 MCP tools and 167 CLI commands (`mcp-video` 1.6.12 shim).
 
-**Published product:** Kinocut **1.15.0** (2026-08-19) · **196 MCP / 167 CLI** · living snapshot [`docs/status/NOW.md`](docs/status/NOW.md)
+**Published product:** Kinocut **1.15.1** (2026-08-31) · **196 MCP / 167 CLI** · living snapshot [`docs/status/NOW.md`](docs/status/NOW.md)
 **Canonical claims:** [`docs/public_claims.json`](docs/public_claims.json)  
 **Human-only residuals:** [`docs/HUMAN_GATES.md`](docs/HUMAN_GATES.md)  
 **Residual portfolio (living truth):** [`docs/status/2026-08-12-residual-maturity-matrix.md`](docs/status/2026-08-12-residual-maturity-matrix.md) · [sound residual DAG](docs/status/2026-08-12-sound-residual-stage-dag.md) · [fixture freeze](docs/status/2026-08-12-sound-fixture-freeze.md) · [L1 truth pass](docs/status/2026-08-12-l1-truth-pass.md) · [phase checkpoints](docs/status/PHASE_CHECKPOINTS.md)  
 **Excellence program (snapshot):** [`docs/status/2026-08-07-kinocut-excellence-audit.md`](docs/status/2026-08-07-kinocut-excellence-audit.md) · handoff [`docs/handoffs/2026-08-07/kinocut-excellence-campaign.md`](docs/handoffs/2026-08-07/kinocut-excellence-campaign.md)  
 **Earlier tip snapshot:** [post-campaign tip status](docs/status/2026-07-27-post-campaign-tip-status.md) (evidence only)
 
-This file is **planning truth for after 1.15.0**. July 2026 status notes and pre-1.3 history live under **Archive** — they are evidence, not current claims. Prefer the **2026-08-12 residual matrix** over any July “S5–S15 incomplete / missing packages” language.
+This file is **planning truth for after 1.15.1**. July 2026 status notes and pre-1.3 history live under **Archive** — they are evidence, not current claims. Prefer the **2026-08-12 residual matrix** over any July “S5–S15 incomplete / missing packages” language.
 
 ---
 
@@ -26,7 +26,7 @@ Release ritual still documents *how* to freeze claims at cut time; this freeze *
 
 ---
 
-## Current (published 1.15.0)
+## Current (published 1.15.1)
 
 - **First-class Windows support** — portable projectstore file locking (`fcntl`/`msvcrt`), contention-only lock contract, UTF-8 stdio, `windows-latest` smoke job. `kino --mcp` is importable on Windows.
 - **Honest MCP diagnostics** — `kino --mcp` prints the real server-tree import cause; `kino doctor` required `mcp-server-import` check.
@@ -70,7 +70,7 @@ Ordered per residual matrix + excellence audit. Prefer one work package per PR. 
 | CI `light` vs `heavy` runner topology | Ops | Partial |
 | First-10 users (#92) | — | **Closed 2026-08-12** — adoption already past gate (107 GitHub stars; ~23k PyPI downloads last month). See `docs/HUMAN_GATES.md` |
 
-Product phases 1–4 + Track E are **GO** on tip (1.15.0). Agents must not invent third-party directory approvals. Do **not** re-open #92 as incomplete.
+Product phases 1–4 + Track E are **GO** on tip (1.15.1). Agents must not invent third-party directory approvals. Do **not** re-open #92 as incomplete.
 
 ---
 

--- a/docs/DIRECTORY_REBRAND_STATUS.md
+++ b/docs/DIRECTORY_REBRAND_STATUS.md
@@ -17,9 +17,9 @@ about third-party pages; verify an external page before acting on its listed sta
 - Description: Guardrailed video editing for AI agents with FFmpeg, captions,
   effects, Hyperframes, resumable workflows, repurposing, quality gates, and
   provenance receipts.
-- Published surface: 196 MCP tools / 167 CLI commands (1.15.0)
-- Development tip: 196 MCP tools / 167 CLI commands (matches published 1.15.0)
-- Current release: 1.15.0 (published 2026-08-19)
+- Published surface: 196 MCP tools / 167 CLI commands (1.15.1)
+- Development tip: 196 MCP tools / 167 CLI commands (matches published 1.15.1)
+- Current release: 1.15.1 (published 2026-08-31)
 - Submission ops: `docs/status/DIRECTORY_SUBMISSION_OPS.md`
 
 ## Reconciliation Snapshot (2026-07-10)

--- a/docs/MCPB.md
+++ b/docs/MCPB.md
@@ -7,7 +7,7 @@ MCPB does not bundle Python, Kinocut, FFmpeg, Node, Hyperframes, or AI model wei
 ## Runtime Requirements
 
 - Node.js 18 or newer, used only by the MCPB launcher.
-- Python 3.11 or newer with `kinocut==1.15.0` installed.
+- Python 3.11 or newer with `kinocut==1.15.1` installed.
 - FFmpeg and ffprobe available on `PATH`, or an executable named `ffmpeg` configured through the installer field with an adjacent `ffprobe`.
 - Optional AI features require the matching Kinocut extras and local model dependencies.
 - Hyperframes tools require a resolvable Hyperframes command; leave the field blank if you do not use those tools.
@@ -29,7 +29,7 @@ python3 scripts/build-mcpb.py
 The script validates the v0.4 manifest fields used by this package and writes:
 
 ```text
-dist/kinocut-1.15.0.mcpb
+dist/kinocut-1.15.1.mcpb
 ```
 
 Focused validation:

--- a/docs/RELEASE_1.8_CHECKLIST.md
+++ b/docs/RELEASE_1.8_CHECKLIST.md
@@ -10,7 +10,7 @@ publish steps for this completed release.
 [`.github/workflows/publish.yml`](../.github/workflows/publish.yml)
 
 **Tip surface at freeze:** 155 MCP tools · 134 CLI commands  
-**Published result:** 1.15.0 · 196 MCP / 167 CLI
+**Published result:** 1.15.1 · 196 MCP / 167 CLI
 
 (1.8.0 cutover was 142/121; later tags: 1.9.0 150/129 · 1.10.0 155/134 · 1.11.1 161/140 ·
 1.12.0 169/145 · 1.13.0 194/165 · 1.13.1 194/165 · 1.13.2 194/165 · 1.13.4 194/165. This page remains the cutover procedure audit record.)

--- a/docs/public_claims.json
+++ b/docs/public_claims.json
@@ -6,9 +6,9 @@
     "kinocut",
     "mcp-video"
   ],
-  "published_version": "1.15.0",
+  "published_version": "1.15.1",
   "published_date": "2026-08-19",
-  "release_candidate_version": "1.15.0",
+  "release_candidate_version": "1.15.1",
   "published_mcp_tools": 196,
   "published_cli_commands": 167,
   "development_mcp_tools": 196,

--- a/docs/status/2026-07-14-1.8-release-notes.md
+++ b/docs/status/2026-07-14-1.8-release-notes.md
@@ -4,7 +4,7 @@
 
 **Published surface:** 142 MCP tools / 121 CLI commands.
 
-**Later pin (current as of 1.15.0):** `mcp-video==1.6.11` currently pins `kinocut==1.15.0`.
+**Later pin (current as of 1.15.1):** `mcp-video==1.6.12` currently pins `kinocut==1.15.1`.
 
 ## Three agent-facing bullets
 
@@ -15,7 +15,7 @@
 2. **What got safer** — Approvals require active human decisions (analyzer-only cannot
    approve); salvage/body-swap reject stale/aliased/protected inputs; Hyperframes init
    no longer hangs under MCP (no TTY).
-3. **Compat** — `mcp-video==1.6.11` currently pins `kinocut==1.15.0`; `mcp_video` imports,
+3. **Compat** — `mcp-video==1.6.12` currently pins `kinocut==1.15.1`; `mcp_video` imports,
    `MCP_VIDEO_*`, `~/.mcp-video`, `mcp-video://`, and legacy receipt keys remain supported
    on the 1.14.x+ line. Prefer `kinocut` / `kino` for new work.
 

--- a/kinocut/cli/handlers_hyperframes.py
+++ b/kinocut/cli/handlers_hyperframes.py
@@ -198,9 +198,7 @@ def _register_media_commands(runner: CommandRunner) -> None:
 
         info = bool(getattr(a, "info", False))
         message = (
-            "Listing people vs product cutout models..."
-            if info
-            else "Cutting person or product from background..."
+            "Listing people vs product cutout models..." if info else "Cutting person or product from background..."
         )
         r = _with_spinner(
             message,

--- a/kinocut/cli/parser/hyperframes.py
+++ b/kinocut/cli/parser/hyperframes.py
@@ -136,10 +136,7 @@ def _add_media_tools_parsers(subparsers: argparse._SubParsersAction) -> None:
     remove_bg_p.add_argument(
         "--model",
         default=None,
-        help=(
-            "u2net_human_seg (people, default) or birefnet-general "
-            "(products/objects; needs kinocut[object-matte])"
-        ),
+        help=("u2net_human_seg (people, default) or birefnet-general (products/objects; needs kinocut[object-matte])"),
     )
     remove_bg_p.add_argument(
         "--mask-interval",
@@ -151,10 +148,7 @@ def _add_media_tools_parsers(subparsers: argparse._SubParsersAction) -> None:
     remove_bg_p.add_argument(
         "--equipment-overlay",
         default=None,
-        help=(
-            "Write a diagnostic PNG of leftover studio gear "
-            "(turntable, stand, tripod, sweep). Object backend only."
-        ),
+        help=("Write a diagnostic PNG of leftover studio gear (turntable, stand, tripod, sweep). Object backend only."),
     )
     remove_bg_p.add_argument(
         "--fail-if-equipment-on-subject",

--- a/kinocut/hyperframes_ops_helpers.py
+++ b/kinocut/hyperframes_ops_helpers.py
@@ -112,10 +112,7 @@ def _remove_background_info() -> HyperframesJsonResult:
                 "subject": "products-and-objects",
                 "backend": REMOVE_BACKGROUND_OBJECT_BACKEND,
                 "install": 'pip install "kinocut[object-matte]"',
-                "summary": (
-                    "Products, packaging, and other non-person objects "
-                    "on a table, sweep, or turntable."
-                ),
+                "summary": ("Products, packaging, and other non-person objects on a table, sweep, or turntable."),
                 "limits": {
                     "maxFrames": MAX_OBJECT_MATTE_FRAMES,
                     "timeoutSeconds": DEFAULT_OBJECT_MATTE_TIMEOUT,

--- a/kinocut/object_matte/media.py
+++ b/kinocut/object_matte/media.py
@@ -202,9 +202,7 @@ def _read_exact(stream, size: int, deadline: float) -> bytes | None:
     return b"".join(chunks)
 
 
-def iter_video_rgb(
-    input_path: str, width: int, height: int, deadline: float | None = None
-) -> Iterator[Image.Image]:
+def iter_video_rgb(input_path: str, width: int, height: int, deadline: float | None = None) -> Iterator[Image.Image]:
     frame_bytes = width * height * 3
     ends = time.monotonic() + DEFAULT_OBJECT_MATTE_TIMEOUT if deadline is None else deadline
     proc = subprocess.Popen(  # noqa: S603

--- a/kinocut/validation.py
+++ b/kinocut/validation.py
@@ -130,8 +130,7 @@ REMOVE_BACKGROUND_OBJECT_BACKEND = "kinocut-onnx"
 # https://github.com/danielgatis/rembg/releases/download/v0.0.0/BiRefNet-general-epoch_244.onnx
 OBJECT_MATTE_WEIGHTS_FILENAME = "birefnet-general.onnx"
 OBJECT_MATTE_WEIGHTS_URL = (
-    "https://github.com/danielgatis/rembg/releases/download/v0.0.0/"
-    "BiRefNet-general-epoch_244.onnx"
+    "https://github.com/danielgatis/rembg/releases/download/v0.0.0/BiRefNet-general-epoch_244.onnx"
 )
 OBJECT_MATTE_WEIGHTS_SHA256 = "58f621f00f5d756097615970a88a791584600dcf7c45b18a0a6267535a1ebd3c"
 OBJECT_MATTE_WEIGHTS_MD5 = "7a35a0141cbbc80de11d9c9a28f52697"

--- a/llms.txt
+++ b/llms.txt
@@ -13,10 +13,10 @@ Kinocut is a free, open-source Model Context Protocol (MCP) server that gives AI
 - **What it is:** MCP server + Python client + CLI for agentic video editing
 - **Publisher:** KyaniteLabs — https://kyanitelabs.tech/
 - **License:** Apache-2.0
-- **Latest published release:** 1.15.0 (2026-08-19)
+- **Latest published release:** 1.15.1 (2026-08-31)
 - **Last-updated:** 2026-08-19
-- **Published surface (1.15.0):** 196 MCP tools / 167 CLI commands
-- **Development tip (master, 1.15.0):** 196 MCP tools / 167 CLI commands — matches the published 1.15.0 release.
+- **Published surface (1.15.1):** 196 MCP tools / 167 CLI commands
+- **Development tip (master, 1.15.1):** 196 MCP tools / 167 CLI commands — matches the published 1.15.1 release.
 - **Runtime:** Python 3.11+, FFmpeg on PATH; optional extras for Whisper/upscale/etc.
 - **MCP transport:** stdio
 - **MCP Registry id:** `io.github.KyaniteLabs/kinocut`
@@ -46,7 +46,7 @@ Pack: python scripts/generate_golden_pack.py → demo/golden-pack/
 Compatibility:
 
 ```bash
-pip install --upgrade mcp-video   # 1.6.11 shim → kinocut 1.15.0
+pip install --upgrade mcp-video   # 1.6.12 shim → kinocut 1.15.1
 ```
 
 ## Canonical links

--- a/mcpb/README.md
+++ b/mcpb/README.md
@@ -2,6 +2,6 @@
 
 This bundle launches Kinocut as a local stdio MCP server through the package's Node launcher.
 
-It is a staged/local-only distribution package. It expects Python 3.11+, `kinocut==1.15.0`, and FFmpeg to already be installed on the user's machine. Optional AI, shader, and Hyperframes tools remain capability-gated until their dependencies are installed and configured. Native MCPB bundles are not published with this release.
+It is a staged/local-only distribution package. It expects Python 3.11+, `kinocut==1.15.1`, and FFmpeg to already be installed on the user's machine. Optional AI, shader, and Hyperframes tools remain capability-gated until their dependencies are installed and configured. Native MCPB bundles are not published with this release.
 
 See `docs/MCPB.md` in the Kinocut repository for install, validation, and release-gate details.

--- a/npm/bin/kinocut.js
+++ b/npm/bin/kinocut.js
@@ -2,7 +2,7 @@
 
 import { spawnSync } from "node:child_process";
 
-const args = ["--from", "kinocut==1.15.0", "kino", ...process.argv.slice(2)];
+const args = ["--from", "kinocut==1.15.1", "kino", ...process.argv.slice(2)];
 const result = spawnSync("uvx", args, { stdio: "inherit" });
 
 if (result.error?.code === "ENOENT") {

--- a/tests/test_kinocut_distribution.py
+++ b/tests/test_kinocut_distribution.py
@@ -15,8 +15,8 @@ import mcp_video
 
 
 ROOT = Path(__file__).resolve().parents[1]
-KINOCUT_VERSION = "1.15.0"
-SHIM_VERSION = "1.6.11"
+KINOCUT_VERSION = "1.15.1"
+SHIM_VERSION = "1.6.12"
 
 
 def _toml(path: Path) -> dict:

--- a/tests/test_object_matte_backend.py
+++ b/tests/test_object_matte_backend.py
@@ -303,9 +303,7 @@ def test_scratch_budget_aborts_before_unbounded_sequence() -> None:
     assert estimate_scratch_bytes(2, 2, 3, hole=True) == 2 * 2 * 4 * 3 * 2
 
 
-def test_run_object_matte_scratch_cap_stops_before_writes(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_run_object_matte_scratch_cap_stops_before_writes(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     src = _png(tmp_path / "sku.png", size=(32, 32))
     dest = tmp_path / "sku-cutout.webm"
     writes: list[str] = []


### PR DESCRIPTION
## Root cause
The 1.15.1 cut (b249833) bumped pyproject/shim but skipped most of the version sweep: `tests/test_kinocut_distribution.py` hardcoded constants (KINOCUT_VERSION 1.15.0 / SHIM_VERSION 1.6.11), `docs/public_claims.json`, and every claims-enforced docs surface still declared 1.15.0 as the current release — so `test_kinocut_is_the_canonical_distribution...` and both public-claims tests fail on clean master, and the public docs claim the wrong current release for a version that is already on PyPI.

## Change
Full sweep to 1.15.1 / shim 1.6.12 across: test constants, public_claims.json, DIRECTORY_REBRAND_STATUS, RELEASE_1.8_CHECKLIST, 1.8 release-notes shim pins, README (release tables, new "What's in 1.15.1" section, compatibility window, mcpb README), llms.txt, ROADMAP current-product lines, docs/MCPB.md. Historical entries (1.15.0 and earlier) preserved.

## Verification
`pytest tests/test_public_claims.py tests/test_kinocut_distribution.py -q`: 21 passed, 2 failed — both failures (npm thin-bootstrap, mcpb node-floor) reproduce byte-identically on clean master on this machine (known local-env failures, Node v26.7.0; CI runners pass them). The claims-enforced failures are all resolved by this PR.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/kinocut/pr/472"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790778847&installation_model_id=20207&pr_number=472&repository=KyaniteLabs%2Fkinocut&return_to=https%3A%2F%2Fgithub.com%2FKyaniteLabs%2Fkinocut%2Fpull%2F472&signature=90dbab57a2cfd5e288b6cfc65bc450fd36bf4d74f3bc548bc1a8c96af1f4297a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated release references to version 1.15.1, dated August 31, 2026.
  * Updated compatibility, package, roadmap, and release-status guidance for the latest release.
  * Documented object-matte streaming decode, scratch-directory limits, and related maintenance improvements.
  * Refreshed packaging instructions and public release metadata.

* **Tests**
  * Updated distribution checks for version 1.15.1 and its corresponding video integration version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->