### PR TITLE
fix: quote lavfi movie= filter value so Windows drive paths survive

### DIFF
--- a/kinocut/quality_guardrails.py
+++ b/kinocut/quality_guardrails.py
@@ -88,7 +88,11 @@ class VisualQualityGuardrails(QualityChecksMixin):
         self.max_analyze_seconds = max_analyze_seconds
 
     def _movie_source(self, video: str, tail: str) -> str:
-        movie = f"movie={_escape_lavfi_path(video)}"
+        # Quote the value: FFmpeg runs two unescaping passes over filter args,
+        # so a single-escaped drive-letter colon ("D\:") is re-split on pass 2
+        # and the movie filter receives only "D". Quoting survives both passes
+        # on Windows and is a no-op for colon-free POSIX paths.
+        movie = f"movie='{_escape_lavfi_path(video)}'"
         limit = self.max_analyze_seconds
         if limit and limit > 0:
             movie = f"{movie},trim=duration={float(limit):.3f},setpts=PTS-STARTPTS"

--- a/tests/test_quality_guardrails.py
+++ b/tests/test_quality_guardrails.py
@@ -277,7 +277,18 @@ class TestVisualQualityGuardrails:
 
         cmd = fake.call_args.args[0]
         lavfi_arg = cmd[cmd.index("-i") + 1]
-        assert lavfi_arg.startswith("movie=/tmp/with\\:comma\\,\\[brackets\\].mp4")
+        assert lavfi_arg.startswith("movie='/tmp/with\\:comma\\,\\[brackets\\].mp4'")
+
+    def test_movie_source_quotes_windows_drive_paths(self, guardrails):
+        """Windows drive-letter paths must be quoted, not just escaped.
+
+        FFmpeg runs two unescaping passes over filter args. With only the
+        per-character escaping, the drive colon in "C\\:" is re-split on the
+        second pass and the movie filter receives just "C", so every
+        lavfi-based check fails on Windows absolute paths.
+        """
+        source = guardrails._movie_source("C:\\Users\\me\\clip.mp4", "signalstats")
+        assert source == "movie='C\\:\\\\Users\\\\me\\\\clip.mp4',signalstats"
 
     def test_run_ffprobe_logs_nonzero_exit(self, guardrails):
         fake = Mock(return_value=Mock(returncode=1, stdout="", stderr="ffprobe failed"))


### PR DESCRIPTION
## Summary

On Windows, every lavfi-based quality check (`_run_ffprobe` / `_get_rgb_means` →
brightness, contrast, saturation, color balance, RGB means) fails on absolute
paths: the `movie` filter receives only the drive letter.

```
[Parsed_movie_0 @ ...] Failed to avformat_open_input 'D'
[AVFilterGraph @ ...] Error processing filtergraph: No such file or directory
```

Root cause: FFmpeg applies **two unescaping passes** to filter arguments. The
per-character escaping in `_escape_lavfi_path` survives the first pass, but on
Windows the drive-letter colon in `D\:` is re-split on the second pass, so the
movie filter ends up with just `D`.

The fix wraps the value in single quotes — standard FFmpeg filter-arg quoting —
which keeps the escaped colon intact through both passes. It is a no-op for
colon-free POSIX paths.

## Reproduction (Windows 11, kinocut @ 3331027, ffmpeg 8.1 & 9.0.1)

```python
import subprocess

video = r"D:\path\to\clip.mp4"
esc = video.replace("\\", "\\\\").replace(":", "\\:")
arg = f"movie={esc},signalstats"          # kinocut 1.15.1 behavior (unquoted)
r = subprocess.run(["ffprobe", "-v", "error", "-f", "lavfi", arg,
                    "-show_entries", "frame_tags=lavfi.signalstats.YAVG",
                    "-of", "csv=p=0", "-read_intervals", "%+#1"],
                   capture_output=True, text=True)
print(r.returncode, r.stderr)
# 1 ... [Parsed_movie_0 @ ...] Failed to avformat_open_input 'D'
```

Variant matrix (all via `subprocess`, no shell escaping involved):

| lavfi arg | ffmpeg 8.1 / 9.0.1 |
|---|---|
| `movie=D\:\\path\\clip.mp4` — 1.15.1 as-is (escaped, unquoted) | FAIL — filter receives `D` |
| `movie=D\:/path/clip.mp4` — fwd slashes, escaped colon, unquoted | FAIL |
| `movie=D\\:/path/clip.mp4` — `_escape_ffmpeg_filter_path` Windows branch | FAIL |
| `movie='D:/path/clip.mp4'` — quoted, raw colon | FAIL |
| `movie='D\:/path/clip.mp4'` — quoted + escaped colon | **PASS** |
| `movie=D\\:\\\\path\\\\clip.mp4` — double-escaped, unquoted | PASS |

So both quoting *and* per-character escaping are required: quoting alone does
not protect the colon from the option parser, and escaping alone does not
survive the graph parser.

## Why not reuse `_escape_ffmpeg_filter_path` (#458)?

That helper's Windows branch (unquoted, forward-slashed, double-escaped colon)
is verified for `subtitles=`, but against `movie=` the same unquoted form still
truncates to the drive letter on both 8.1 and 9.0.1 (row 3 above) — the two
seams do not digest escaping identically. Its POSIX branch (quoted, single
pass) is exactly the shape that works here, but routing a `D:\...` path through
it would also forward-slash + double-escape, which fails for `movie=`.

`_escape_lavfi_path` is kept (not replaced): `tests/test_adversarial_audit.py`
asserts the identifier exists in the guardrails source, and this seam only
needs the quote wrapper added.

## Changes

- `kinocut/quality_guardrails.py` — `_movie_source` now emits `movie='{escaped}'`
- `tests/test_quality_guardrails.py` — updated
  `test_get_rgb_means_escapes_lavfi_path` to the quoted form, and added
  `test_movie_source_quotes_windows_drive_paths` (verified red on the old
  code, green with the fix)

## Testing

- `tests/test_quality_guardrails.py`: 36/36 passed on Windows with real ffmpeg
  9.0.1 (gyan essentials build); the fix was also verified against 8.1
- `tests/test_ffmpeg_filter_path.py` + `tests/test_adversarial_audit.py`:
  57/57 passed (helper behavior and audit assertions untouched)
- End-to-end: the confidence-baseline golden path workflow fails its quality
  gate at every dimension before this fix (all lavfi checks error out on
  `avformat_open_input 'D'`) and passes all checks after it

Related: #458 — same family of Windows filter-escaping issues; that fix did
not cover this call site.