### PR TITLE
fix(windows): keep the drive letter when deriving output paths

### DIFF
--- a/kinocut/paths.py
+++ b/kinocut/paths.py
@@ -8,9 +8,11 @@ import os
 def _auto_output(input_path: str, suffix: str = "edited", ext: str | None = None) -> str:
     base, original_ext = os.path.splitext(input_path)
     ext = ext or original_ext or ".mp4"
-    # Sanitize colons in base path — they break FFmpeg filter syntax
-    # and are problematic on Windows
-    safe_base = base.replace(":", "_")
+    # Sanitize colons in the base path — they break FFmpeg filter syntax.
+    # Split the drive off first: on Windows the leading "C:" is a drive
+    # separator, and replacing it turns an absolute path into a relative one.
+    drive, tail = os.path.splitdrive(base)
+    safe_base = drive + tail.replace(":", "_")
     output = f"{safe_base}_{suffix}{ext}"
     # Prevent overwriting the input file
     if output == input_path:
@@ -21,5 +23,6 @@ def _auto_output(input_path: str, suffix: str = "edited", ext: str | None = None
 
 def _auto_output_dir(input_path: str, suffix: str = "output") -> str:
     base, _ = os.path.splitext(input_path)
-    safe_base = base.replace(":", "_")
+    drive, tail = os.path.splitdrive(base)
+    safe_base = drive + tail.replace(":", "_")
     return f"{safe_base}_{suffix}"

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -1,0 +1,67 @@
+"""Tests for output path derivation helpers."""
+
+import os
+
+import pytest
+
+from mcp_video.paths import _auto_output, _auto_output_dir
+
+
+class TestAutoOutputAbsolutePaths:
+    """Derived output paths must stay absolute on every platform.
+
+    On Windows the leading ``C:`` is a drive separator, not an FFmpeg filter
+    hazard. Sanitising it turns an absolute path into a relative one and every
+    default-output operation fails.
+    """
+
+    def test_auto_output_preserves_absolute_input(self, tmp_path):
+        result = _auto_output(str(tmp_path / "clip.mp4"))
+        assert os.path.isabs(result)
+        assert os.path.dirname(result) == str(tmp_path)
+
+    def test_auto_output_dir_preserves_absolute_input(self, tmp_path):
+        result = _auto_output_dir(str(tmp_path / "clip.mp4"))
+        assert os.path.isabs(result)
+        assert os.path.dirname(result) == str(tmp_path)
+
+    @pytest.mark.skipif(os.name != "nt", reason="drive letters are Windows-only")
+    def test_auto_output_keeps_drive_letter(self):
+        assert _auto_output(r"C:\media\clip.mp4") == r"C:\media\clip_edited.mp4"
+
+    @pytest.mark.skipif(os.name != "nt", reason="drive letters are Windows-only")
+    def test_auto_output_dir_keeps_drive_letter(self):
+        assert _auto_output_dir(r"C:\media\clip.mp4") == r"C:\media\clip_output"
+
+
+class TestAutoOutputColonSanitising:
+    """Colons outside the drive prefix are still replaced."""
+
+    def test_colon_in_directory_is_sanitised(self):
+        result = _auto_output("/media/a:b/clip.mp4")
+        assert ":" not in result
+        assert "a_b" in result
+
+    def test_colon_in_filename_is_sanitised(self):
+        assert "we_ird" in _auto_output("/media/x/we:ird.mp4")
+
+    @pytest.mark.skipif(os.name != "nt", reason="drive letters are Windows-only")
+    def test_drive_kept_while_other_colons_sanitised(self):
+        assert _auto_output(r"C:\media\a:b\clip.mp4") == r"C:\media\a_b\clip_edited.mp4"
+
+
+class TestAutoOutputExistingBehaviour:
+    """Pre-existing contract must not change."""
+
+    def test_suffix_and_extension(self):
+        assert _auto_output("/media/clip.mp4", "trimmed") == "/media/clip_trimmed.mp4"
+
+    def test_explicit_extension_override(self):
+        assert _auto_output("/media/clip.mp4", "audio", ext=".mp3") == "/media/clip_audio.mp3"
+
+    def test_missing_extension_defaults_to_mp4(self):
+        assert _auto_output("/media/clip", "out") == "/media/clip_out.mp4"
+
+    def test_output_never_equals_input(self):
+        source = "/media/clip.mp4"
+        assert _auto_output(source) != source


### PR DESCRIPTION
Fixes #494.

## Problem

`_auto_output` and `_auto_output_dir` sanitise **every** colon in the base path. On Windows the first colon is the drive separator, so the derived path stops being absolute:

```python
_auto_output(r"C:\media\clip.mp4")   # 'C_\media\clip_edited.mp4'
os.path.isabs(...)                   # False
```

Every tool called without an explicit `output_path` then fails, and FFmpeg reports a missing file. The error names the *input* path, which is misleading — the input is fine; it is the output that is malformed.

## Fix

Split the drive off before sanitising:

```python
drive, tail = os.path.splitdrive(base)
safe_base = drive + tail.replace(":", "_")
```

The original intent — keeping colons out of FFmpeg filter strings — is preserved for every colon that isn't the drive separator. `os.path.splitdrive` returns an empty drive on POSIX, so Linux and macOS behaviour is byte-for-byte unchanged.

| Input | Before | After |
|---|---|---|
| `C:\media\clip.mp4` | `C_\media\clip_edited.mp4` (relative) | `C:\media\clip_edited.mp4` (absolute) |
| `C:\media\a:b\clip.mp4` | `C_\media\a_b\clip_edited.mp4` | `C:\media\a_b\clip_edited.mp4` |
| `/media/a:b/clip.mp4` | `/media/a_b/clip_edited.mp4` | unchanged |

Both `_auto_output` and `_auto_output_dir` carried the same line; both are fixed. The CLI's separate `_auto_output` in `cli/common.py` does not sanitise colons and was never affected.

## Tests

New `tests/test_paths.py` (11 tests, hermetic, no FFmpeg required):

- **Absolute-path preservation** via `tmp_path` — meaningful on Windows, harmless on POSIX, so it guards the regression on every platform rather than only under a Windows marker.
- **Windows-only drive-letter assertions**, `skipif(os.name != "nt")`.
- **Colon sanitising outside the drive** still works.
- **Pre-existing contract** — suffix, explicit `ext` override, default `.mp4`, output never equal to input.

## Verification

Targeted run across the affected surfaces (`test_engine`, `test_engine_advanced`, `test_engine_edge_cases`, `test_cli`, `test_cli_handlers`, `test_client`, `test_editorial`, `test_e2e`, `test_public_surface`, `test_projectstore_edit_projects`) on Windows 11 / Python 3.11 / FFmpeg 9.0.1:

| | Failed | Passed |
|---|---|---|
| master | 56 | 461 |
| this branch | **32** | **485** |

**24 previously-failing tests now pass, and diffing the failure sets shows zero new failures.** (`test_paths.py` is not in that set, so the +24 is entirely pre-existing tests being repaired.)

The remaining 32 are a separate, unrelated Windows problem — `UnicodeDecodeError: 'charmap' codec` when tests capture CLI subprocess output on a cp1252 console, almost all in `test_cli.py`. Out of scope here; I can file it separately if useful.

## Note on CI

The `windows-latest` job installs FFmpeg but then runs only lint, import checks, `kino doctor`, and `test_public_surface` / `test_doctor` / `test_models` / `test_errors` — none of which execute an FFmpeg operation. That is why this survived a release headlined as first-class Windows support: on Linux the temp paths contain no colon, so the bug is structurally invisible.

Adding one media-producing test to that job would close the gap. I left it out to keep this PR focused, but I'm happy to add it here or in a follow-up, whichever you prefer.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/kinocut/pr/496"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790793079&installation_model_id=20207&pr_number=496&repository=KyaniteLabs%2Fkinocut&return_to=https%3A%2F%2Fgithub.com%2FKyaniteLabs%2Fkinocut%2Fpull%2F496&signature=ea1f9b46bc885690b904dd2e364697f30d7d519a014f66e0cbb87a14956d53be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Windows path handling so drive letters remain intact while unsupported colons elsewhere are safely sanitized.
  - Preserved absolute paths and existing output naming behavior, including extensions and default `.mp4` output.

- **Tests**
  - Added coverage for cross-platform path handling, Windows drive prefixes, filename sanitization, extension overrides, and ensuring generated output paths differ from inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->