### PR TITLE
fix(bundle): writer validates metadata under the verifier's contract

### DIFF
--- a/kinocut/winners_bundle.py
+++ b/kinocut/winners_bundle.py
@@ -84,7 +84,7 @@ def write_bundle(
     manifest_artifacts: list[dict[str, Any]] = []
     receipt_artifacts: list[WinnersArtifactInfo] = []
     used_names: set[str] = set()
-    for spec in artifacts:
+    for index, spec in enumerate(artifacts):
         source = Path(spec["payload_source"])
         if not source.is_file():
             _fail(f"payload source missing: {source}")
@@ -96,17 +96,24 @@ def write_bundle(
         digest = _sha256_file(payload_dir / name)
         size = (payload_dir / name).stat().st_size
         payload_rel = f"payload/{name}"
+        # .get() for metadata so a missing field is a ValidationError from
+        # _validate_artifact, never a raw KeyError (CodeRabbit, PR #489).
         entry = {
-            "artifact_id": spec["artifact_id"],
-            "event_id": spec["event_id"],
-            "domain": spec["domain"],
-            "axes": spec["axes"],
-            "level": spec["level"],
-            "license": spec["license"],
+            "artifact_id": spec.get("artifact_id"),
+            "event_id": spec.get("event_id"),
+            "domain": spec.get("domain"),
+            "axes": spec.get("axes"),
+            "level": spec.get("level"),
+            "license": spec.get("license"),
             "payload": {"path": payload_rel, "sha256": digest, "bytes": size},
         }
         if spec.get("judges") is not None:
             entry["judges"] = list(spec["judges"])
+        # The writer must not emit a self-invalidating bundle: every entry is
+        # validated under the same contract the verifier applies (CodeRabbit,
+        # PR #489 — e.g. license="AGPL-9.9" or judges=[] previously wrote a
+        # bundle that only failed at verify time).
+        _validate_artifact(entry, index)
         manifest_artifacts.append(entry)
         receipt_artifacts.append(
             WinnersArtifactInfo(

--- a/tests/test_winners_bundle.py
+++ b/tests/test_winners_bundle.py
@@ -93,7 +93,7 @@ class TestWriterFailsClosed:
     def test_writer_rejects_missing_license_not_keyerror(self, tmp_path):
         spec = dict(_artifact_spec(_make_payload(tmp_path)))
         del spec["license"]
-        with pytest.raises(ValidationError, match="missing required fields"):
+        with pytest.raises(ValidationError, match="license"):
             write_bundle(tmp_path / "b2", [spec], "2026-08-31T00:00:00Z")
 
     def test_writer_rejects_empty_judges(self, tmp_path):

--- a/tests/test_winners_bundle.py
+++ b/tests/test_winners_bundle.py
@@ -82,6 +82,26 @@ class TestWriteVerifyRoundtrip:
         assert len(verify_bundle(dest).artifacts) == 2
 
 
+class TestWriterFailsClosed:
+    """The writer must not emit a self-invalidating bundle (CodeRabbit, PR #489)."""
+
+    def test_writer_rejects_unknown_license(self, tmp_path):
+        spec = _artifact_spec(_make_payload(tmp_path)) | {"license": "AGPL-9.9"}
+        with pytest.raises(ValidationError, match="license"):
+            write_bundle(tmp_path / "b1", [spec], "2026-08-31T00:00:00Z")
+
+    def test_writer_rejects_missing_license_not_keyerror(self, tmp_path):
+        spec = dict(_artifact_spec(_make_payload(tmp_path)))
+        del spec["license"]
+        with pytest.raises(ValidationError, match="missing required fields"):
+            write_bundle(tmp_path / "b2", [spec], "2026-08-31T00:00:00Z")
+
+    def test_writer_rejects_empty_judges(self, tmp_path):
+        spec = _artifact_spec(_make_payload(tmp_path)) | {"judges": []}
+        with pytest.raises(ValidationError, match="judges"):
+            write_bundle(tmp_path / "b3", [spec], "2026-08-31T00:00:00Z")
+
+
 class TestVerifyFailsClosed:
     def test_missing_manifest(self, tmp_path):
         with pytest.raises(ValidationError, match=r"no manifest\.json"):


### PR DESCRIPTION
## Root cause
CodeRabbit major finding on #489 (merged): `write_bundle` copied `license`/`judges` into the manifest without applying `_validate_artifact`'s constraints — `license=AGPL-9.9` or `judges=[]` wrote a bundle that only failed at verify time, and a missing `license` raised a raw `KeyError` (also a repo-law violation: custom error types only).

## Change
Every assembled entry is validated at write time under the same contract the verifier applies; metadata fields read via `.get()` so missing fields surface as `ValidationError`, never `KeyError`.

## Verification
3 new fail-closed writer tests (unknown license, missing license → ValidationError not KeyError, empty judges); 21/21 bundle + 17/17 engine tests green; ruff clean; shim check OK.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/kinocut/pr/491"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790787565&installation_model_id=20207&pr_number=491&repository=KyaniteLabs%2Fkinocut&return_to=https%3A%2F%2Fgithub.com%2FKyaniteLabs%2Fkinocut%2Fpull%2F491&signature=7e444fc44fa7e91ecbb0e3c7572bf7dc7ee49f76192c8b86d1c22d2a77435b91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->