### PR TITLE
fix(ffmpeg): POSIX filter-path escaping — quoted single-pass form

### DIFF
--- a/kinocut/ffmpeg_helpers.py
+++ b/kinocut/ffmpeg_helpers.py
@@ -563,24 +563,41 @@ def _escape_ffmpeg_filter_value(value: str) -> str:
     )
 
 
+_WINDOWS_FILTER_PATH_RE = re.compile(r"^(?:[A-Za-z]:[\\/]{1,2}|\\\\)")
+
+
 def _escape_ffmpeg_filter_path(value: str) -> str:
-    """Escape a filesystem path used as an *unquoted* FFmpeg filter option value.
+    """Escape a filesystem path used as an FFmpeg filter option value.
 
-    An unquoted option value is unescaped twice: once by the filtergraph parser and
-    once by the filter's own argument parser. ``_escape_ffmpeg_filter_value`` escapes
-    only once, which is enough on POSIX but breaks on Windows: the drive-letter colon
-    survives the first pass and is then read as an option separator, and the
-    backslashes are consumed as escape characters.
+    Two shapes, two strategies — both verified against a real ``subtitles=``
+    burn-in (ffmpeg 7.x, 2026-08-31), because every rule here was learned from
+    an actual decoder failure, not from the docs:
 
-    ``C:\\dir\\subs.ass`` currently becomes ``C\\:\\\\dir\\\\subs.ass``, which FFmpeg
-    resolves to the filename ``C`` plus a bogus ``original_size`` option. Normalising
-    the separators to forward slashes (accepted by FFmpeg on Windows) keeps them from
-    being eaten, and escaping the colon twice lets it survive both passes.
+    **Windows-style paths** (drive-letter or UNC prefix) stay *unquoted* with
+    double-escaped colons and forward-slashed separators: ``C:\\dir\\subs.ass``
+    becomes ``C\\\\:/dir/subs.ass``. Unquoted is what the two-parser reality
+    requires here — the drive-letter colon must survive BOTH the filtergraph
+    parser and the filter's own option parser, and quoting does not protect a
+    colon from the option parser.
 
-    No-op for ordinary POSIX paths, and correct for POSIX paths that do contain a
-    colon, since the same two-pass parsing applies there.
+    **POSIX-style paths** are emitted *quoted* with a single escaping pass:
+    ``'/tmp/a\\ b,x.ass'``-style output produced by wrapping
+    :func:`_escape_ffmpeg_filter_value` in single quotes. Empirically the
+    quoted single-pass form is the only strategy that lets literal
+    backslashes and the filtergraph metacharacters ``, ; [ ] =`` reach the
+    filter intact; every doubled-backslash variant tested fails one parser
+    or the other, and the pre-quote unquoted form corrupted legal POSIX
+    filenames (``/tmp/a\\b.ass`` opened as ``/tmp/a/b.ass``) and passed
+    ``, ; [ ]`` through raw, splitting the filtergraph.
+
+    Known limitation (fails under every strategy, including all historical
+    ones — not a regression): a filename containing an apostrophe cannot be
+    passed through this seam; FFmpeg's two quote-processing layers eat it in
+    every quoting/escaping combination we tested.
     """
-    return value.replace("\\", "/").replace(":", "\\\\:")
+    if _WINDOWS_FILTER_PATH_RE.match(value):
+        return value.replace("\\", "/").replace(":", "\\\\:")
+    return f"'{_escape_ffmpeg_filter_value(value)}'"
 
 
 def _get_video_duration(video_path: str, *, pass_fds: tuple[int, ...] = ()) -> float:

--- a/tests/test_ffmpeg_filter_path.py
+++ b/tests/test_ffmpeg_filter_path.py
@@ -1,38 +1,65 @@
 """Escaping rules for paths embedded in FFmpeg filter option values.
 
-Regression cover for the Windows subtitle burn-in failure: an unquoted filter option
-value is unescaped twice, so a single-pass escape leaves the drive-letter colon acting
-as an option separator and lets the backslashes be eaten as escape characters.
+Regression cover for two historical bugs, both verified against a real
+``subtitles=`` burn-in (ffmpeg 7.x):
+
+1. The Windows subtitle failure: an unquoted filter option value is unescaped
+   twice, so a single-pass escape leaves the drive-letter colon acting as an
+   option separator and lets the backslashes be eaten as escape characters.
+2. The POSIX regressions of the first fix: unconditional backslash
+   normalisation corrupted legal POSIX filenames (``/tmp/a\\b.ass`` opened as
+   ``/tmp/a/b.ass``), and the filtergraph metacharacters ``, ; [ ] =`` passed
+   through raw, splitting the filtergraph.
 """
 
 from kinocut.ffmpeg_helpers import _escape_ffmpeg_filter_path, _escape_ffmpeg_filter_value
 
 
-def test_windows_path_survives_both_unescaping_passes():
-    # The colon is escaped twice and separators become forward slashes, so neither is
-    # consumed by the filtergraph parser before the filter sees the filename.
-    assert _escape_ffmpeg_filter_path(r"C:\kctest\subs.ass") == "C\\\\:/kctest/subs.ass"
+class TestWindowsPaths:
+    def test_windows_path_survives_both_unescaping_passes(self):
+        # Unquoted with a double-escaped colon and forward-slashed separators:
+        # quoting does not protect a colon from the option parser.
+        assert _escape_ffmpeg_filter_path(r"C:\kctest\subs.ass") == "C\\\\:/kctest/subs.ass"
+
+    def test_windows_unc_path_is_normalised(self):
+        assert _escape_ffmpeg_filter_path(r"\\server\share\subs.ass") == "//server/share/subs.ass"
+
+    def test_single_pass_escape_is_not_enough_for_a_windows_path(self):
+        # Documents the original bug: this is what the value helper produces,
+        # and FFmpeg reads the filename as "C" plus an original_size option.
+        assert _escape_ffmpeg_filter_value(r"C:\kctest\subs.ass") == "C\\:\\\\kctest\\\\subs.ass"
 
 
-def test_single_pass_escape_is_not_enough_for_a_windows_path():
-    # Documents the bug: this is what the value helper produces, and FFmpeg reads the
-    # filename as "C" and the remainder as an original_size option.
-    assert _escape_ffmpeg_filter_value(r"C:\kctest\subs.ass") == "C\\:\\\\kctest\\\\subs.ass"
+class TestPosixPaths:
+    def test_plain_posix_path_is_quoted(self):
+        assert _escape_ffmpeg_filter_path("/tmp/kinocut/subs.ass") == "'/tmp/kinocut/subs.ass'"
 
+    def test_relative_path_is_quoted(self):
+        assert _escape_ffmpeg_filter_path("subs.ass") == "'subs.ass'"
 
-def test_posix_path_is_unchanged():
-    assert _escape_ffmpeg_filter_path("/tmp/kinocut/subs.ass") == "/tmp/kinocut/subs.ass"
+    def test_literal_backslash_is_preserved_not_eaten(self):
+        # Regression: the unquoted form corrupted /tmp/a\b.ass into /tmp/a/b.ass.
+        # The quoted single-pass form lets the backslash reach the filter.
+        assert _escape_ffmpeg_filter_path("/tmp/a\\b.ass") == "'/tmp/a\\\\b.ass'"
 
+    def test_filtergraph_metacharacters_are_escaped(self):
+        # Regression: , ; [ ] = passed through raw and split the filtergraph.
+        assert _escape_ffmpeg_filter_path("x,y.ass") == "'x\\,y.ass'"
+        assert _escape_ffmpeg_filter_path("x;y.ass") == "'x\\;y.ass'"
+        assert _escape_ffmpeg_filter_path("x[y].ass") == "'x\\[y\\].ass'"
+        assert _escape_ffmpeg_filter_path("a=b.ass") == "'a\\=b.ass'"
 
-def test_posix_path_with_a_colon_is_escaped():
-    assert _escape_ffmpeg_filter_path("/tmp/a:b/subs.ass") == "/tmp/a\\\\:b/subs.ass"
+    def test_posix_path_with_a_colon_is_escaped(self):
+        assert _escape_ffmpeg_filter_path("/tmp/a:b/subs.ass") == "'/tmp/a\\:b/subs.ass'"
 
-
-def test_relative_path_is_unchanged():
-    assert _escape_ffmpeg_filter_path("subs.ass") == "subs.ass"
+    def test_apostrophe_documented_limitation(self):
+        # Filenames with apostrophes fail under EVERY strategy we tested
+        # (quoted, unquoted, every doubling) — including the historical ones.
+        # This documents the output shape; ffmpeg itself cannot open the file.
+        assert _escape_ffmpeg_filter_path("it's.ass") == "'it'\\''s.ass'"
 
 
 def test_value_helper_still_used_for_scalars():
-    # Numbers, colours and font *names* keep the single-pass helper.
+    # Numbers, colours and font *names* keep the single-pass helper, unquoted.
     assert _escape_ffmpeg_filter_value("15.0") == "15.0"
     assert _escape_ffmpeg_filter_value("white") == "white"


### PR DESCRIPTION
## Root cause
PR #458's Windows fix (merged 2026-08-18, shipped in 1.15.0) left two confirmed gaps live on master: (1) unconditional backslash→slash normalisation corrupts legal POSIX filenames — `/tmp/a\\b.ass` opens as `/tmp/a/b.ass`; (2) filtergraph metacharacters `' , ; [ ]` pass through unescaped, splitting filtergraphs (8 engine call sites route through this helper).

## Change
`_escape_ffmpeg_filter_path` now has two empirically-verified strategies: **Windows-style paths** (drive-letter/UNC) keep the shipped unquoted double-escape byte-for-byte (real-Windows-verified by the #458 author; tests unchanged); **POSIX-style paths** emit the quoted single-pass form `'{escaped}'` — the only strategy of seven tested that gets literal backslashes AND `, ; [ ] =` through both FFmpeg parsers intact. The full empirical matrix (quoted/doubled × backslash/comma/semicolon/brackets/equals/apostrophe/colon) is summarized in the helper docstring; apostrophe filenames fail under every strategy including all historical ones — documented as a known limitation, not a regression.

## Verification
- **Real engine, hostile filenames:** `Client.subtitles()` burn-in succeeds for `plain.ass`, `a\\b.ass`, `x,y.ass`, `x;y.ass`, `x[y].ass`, `a=b.ass` — the two gap cases were live-broken on master before this change.
- 10/10 `tests/test_ffmpeg_filter_path.py` (contract rewritten + regression tests for both gaps); 44/44 path-safety convergence + shorts path-safety; 506 subtitle/stabilize/timeline/text engine tests.
- Full suite: **4916 passed, 1 failed** — the documented local-Node mcpb env failure (passes in CI; unchanged).
- ruff check + format clean.

Credit: the two gaps were originally flagged in the #458 review by @simongonzalezdc/CodeRabbit and verified empirically at merge time; this closes them maintainer-side per the contributor-etiquette policy.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/kinocut/pr/475"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790782451&installation_model_id=20207&pr_number=475&repository=KyaniteLabs%2Fkinocut&return_to=https%3A%2F%2Fgithub.com%2FKyaniteLabs%2Fkinocut%2Fpull%2F475&signature=9d15e57a6cc6729337b6f8f9c5027cfbcc2999cd832d048e312caeaf23f4074c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->