### PR TITLE
test: verify Windows collection and real subtitle paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -422,6 +422,9 @@ jobs:
       - name: Lint
         if: needs.changes.outputs.code == 'true'
         run: python -m ruff check kinocut/ mcp_video.py tests/
+      - name: Collect whole test suite
+        if: needs.changes.outputs.code == 'true'
+        run: python -m pytest --collect-only -q --tb=short
       - name: Import checks (server tree imports on Windows)
         if: needs.changes.outputs.code == 'true'
         run: |
@@ -437,4 +440,10 @@ jobs:
           python -m pytest tests/test_public_surface.py tests/test_doctor.py
           tests/test_models.py tests/test_errors.py
           tests/test_projectstore_filelock.py
+          -q --tb=short
+      - name: Windows drive-path FFmpeg render
+        if: needs.changes.outputs.code == 'true'
+        run: >-
+          python -m pytest
+          tests/test_ffmpeg_filter_path.py::test_windows_drive_and_backslash_paths_render_with_ffmpeg
           -q --tb=short

--- a/tests/test_ffmpeg_filter_path.py
+++ b/tests/test_ffmpeg_filter_path.py
@@ -12,7 +12,16 @@ Regression cover for two historical bugs, both verified against a real
    through raw, splitting the filtergraph.
 """
 
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from kinocut.engine import probe, subtitles
 from kinocut.ffmpeg_helpers import _escape_ffmpeg_filter_path, _escape_ffmpeg_filter_value
+from tests.subtitle_render_test_support import _make_testsrc_video, requires_ffmpeg
 
 
 class TestWindowsPaths:
@@ -63,3 +72,26 @@ def test_value_helper_still_used_for_scalars():
     # Numbers, colours and font *names* keep the single-pass helper, unquoted.
     assert _escape_ffmpeg_filter_value("15.0") == "15.0"
     assert _escape_ffmpeg_filter_value("white") == "white"
+
+
+@requires_ffmpeg
+@pytest.mark.skipif(os.name != "nt", reason="drive-qualified backslash paths require native Windows")
+def test_windows_drive_and_backslash_paths_render_with_ffmpeg(tmp_path: Path):
+    workdir = tmp_path / "drive path"
+    workdir.mkdir()
+    source = workdir / "source clip.mp4"
+    subtitle = workdir / "caption file.srt"
+    output = workdir / "rendered clip.mp4"
+
+    for path in (source, subtitle, output):
+        assert path.drive
+        assert "\\" in str(path)
+
+    _make_testsrc_video(source, 160, 120, seconds=1)
+    subtitle.write_text("1\n00:00:00,000 --> 00:00:00,800\nWindows path\n", encoding="utf-8")
+
+    result = subtitles(str(source), str(subtitle), output_path=str(output))
+
+    assert result.success is True
+    assert output.is_file()
+    assert probe(str(output)).duration > 0

--- a/tests/test_rescue_e2e.py
+++ b/tests/test_rescue_e2e.py
@@ -6,7 +6,6 @@ import hashlib
 import json
 import os
 import platform
-import resource
 import subprocess
 import time
 import urllib.request
@@ -26,6 +25,15 @@ from tests.rescue_fixtures import (
 
 def _sha256(path) -> str:
     return "sha256:" + hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _optional_max_rss() -> int | None:
+    """Return platform RSS telemetry when the stdlib resource module exists."""
+    try:
+        import resource
+    except ModuleNotFoundError:
+        return None
+    return resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
 
 
 def _stream_contract(path: Path) -> dict:
@@ -285,7 +293,7 @@ def test_planning_performance_receipt_has_required_context(tmp_path, capsys):
         "cold_seconds": timings[0],
         "warm_seconds": timings[1],
         "cpu": platform.processor() or "unknown",
-        "memory_max_rss": resource.getrusage(resource.RUSAGE_SELF).ru_maxrss,
+        "memory_max_rss": _optional_max_rss(),
         "os": platform.platform(),
         "ffmpeg_version": ffmpeg_version,
         "clip": {"duration_seconds": 60, "width": 1920, "height": 1080, "fps": 30},

--- a/tests/test_rescue_e2e_collection.py
+++ b/tests/test_rescue_e2e_collection.py
@@ -1,0 +1,19 @@
+"""Cross-platform collection regressions for the rescue end-to-end module."""
+
+from __future__ import annotations
+
+import runpy
+import sys
+from pathlib import Path
+
+
+def test_rescue_e2e_collects_without_resource(monkeypatch):
+    monkeypatch.setitem(sys.modules, "resource", None)
+
+    namespace = runpy.run_path(
+        str(Path(__file__).with_name("test_rescue_e2e.py")),
+        run_name="test_rescue_e2e_without_resource",
+    )
+
+    assert "test_planning_performance_receipt_has_required_context" in namespace
+    assert namespace["_optional_max_rss"]() is None


### PR DESCRIPTION
Windows could not collect the full test suite because the rescue end-to-end tests imported the POSIX-only `resource` module. Collection now works when that module is unavailable, while RSS measurements remain explicitly unavailable on unsupported platforms.

The Windows CI job retains its existing checks and adds whole-suite collection plus a real FFmpeg subtitle render using a drive-qualified path with backslashes. This verifies the path behavior on Windows instead of relying solely on string-escaping assertions.

Validation: the full local suite passed with 5,005 tests, 176 skips, and eight warnings; import compatibility and pinned Ruff checks pass. All 16 CI jobs pass on the reviewed commit. Native Windows collected 5,181 tests and passed the real drive-path subtitle render, alongside the retained smoke checks.

Fixes #495. Fixes #480.
