### PR TITLE
fix: treat trim end as an absolute timestamp on the input-seeking path

### DIFF
--- a/kinocut/engine_edit.py
+++ b/kinocut/engine_edit.py
@@ -108,7 +108,7 @@ def trim(
     output = output_path or _auto_output(input_path, "trimmed")
     _validate_output_path(output)
 
-    _validate_trim_times(start, duration, end)
+    start_sec = _validate_trim_times(start, duration, end)
 
     prefix: list[str] = []
     if not accurate and start:
@@ -121,7 +121,14 @@ def trim(
     if duration:
         prefix.extend(["-t", str(duration)])
     elif end:
-        prefix.extend(["-to", str(end)])
+        if accurate:
+            # Output seeking preserves source timestamps, so -to is absolute.
+            prefix.extend(["-to", str(end)])
+        else:
+            # Input seeking (-ss before -i) rebases output timestamps to zero,
+            # so a trailing -to is measured from the seek point and silently
+            # behaves as a duration. Convert the absolute end time explicitly.
+            prefix.extend(["-t", str(_time_to_seconds(end) - start_sec)])
 
     with _timed_operation() as timing:
         _run_ffmpeg(prefix + _build_ffmpeg_cmd(output_path=output))

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -865,3 +865,78 @@ class TestMergeSingleClip:
         assert len(ffmpeg_calls) == 1
         assert "-c" in ffmpeg_calls[0]
         assert "copy" in ffmpeg_calls[0]
+
+
+class TestTrimEndSemantics:
+    """``end`` is an absolute source timestamp, not a duration.
+
+    ``sample_video`` is 3s. With ``start=1``, an absolute ``end=2`` yields a 1s
+    clip, while treating ``end`` as a duration yields 2s -- so these cases
+    distinguish the two readings without being clipped by the source length.
+    The pre-existing ``test_trim_by_end`` uses ``start=0``, where both readings
+    agree, which is why this regression went unnoticed.
+    """
+
+    def test_end_is_absolute_when_start_is_nonzero(self, sample_video, tmp_path):
+        out = str(tmp_path / "by_end.mp4")
+        trim(sample_video, start="1", end="2", output_path=out)
+        assert abs(probe(out).duration - 1.0) < 0.25
+
+    def test_end_matches_equivalent_duration(self, sample_video, tmp_path):
+        by_end = str(tmp_path / "by_end.mp4")
+        by_duration = str(tmp_path / "by_duration.mp4")
+        trim(sample_video, start="1", end="2", output_path=by_end)
+        trim(sample_video, start="1", duration="1", output_path=by_duration)
+        assert abs(probe(by_end).duration - probe(by_duration).duration) < 0.25
+
+    def test_end_is_absolute_in_accurate_mode(self, sample_video, tmp_path):
+        out = str(tmp_path / "accurate.mp4")
+        trim(sample_video, start="1", end="2", output_path=out, accurate=True)
+        assert abs(probe(out).duration - 1.0) < 0.25
+
+    def test_end_before_start_is_rejected(self, sample_video):
+        with pytest.raises(MCPVideoError):
+            trim(sample_video, start="2", end="1")
+
+
+class TestTrimEndFFmpegArgs:
+    """Argument-level contract for ``end``. Does not require FFmpeg."""
+
+    @staticmethod
+    def _capture_trim(monkeypatch, tmp_path, **kwargs):
+        from kinocut import engine_edit
+
+        source = tmp_path / "in.mp4"
+        source.write_bytes(b"\x00")
+        calls: list[list[str]] = []
+        monkeypatch.setattr(engine_edit, "_run_ffmpeg", lambda cmd: calls.append(cmd))
+        monkeypatch.setattr(engine_edit, "_build_edit_result", lambda *a, **k: None)
+        engine_edit.trim(
+            str(source), output_path=str(tmp_path / "out.mp4"), **kwargs
+        )
+        return calls[0]
+
+    def test_input_seeking_converts_end_to_duration(self, monkeypatch, tmp_path):
+        # -ss before -i rebases output timestamps to zero, so a trailing -to
+        # would be measured from the seek point and act as a duration.
+        cmd = self._capture_trim(monkeypatch, tmp_path, start="5", end="10")
+        assert "-to" not in cmd
+        assert "-t" in cmd
+        assert float(cmd[cmd.index("-t") + 1]) == pytest.approx(5.0)
+
+    def test_output_seeking_keeps_end_absolute(self, monkeypatch, tmp_path):
+        # -ss after -i preserves source timestamps, so -to is already absolute.
+        cmd = self._capture_trim(
+            monkeypatch, tmp_path, start="5", end="10", accurate=True
+        )
+        assert "-to" in cmd
+        assert cmd[cmd.index("-to") + 1] == "10"
+
+    def test_explicit_duration_is_passed_through(self, monkeypatch, tmp_path):
+        cmd = self._capture_trim(monkeypatch, tmp_path, start="5", duration="10")
+        assert cmd[cmd.index("-t") + 1] == "10"
+        assert "-to" not in cmd
+
+    def test_end_without_start_still_equals_end(self, monkeypatch, tmp_path):
+        cmd = self._capture_trim(monkeypatch, tmp_path, end="10")
+        assert float(cmd[cmd.index("-t") + 1]) == pytest.approx(10.0)

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -911,9 +911,7 @@ class TestTrimEndFFmpegArgs:
         calls: list[list[str]] = []
         monkeypatch.setattr(engine_edit, "_run_ffmpeg", lambda cmd: calls.append(cmd))
         monkeypatch.setattr(engine_edit, "_build_edit_result", lambda *a, **k: None)
-        engine_edit.trim(
-            str(source), output_path=str(tmp_path / "out.mp4"), **kwargs
-        )
+        engine_edit.trim(str(source), output_path=str(tmp_path / "out.mp4"), **kwargs)
         return calls[0]
 
     def test_input_seeking_converts_end_to_duration(self, monkeypatch, tmp_path):
@@ -926,9 +924,7 @@ class TestTrimEndFFmpegArgs:
 
     def test_output_seeking_keeps_end_absolute(self, monkeypatch, tmp_path):
         # -ss after -i preserves source timestamps, so -to is already absolute.
-        cmd = self._capture_trim(
-            monkeypatch, tmp_path, start="5", end="10", accurate=True
-        )
+        cmd = self._capture_trim(monkeypatch, tmp_path, start="5", end="10", accurate=True)
         assert "-to" in cmd
         assert cmd[cmd.index("-to") + 1] == "10"
 


### PR DESCRIPTION
Fixes #492.

## Problem

`trim(..., end=...)` returns a clip of `end` **seconds** instead of one ending at the absolute timestamp `end`, whenever `accurate=False` — the default, and the only path reachable from the CLI. It returns `success: true` with `warnings: []`, so the wrong duration is reported as a clean result.

```bash
kino trim input.mp4 -s 00:00:05 -e 00:00:10 -o out.mp4   # 10s, expected 5s
```

## Cause

In `engine_edit.trim`, `-ss` is placed before `-i` for fast input seeking, which rebases output timestamps to zero. The trailing `-to` is an output option, so FFmpeg measures it from the seek point and it degrades into a duration. The `accurate=True` path puts `-ss` after `-i`, preserves source timestamps, and was already correct.

`_validate_trim_times` rejects `end <= start`, which only makes sense if `end` is absolute — so the fast path disagreed with the validator guarding it.

## Scope

`engine_edit.trim` is imported by `engine.py` (the MCP surface), `engine_batch.py`, `engine_timeline.py`, `product/shorts_render.py`, and `te/edl_apply.py`.

`engine_timeline.py:250-255` forwards `trim_end` into the default path, with the comment directly above stating the intent: *"`trim_end` wins, because it pins an absolute end on the source timeline."* It never sets `accurate=True`, so any timeline/EDL clip with a non-zero `trim_start` and a `trim_end` was cut to the wrong length.

## Fix

Convert the absolute end into an explicit duration on the input-seeking path, reusing the `start_sec` that `_validate_trim_times` already returns and the code was discarding. No signature or public-surface change.

## Why it wasn't caught

`test_trim_by_end` uses `start="0"`, where the absolute and duration readings coincide.

## Tests

`TestTrimEndSemantics` — integration coverage with a non-zero start, where the two readings diverge (1s vs 2s on the 3s `sample_video`), including the `accurate=True` path and the `end < start` rejection.

`TestTrimEndFFmpegArgs` — argument-level tests pinning the `-t`/`-to` contract for both seek modes. Hermetic; no FFmpeg required.

| Case | Before | After |
|---|---|---|
| `-s 5 -e 10` | 10.0 | **5.0** |
| `-s 10 -e 22` | 22.0 | **12.0** |
| `-s 5 -d 10` | 10.0 | 10.0 |
| `-e 10` | 10.0 | 10.0 |
| `accurate=True, -s 5 -e 10` | 5.0 | 5.0 |

## Verification

Targeted run across trim's callers (`test_engine`, `test_engine_advanced`, `test_engine_edge_cases`, `test_cli`, `test_cli_handlers`, `test_client`, `test_editorial`, `test_e2e`, `test_public_surface`, `test_projectstore_edit_projects`):

| | Failed | Passed |
|---|---|---|
| master | 56 | 461 |
| this branch | 56 | **469** |

Identical failure set, +8 passes (the new tests). No regressions.

**Note on those 56:** they are pre-existing and environmental, not related to this change — I ran the suite on Windows, where `_auto_output` rewrites the `C:` drive letter to `C_` (the colon-sanitising step described in CONTRIBUTING), producing an invalid path. Tests that pass an explicit `output_path` are unaffected. `tests/test_rescue_e2e.py` also cannot be collected on Windows (`ModuleNotFoundError: No module named 'resource'`). Both look worth separate issues if you'd like them filed — I kept them out of this PR.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/kinocut/pr/493"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790791127&installation_model_id=20207&pr_number=493&repository=KyaniteLabs%2Fkinocut&return_to=https%3A%2F%2Fgithub.com%2FKyaniteLabs%2Fkinocut%2Fpull%2F493&signature=3420cea07cb051fb74d506c4364e004970ce41ecc2f729a5f867d629030ed7fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved video trimming so end times are consistently interpreted as absolute timestamps.
  * Ensured accurate and fast seeking produce equivalent trim results.
  * Added validation when the specified end time precedes the start time.
  * Preserved explicit duration handling and correct behavior when no start time is provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->