### PR TITLE
feat(envelope): agreed license + judges fields for winners-bundle v0.1

### DIFF
--- a/kinocut/revideo_models.py
+++ b/kinocut/revideo_models.py
@@ -27,6 +27,10 @@ class WinnersArtifactInfo(BaseModel):
     domain: str
     axes: str
     level: str
+    license: str = Field(description="Deterministic license mapping (liminal #999): LGPL-2.1/MIT/AGPL-3.0/BSD-3/house.")
+    judges: list[str] | None = Field(
+        default=None, description="Judge identities; null for historical events (never fabricated)."
+    )
     payload_path: str = Field(description="Path relative to the bundle root.")
     payload_sha256: str
     payload_bytes: int

--- a/kinocut/validation.py
+++ b/kinocut/validation.py
@@ -557,7 +557,21 @@ WINNERS_ARTIFACT_REQUIRED_FIELDS = (
     "domain",
     "axes",
     "level",
+    "license",
     "payload",
+)
+# Agreed on liminal #999 (2026-08-31): deterministic license mapping emitted by
+# the Sinter export step (p5->LGPL-2.1, three/tone->MIT, hydra/strudel->AGPL-3.0,
+# d3-dataviz->BSD-3, self-contained->house). Historical events carry judges:null
+# rather than fabricated backfill.
+WINNERS_KNOWN_LICENSES = frozenset(
+    {
+        "LGPL-2.1",
+        "MIT",
+        "AGPL-3.0",
+        "BSD-3",
+        "house",
+    }
 )
 WINNERS_PAYLOAD_REQUIRED_FIELDS = ("path", "sha256", "bytes")
 

--- a/kinocut/winners_bundle.py
+++ b/kinocut/winners_bundle.py
@@ -45,6 +45,7 @@ from .revideo_engine import _sha256_file
 from .revideo_models import WinnersArtifactInfo, WinnersBundleReceipt
 from .validation import (
     WINNERS_ARTIFACT_REQUIRED_FIELDS,
+    WINNERS_KNOWN_LICENSES,
     WINNERS_MANIFEST_REQUIRED_FIELDS,
     WINNERS_PAYLOAD_REQUIRED_FIELDS,
 )
@@ -101,8 +102,11 @@ def write_bundle(
             "domain": spec["domain"],
             "axes": spec["axes"],
             "level": spec["level"],
+            "license": spec["license"],
             "payload": {"path": payload_rel, "sha256": digest, "bytes": size},
         }
+        if spec.get("judges") is not None:
+            entry["judges"] = list(spec["judges"])
         manifest_artifacts.append(entry)
         receipt_artifacts.append(
             WinnersArtifactInfo(
@@ -111,6 +115,8 @@ def write_bundle(
                 domain=entry["domain"],
                 axes=entry["axes"],
                 level=entry["level"],
+                license=entry["license"],
+                judges=entry.get("judges"),
                 payload_path=payload_rel,
                 payload_sha256=digest,
                 payload_bytes=size,
@@ -158,9 +164,18 @@ def _validate_artifact(entry: Any, index: int) -> dict[str, Any]:
     for field in ("artifact_id", "event_id"):
         if not _is_hex64(entry[field]):
             _fail(f"artifacts[{index}].{field} must be a 64-char sha256 hex string")
-    for field in ("domain", "axes", "level"):
+    for field in ("domain", "axes", "level", "license"):
         if not isinstance(entry[field], str) or not entry[field]:
             _fail(f"artifacts[{index}].{field} must be a non-empty string")
+    if entry["license"] not in WINNERS_KNOWN_LICENSES:
+        _fail(f"artifacts[{index}].license must be one of {sorted(WINNERS_KNOWN_LICENSES)} (got {entry['license']!r})")
+    judges = entry.get("judges")
+    if judges is not None and (
+        not isinstance(judges, list) or not judges or not all(isinstance(j, str) and j for j in judges)
+    ):
+        _fail(
+            f"artifacts[{index}].judges must be null (historical events) or a non-empty list of judge identity strings"
+        )
     payload = entry["payload"]
     if not isinstance(payload, dict):
         _fail(f"artifacts[{index}].payload must be an object")
@@ -217,6 +232,8 @@ def verify_bundle(bundle_dir: str | Path) -> WinnersBundleReceipt:
                 domain=validated["domain"],
                 axes=validated["axes"],
                 level=validated["level"],
+                license=validated["license"],
+                judges=validated.get("judges"),
                 payload_path=str(payload_rel),
                 payload_sha256=actual_digest,
                 payload_bytes=actual_bytes,

--- a/tests/test_winners_bundle.py
+++ b/tests/test_winners_bundle.py
@@ -33,6 +33,8 @@ def _artifact_spec(payload_source: Path) -> dict:
         "domain": "glsl",
         "axes": "D=2.0 A=2.0 R=3.0 N=2.0 | judges: test | defects: 0",
         "level": "S",
+        "license": "MIT",
+        "judges": ["gemini-3.7", "minimax-m3"],
         "payload_source": str(payload_source),
     }
 
@@ -60,6 +62,8 @@ class TestWriteVerifyRoundtrip:
         (artifact,) = receipt.artifacts
         assert artifact.artifact_id == _HEX and artifact.event_id == _EVENT
         assert artifact.domain == "glsl" and artifact.level == "S"
+        assert artifact.license == "MIT"
+        assert artifact.judges == ["gemini-3.7", "minimax-m3"]
         assert artifact.payload_path == "payload/winner.glsl"
         assert artifact.payload_bytes == len(b"void main() {}")
 
@@ -129,6 +133,30 @@ class TestVerifyFailsClosed:
             lambda m: m["artifacts"][0]["payload"].update(path="payload/../manifest.json"),
         )
         with pytest.raises(ValidationError, match="bundle-relative"):
+            verify_bundle(bundle)
+
+    def test_unknown_license_rejected(self, tmp_path):
+        bundle = _bundle(tmp_path)
+        _rewrite_manifest(bundle, lambda m: m["artifacts"][0].update(license="AGPL-9.9"))
+        with pytest.raises(ValidationError, match="license"):
+            verify_bundle(bundle)
+
+    def test_missing_license_rejected(self, tmp_path):
+        bundle = _bundle(tmp_path)
+        _rewrite_manifest(bundle, lambda m: m["artifacts"][0].pop("license"))
+        with pytest.raises(ValidationError, match="missing required fields"):
+            verify_bundle(bundle)
+
+    def test_historical_judges_null_accepted(self, tmp_path):
+        bundle = _bundle(tmp_path)
+        _rewrite_manifest(bundle, lambda m: m["artifacts"][0].update(judges=None))
+        receipt = verify_bundle(bundle)
+        assert receipt.artifacts[0].judges is None
+
+    def test_empty_judges_list_rejected(self, tmp_path):
+        bundle = _bundle(tmp_path)
+        _rewrite_manifest(bundle, lambda m: m["artifacts"][0].update(judges=[]))
+        with pytest.raises(ValidationError, match="judges"):
             verify_bundle(bundle)
 
     def test_non_hex_identity_rejected(self, tmp_path):


### PR DESCRIPTION
## Root cause / context
The Sinter×Kino envelope v0.1 spec was agreed on liminal #999 (2026-08-31): per-artifact `license` (required, from the deterministic import-scan mapping the Sinter export step emits) and `judges` (optional-nullable — structured on new scoring events, `null` for historical events rather than fabricated backfill). This lands the agreement in the shipped verifier. v0.1 amends in place because no real bundle has been exported yet — the schema freezes at first export.

## Change
- `license` required on every artifact, validated against the agreed set {LGPL-2.1, MIT, AGPL-3.0, BSD-3, house}.
- `judges` accepted as null or non-empty list of identity strings; receipts carry both fields through.
- Reference writer emits both; 5 new tests (unknown/missing license, null judges accepted, empty judges rejected, roundtrip).

## Verification
35 passed across the bundle + engine suites; ruff check/format clean; shim import check OK. Unblocks the revideo registration PR (wayfinder #486).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/kinocut/pr/489"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790786437&installation_model_id=20207&pr_number=489&repository=KyaniteLabs%2Fkinocut&return_to=https%3A%2F%2Fgithub.com%2FKyaniteLabs%2Fkinocut%2Fpull%2F489&signature=754f7acc495c8d1b1bc859a287bfd0948f39dc5728008e042aba689b713b9f8b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added license information to winners bundle artifacts.
  * Added optional judge information, supporting historical events without judge data.
  * Preserved license and judge details in manifests and receipts.

* **Bug Fixes**
  * Improved bundle validation to reject missing or unsupported licenses.
  * Rejects empty judge lists while allowing valid historical records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->