### PR TITLE
docs: staleness audit — 1.15.1 current-release lines, NOW.md refresh, release retro

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Kinocut **1.15.1** is a maintenance release on top of 1.15.0: the `mcp-video` co
 
 ## What's in 1.15.0
 
-Kinocut **1.15.0** is what you get from `pip install kinocut` today: first-class Windows support and honest diagnostics on top of 1.14.x (same 360 dual-cam assembly and performance surface), driven by a community bug report. Surface stays **196 MCP / 167 CLI** — no new public tool name.
+Kinocut **1.15.0** (2026-08-19) was the Windows/diagnostics release: first-class Windows support and honest diagnostics on top of 1.14.x (same 360 dual-cam assembly and performance surface), driven by a community bug report. Surface stays **196 MCP / 167 CLI** — no new public tool name.
 
 - **Honest MCP startup failures** — `kino --mcp` keeps the "requires the 'mcp' package" hint only when `mcp` is genuinely absent; every other server-tree import failure now prints its real cause (filesystem paths redacted, markup-safe) and exits non-zero. Reported in [#445](https://github.com/KyaniteLabs/kinocut/issues/445).
 - **doctor verifies the MCP server import** — new required `mcp-server-import` check imports the same server tree `--mcp` uses, so `kino doctor` can no longer report OK while MCP mode is broken.
@@ -149,13 +149,13 @@ Also already on the published line from 1.13.x:
 
 Full notes: [CHANGELOG.md](CHANGELOG.md) · published [v1.15.0](https://github.com/KyaniteLabs/kinocut/releases/tag/v1.15.0)
 
-## Beyond 1.15.0 (draft / gated)
+## Beyond 1.15.1 (draft / gated)
 
-**1.15.0 is the latest published release.** Live directory submissions and launch posts remain operator/human residual (`docs/HUMAN_GATES.md`) and are **not** claimed complete.
+**1.15.1 is the latest published release.** Live directory submissions and launch posts remain operator/human residual (`docs/HUMAN_GATES.md`) and are **not** claimed complete.
 
 ### Staged and Gated Surfaces
 
-While the core FFmpeg editing, 360 assembly, workflow engine, still/plate editing, AI-video review/salvage, and sound capabilities are fully integrated on the **published 1.15.0** line, the following surfaces remain gated, partial, or unreleased:
+While the core FFmpeg editing, 360 assembly, workflow engine, still/plate editing, AI-video review/salvage, and sound capabilities are fully integrated on the **published 1.15.x** line, the following surfaces remain gated, partial, or unreleased:
 
 - **Desktop MCPB Packaging:** The staged desktop package (`mcpb/`) is a staged configuration and is **not** a published self-contained native runtime yet (pending FFmpeg provenance, licensing, and clean-machine gates). See [docs/MCPB.md](docs/MCPB.md).
 - **Sonic World Audio (`kinocut_sound`):** While the S1–S12 capabilities are integrated on the published line, the remaining slices are blocked or gated:
@@ -164,7 +164,7 @@ While the core FFmpeg editing, 360 assembly, workflow engine, still/plate editin
   - **S15 (Adversarial Gate):** Gated under a release STOP — requires S13 receipts, dual-class benchmarks, and explicit human authorization.
 - **Trusted Execution Kernel:** The protected-timeline trusted execution kernel is post-program/gated and does not execute without the named upstream contract and human gating ([docs/plans/2026-07-09-kinocut-trusted-execution-layer.md](docs/plans/2026-07-09-kinocut-trusted-execution-layer.md)).
 - **Paid Generative / Dubbing Plans:** Generative spend-capped plans and TTS dubbing remain non-executable draft definitions until external backends and credentials are configured.
-- **Product / object matte:** Catalog and shop cutouts on the existing `hyperframes-remove-background` command (`--model birefnet-general`, extra `kinocut[object-matte]`). Default remains people. Not a new MCP/CLI name. On tip (Forgejo #413/#414); not in published 1.15.0. Guide: [docs/PRODUCT_MATTE.md](docs/PRODUCT_MATTE.md).
+- **Product / object matte:** Catalog and shop cutouts on the existing `hyperframes-remove-background` command (`--model birefnet-general`, extra `kinocut[object-matte]`). Default remains people. Not a new MCP/CLI name. Published in **1.15.1** (streaming decode + scratch caps, #414); the ONNX extra installs via `kinocut[object-matte]`. Guide: [docs/PRODUCT_MATTE.md](docs/PRODUCT_MATTE.md).
 
 Product checklist: [ROADMAP.md](ROADMAP.md).
 
@@ -239,7 +239,7 @@ In **Kinocut**, a contract-first path is provided for agent-edited media that mu
 3. **Verdict + acceptance** with exact human evidence (`video_verdict`, `video_acceptance_eval`)
 4. **Bounded derivatives only** — audio-preserving body swap or allowlisted salvage recipes (`video_body_swap`, `video_salvage`), each with lineage and a fresh non-approved review slot
 
-There is no force/bypass flag. Analyzer output alone cannot approve. Stale, aliased, or protected inputs fail closed. Operating guide: [docs/AI_VIDEO_REVIEW_AND_SALVAGE.md](docs/AI_VIDEO_REVIEW_AND_SALVAGE.md). These surfaces are fully integrated in the published 1.15.0 release — see [Status and releases](#status-and-releases).
+There is no force/bypass flag. Analyzer output alone cannot approve. Stale, aliased, or protected inputs fail closed. Operating guide: [docs/AI_VIDEO_REVIEW_AND_SALVAGE.md](docs/AI_VIDEO_REVIEW_AND_SALVAGE.md). These surfaces are fully integrated in the published 1.15.x line — see [Status and releases](#status-and-releases).
 
 ## Dedicated Video Rescue
 
@@ -415,7 +415,7 @@ Published `mcp-video==1.6.12` is a metadata-only compatibility installer for `ki
 
 ## En español
 
-Kinocut es un servidor MCP de edición de video para agentes de IA. La última versión publicada es **1.15.0** (`pip install kinocut`, **196 herramientas MCP / 167 CLI**). Incluye ensamblaje 360 de dual-cam desde un MP4 equirectangular ya stitched (no `.insv`), import perezoso PEP 562 y el mismo surface FFmpeg tipado para recortar, unir, subtitular, mezclar audio, efectos y reutilizar contenido (Shorts, Reels, TikTok), motor de flujos (`workflow`) con recibos verificables, rescate de video, revisión AI-video gobernada y barreras de seguridad antes de renderizar. Programas humanos residuales (directorios, lanzamiento) no se reclaman completos.
+Kinocut es un servidor MCP de edición de video para agentes de IA. La última versión publicada es **1.15.1** (`pip install kinocut`, **196 herramientas MCP / 167 CLI**). Incluye ensamblaje 360 de dual-cam desde un MP4 equirectangular ya stitched (no `.insv`), import perezoso PEP 562 y el mismo surface FFmpeg tipado para recortar, unir, subtitular, mezclar audio, efectos y reutilizar contenido (Shorts, Reels, TikTok), motor de flujos (`workflow`) con recibos verificables, rescate de video, revisión AI-video gobernada y barreras de seguridad antes de renderizar. Programas humanos residuales (directorios, lanzamiento) no se reclaman completos.
 
 Requisito: [FFmpeg](https://ffmpeg.org/) instalado y disponible en el `PATH`.
 
@@ -558,7 +558,7 @@ kino still-package --establish hero.png --beats shot1.png shot2.png --output-dir
 
 ## MCP Tools
 
-On the **published 1.15.0** surface (and matching tip), kino registers **196 MCP tools** and **167 CLI commands**. The table summarizes core categories — `search_tools` discovers the exact operation without loading every description.
+On the **published 1.15.x** surface (and matching tip), kino registers **196 MCP tools** and **167 CLI commands**. The table summarizes core categories — `search_tools` discovers the exact operation without loading every description.
 
 | Category | Count | Highlights |
 | --- | ---: | --- |
@@ -626,6 +626,11 @@ Safety contract:
 - For governed AI-video derivatives, require stored identities, active human decision evidence, and a fresh review slot after every salvage or body-swap — never raw FFmpeg workarounds labeled as governed.
 
 ## Changelog
+
+**1.15.1** (2026-08-31):
+
+- Registry ownership: `mcp-video` shim **1.6.12** + legacy registry republish (#469).
+- Object-matte streaming decode with scratch caps (#414).
 
 **1.15.0** (2026-08-19):
 - **Honest MCP startup failures** — `kino --mcp` reports real import causes; paths redacted, markup-safe (#448, from #445).

--- a/docs/status/2026-08-31-release-retro.md
+++ b/docs/status/2026-08-31-release-retro.md
@@ -1,0 +1,37 @@
+# Release retro — what the 1.15.1 cut taught us (2026-08-31)
+
+> Written after completing the 1.15.1 version-constellation sweep retroactively
+> (PR #472) and a docs staleness audit. The lessons are process rules now.
+
+## What happened
+
+v1.15.1 published 2026-08-31T04:08Z with most of its version sweep skipped.
+Clean-master CI was red at publish time: the distribution test's hardcoded
+`KINOCUT_VERSION`/`SHIM_VERSION` constants, the entire claims-enforced docs
+surface (public_claims.json, README, ROADMAP, llms.txt, MCPB docs,
+DIRECTORY_REBRAND_STATUS, RELEASE_1.8_CHECKLIST), and the npm uvx launcher
+pin all still said 1.15.0/1.6.11. Master lint was also red (six unformatted
+files from the #414 merge). All completed by PR #472.
+
+## Rules
+
+1. **The claims tests are the sweep guide.** `pytest tests/test_public_claims.py
+   tests/test_kinocut_distribution.py` walks every version-bearing surface; a
+   release is not cut until they pass **in a CI-like environment** (with Node
+   available). Locally, the npm/mcpb tests fail confusingly on Node-version
+   grounds and can mask real failures — one such failure (the npm launcher
+   pin) was misread as environment noise until CI caught it.
+2. **`ruff format --check kinocut/ tests/` gates every merge, not just
+   releases.** Direct-to-master landings skipped it twice (six files, #414-era).
+3. **A release commit must include the CHANGELOG section in the same cut** —
+   1.15.1 shipped without one (added by PR #470 alongside the backfilled
+   #458/#459 contributor credits).
+4. **Credits are release-blocking.** #458/#459 shipped in 1.15.0 uncredited
+   because acknowledgement lived in a draft release's living context instead
+   of the CHANGELOG; the draft was later deleted and the credit with it.
+   Contributor acknowledgements belong in the CHANGELOG section at cut time.
+
+## Related
+
+- Version sweep checklist: `docs/RELEASE_1.8_CHECKLIST.md` (claims-enforced).
+- Contributor credit backfills: PRs #470/#471. Sweep completion: PR #472.

--- a/docs/status/NOW.md
+++ b/docs/status/NOW.md
@@ -1,8 +1,8 @@
 # Kinocut now
 
-**Published:** 1.15.0 · **196 MCP / 167 CLI** · `docs/public_claims.json`
+**Published:** 1.15.1 · **196 MCP / 167 CLI** · `docs/public_claims.json`
 
-**Tip (`master`):** 1.15.0 (same counts). 360 dual-cam assembly and PEP 562 lazy `import kinocut` shipped in pip **1.14.1**. Honest diagnostics (`--mcp` import errors, doctor `mcp-server-import`) and first-class Windows support are in pip **1.15.0**. Object-matte ONNX extra (`kinocut[object-matte]`) + studio-equipment gate landed in Forgejo #413; streaming decode/scratch/timeout guards from #412 are ported onto tip. Not in pip 1.15.0. Dual-host matched at `060c9cd` (Forgejo #414 stream/scratch port + #415 tip-SHA docs).
+**Tip (`master`):** 1.15.1 (same counts). Pip history in one line: 1.14.1 = 360 dual-cam + lazy import; 1.15.0 = honest diagnostics + first-class Windows; 1.15.1 (2026-08-31) = registry ownership (shim 1.6.12, #469) + object-matte streaming decode/scratch guards (#412/#414, installable as `kinocut[object-matte]`). Dual-host matched at `060c9cd` (Forgejo #414 stream/scratch port + #415 tip-SHA docs).
 
 **Product pipeline:** Phase 1–4 + Track E **GO**.
 


### PR DESCRIPTION
## Root cause
A full-repo staleness audit after the 1.15.1 sweep (PR #472) found the README still declaring 1.15.0 as current in eight places the claims tests don't reach: the "What's in 1.15.0 … today" lead, "Beyond 1.15.0 (draft / gated)" heading and its "latest published" line, the gated-surfaces lead, the AI-review integration note, the Spanish section, the tool-count line, and the release-history blurb (no 1.15.1 entry). One gated item had flipped status: object-matte streaming decode (#414) shipped IN 1.15.1, so "on tip; not in published" was wrong twice over. `docs/status/NOW.md` (the living snapshot) still said Published/Tip = 1.15.0 and "not in pip 1.15.0" for #414.

## Change
- README: all current-release lines to 1.15.1/1.15.x; "Beyond 1.15.1" heading; object-matte item marked published-in-1.15.1 with the `kinocut[object-matte]` extra; 1.15.1 entry added to the release-history blurb (prior entries intact).
- NOW.md: Published/Tip = 1.15.1, pip-history line consolidated, #414 marked shipped.
- New `docs/status/2026-08-31-release-retro.md`: the four process rules from the 1.15.1 cut (claims-tests-as-sweep-guide in a CI-like env, format gate on every merge, CHANGELOG belongs in the cut, credits are release-blocking).

## Verification
`pytest tests/test_public_claims.py tests/test_kinocut_distribution.py -q`: 22 passed, 1 failed (the documented local-Node mcpb env failure; passes in CI). Docs-only diff.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/kinocut/pr/474"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790781946&installation_model_id=20207&pr_number=474&repository=KyaniteLabs%2Fkinocut&return_to=https%3A%2F%2Fgithub.com%2FKyaniteLabs%2Fkinocut%2Fpull%2F474&signature=f3b27ed43b482a30569bb3ac3b982258a3ed59b6310ff6cb32fc28ee61b4c59f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->