### PR TITLE
fix(tests): decode CLI subprocess output as UTF-8

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -18,6 +18,11 @@ def run_cli(*args: str, expect_fail: bool = False) -> subprocess.CompletedProces
         cmd,
         capture_output=True,
         text=True,
+        # The CLI forces UTF-8 on its own streams (see __main__), so decode as
+        # UTF-8 rather than the locale default -- cp1252 on Windows raises in
+        # the subprocess reader thread and silently leaves stdout as None.
+        encoding="utf-8",
+        errors="replace",
         timeout=30,
     )
     if not expect_fail and result.returncode != 0:


### PR DESCRIPTION
Fixes #497.

## Problem

`run_cli` captured subprocess output with `text=True` and no explicit `encoding`, so CPython decoded the child's stdout using the locale default. The Kinocut CLI deliberately forces UTF-8 on its own streams (`__main__.py:184-188`), so on a cp1252 Windows console the decode raised **inside subprocess's reader thread**. That thread died, `result.stdout` was left as `None`, and every `assert "..." in result.stdout` surfaced as:

```
TypeError: argument of type 'NoneType' is not iterable
```

The underlying `UnicodeDecodeError` only appeared as a `PytestUnhandledThreadExceptionWarning`, so nothing in the failure output pointed at encoding. The harness could not read the UTF-8 the CLI goes out of its way to emit.

## Fix

```python
encoding="utf-8",
errors="replace",
```

This matches what `ffmpeg_helpers._run_ffmpeg` already does for FFmpeg subprocesses (`ffmpeg_helpers.py:264-267`) — `run_cli` simply predates that pairing.

## Measured effect

Windows 11, Python 3.11, FFmpeg 9.0.1, `pytest tests/test_cli.py`:

| | Failed | Passed |
|---|---|---|
| master | 29 | 56 |
| this branch | **2** | **83** |

The two remaining failures are **not** encoding-related, and I verified each:

- `TestCLIPreview::test_preview_outputs_json` — this is #494 (`_auto_output` mangling the Windows drive letter); `preview` uses a default output path. I confirmed it **passes** with #496 applied on top of this branch.
- `TestCLIStoryboard::test_storyboard_outputs_text` — **passes in isolation**, so it is order-dependent and pre-existing. I did not chase it.

With #496 also merged, `test_cli.py` on Windows reduces to that single order-dependent test.

## Scope note

The same `text=True`-without-`encoding` pattern appears at ~20 other sites across 12 test modules that also invoke the CLI (`test_workflow_*.py`, `test_still_plates.py`, `test_post_rescue_api.py`, `test_namespace_routing.py`, `test_c2pa_provenance.py`, `test_public_surface.py`). They are latent instances of the same defect — they only escape it today where the captured output happens to be ASCII.

I deliberately left them out: those modules are slow enough that I could not run them to completion locally, and I did not want to ship a 12-file change I hadn't measured. Happy to do them as a follow-up, or fold them in here if you would rather have one sweep.

## CI note

`test_cli.py` is not among the four modules the `windows-latest` job runs, which is why this never surfaced in CI.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/KyaniteLabs/codesmith/kinocut/pr/498"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790795422&installation_model_id=20207&pr_number=498&repository=KyaniteLabs%2Fkinocut&return_to=https%3A%2F%2Fgithub.com%2FKyaniteLabs%2Fkinocut%2Fpull%2F498&signature=5ec24e9fdb96d74b6349e385557fe525103f6eb979abede055e555bb55238e66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved CLI test reliability by consistently decoding subprocess output as UTF-8, including when unexpected byte sequences are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->